### PR TITLE
chore: Make header names that always need to be sent constants

### DIFF
--- a/Momento/ControlGrpcManager.cs
+++ b/Momento/ControlGrpcManager.cs
@@ -10,6 +10,8 @@ namespace MomentoSdk
 {
     internal sealed class ControlGrpcManager : IDisposable
     {
+        private const string Authorization = "Authorization";
+        private const string Agent = "Agent";
         private readonly GrpcChannel channel;
         private readonly ScsControl.ScsControlClient client;
         private readonly string version = GetAssembly(typeof(MomentoSdk.Responses.CacheGetResponse)).GetName().Version.ToString();
@@ -17,7 +19,7 @@ namespace MomentoSdk
         public ControlGrpcManager(string authToken, string endpoint)
         {
             this.channel = GrpcChannel.ForAddress(endpoint, new GrpcChannelOptions() { Credentials = ChannelCredentials.SecureSsl });
-            List<Header> headers = new List<Header>{ new Header(name: "Authorization", value: authToken), new Header(name: "Agent", value: version) };
+            List<Header> headers = new List<Header>{ new Header(name: Authorization, value: authToken), new Header(name: Agent, value: version) };
             CallInvoker invoker = channel.Intercept(new HeaderInterceptor(headers));
             this.client = new ScsControl.ScsControlClient(invoker);
         }

--- a/Momento/ControlGrpcManager.cs
+++ b/Momento/ControlGrpcManager.cs
@@ -10,8 +10,6 @@ namespace MomentoSdk
 {
     internal sealed class ControlGrpcManager : IDisposable
     {
-        private const string Authorization = "Authorization";
-        private const string Agent = "Agent";
         private readonly GrpcChannel channel;
         private readonly ScsControl.ScsControlClient client;
         private readonly string version = GetAssembly(typeof(MomentoSdk.Responses.CacheGetResponse)).GetName().Version.ToString();
@@ -19,7 +17,7 @@ namespace MomentoSdk
         public ControlGrpcManager(string authToken, string endpoint)
         {
             this.channel = GrpcChannel.ForAddress(endpoint, new GrpcChannelOptions() { Credentials = ChannelCredentials.SecureSsl });
-            List<Header> headers = new List<Header>{ new Header(name: Authorization, value: authToken), new Header(name: Agent, value: version) };
+            List<Header> headers = new List<Header>{ new Header(name: Header.AuthorizationKey, value: authToken), new Header(name: Header.AgentKey, value: version) };
             CallInvoker invoker = channel.Intercept(new HeaderInterceptor(headers));
             this.client = new ScsControl.ScsControlClient(invoker);
         }

--- a/Momento/DataGrpcManager.cs
+++ b/Momento/DataGrpcManager.cs
@@ -10,6 +10,8 @@ namespace MomentoSdk
 {
     internal sealed class DataGrpcManager : IDisposable
     {
+        private const string Authorization = "Authorization";
+        private const string Agent = "Agent";
         private readonly GrpcChannel channel;
         private readonly Scs.ScsClient client;
         
@@ -18,7 +20,7 @@ namespace MomentoSdk
         internal DataGrpcManager(string authToken, string endpoint)
         {
             this.channel = GrpcChannel.ForAddress(endpoint, new GrpcChannelOptions() { Credentials = ChannelCredentials.SecureSsl });
-            List<Header> headers = new List<Header> { new Header(name: "Authorization", value: authToken) , new Header(name: "Agent", value: version)};
+            List<Header> headers = new List<Header> { new Header(name: Authorization, value: authToken) , new Header(name: Agent, value: version)};
             CallInvoker invoker = this.channel.Intercept(new HeaderInterceptor(headers));
             this.client = new Scs.ScsClient(invoker);
         }

--- a/Momento/DataGrpcManager.cs
+++ b/Momento/DataGrpcManager.cs
@@ -10,8 +10,6 @@ namespace MomentoSdk
 {
     internal sealed class DataGrpcManager : IDisposable
     {
-        private const string Authorization = "Authorization";
-        private const string Agent = "Agent";
         private readonly GrpcChannel channel;
         private readonly Scs.ScsClient client;
         
@@ -20,7 +18,7 @@ namespace MomentoSdk
         internal DataGrpcManager(string authToken, string endpoint)
         {
             this.channel = GrpcChannel.ForAddress(endpoint, new GrpcChannelOptions() { Credentials = ChannelCredentials.SecureSsl });
-            List<Header> headers = new List<Header> { new Header(name: Authorization, value: authToken) , new Header(name: Agent, value: version)};
+            List<Header> headers = new List<Header> { new Header(name: Header.AuthorizationKey, value: authToken) , new Header(name: Header.AgentKey, value: version)};
             CallInvoker invoker = this.channel.Intercept(new HeaderInterceptor(headers));
             this.client = new Scs.ScsClient(invoker);
         }

--- a/Momento/HeaderInterceptor.cs
+++ b/Momento/HeaderInterceptor.cs
@@ -8,8 +8,9 @@ namespace MomentoSdk
 {
     class Header
     {
-        private const string Agent = "Agent";
-        public readonly List<string>  onceOnlyHeaders = new List<string>{Agent};
+        public const string AuthorizationKey = "Authorization";
+        public const string AgentKey = "Agent";
+        public readonly List<string>  onceOnlyHeaders = new List<string>{Header.AgentKey};
         public string Name;
         public string Value;
         public Header(String name, String value)

--- a/Momento/HeaderInterceptor.cs
+++ b/Momento/HeaderInterceptor.cs
@@ -8,7 +8,8 @@ namespace MomentoSdk
 {
     class Header
     {
-        public readonly List<string>  onceOnlyHeaders = new List<string>{"Agent"};
+        private const string Agent = "Agent";
+        public readonly List<string>  onceOnlyHeaders = new List<string>{Agent};
         public string Name;
         public string Value;
         public Header(String name, String value)

--- a/Momento/HeaderInterceptor.cs
+++ b/Momento/HeaderInterceptor.cs
@@ -8,7 +8,7 @@ namespace MomentoSdk
 {
     class Header
     {
-        public readonly List<string>  onceOnlyHeaders = new List<string>{"Authorization"};
+        public readonly List<string>  onceOnlyHeaders = new List<string>{"Agent"};
         public string Name;
         public string Value;
         public Header(String name, String value)

--- a/MomentoIntegrationTest/CacheTest.cs
+++ b/MomentoIntegrationTest/CacheTest.cs
@@ -18,7 +18,10 @@ namespace MomentoIntegrationTest
         {
             uint defaultTtlSeconds = 10;
             client = new SimpleCacheClient(authKey, defaultTtlSeconds);
-            client.CreateCache(cacheName);
+            try {
+                client.CreateCache(cacheName);
+            } catch (AlreadyExistsException) {
+            }
         }
 
         // Test cleanup


### PR DESCRIPTION
This is a follow-up pr for the implementation option 2 mentioned [here](https://github.com/momentohq/client-sdk-csharp/pull/37#discussion_r840714313).