### PR TITLE
fix: url-encode cache name and key in presigned urls

### DIFF
--- a/Momento/MomentoSigner.cs
+++ b/Momento/MomentoSigner.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IdentityModel.Tokens.Jwt;
+using System.Web;
 using Microsoft.IdentityModel.Tokens;
 using MomentoSdk.Exceptions;
 
@@ -32,8 +33,8 @@ namespace MomentoSdk
         public string CreatePresignedUrl(string hostname, SigningRequest signingRequest)
         {
             var jwtToken = SignAccessToken(signingRequest);
-            var cacheName = signingRequest.CacheName;
-            var cacheKey = signingRequest.CacheKey;
+            var cacheName = HttpUtility.UrlEncode(signingRequest.CacheName);
+            var cacheKey = HttpUtility.UrlEncode(signingRequest.CacheKey);
 
             return signingRequest.CacheOperation switch
             {

--- a/MomentoTest/MomentoSignerTest.cs
+++ b/MomentoTest/MomentoSignerTest.cs
@@ -72,6 +72,20 @@ namespace MomentoTest
         }
 
         [Fact]
+        public void TestUrlEncoding()
+        {
+            MomentoSigner signer = new MomentoSigner(RS256_JWK);
+            uint expiryEpochSeconds = uint.MaxValue;
+            var url = signer.CreatePresignedUrl("foobar.com", new SigningRequest("testCacheName", "///", CacheOperation.GET, expiryEpochSeconds));
+
+            Uri uriResult;
+            bool result = Uri.TryCreate(url, UriKind.Absolute, out uriResult);
+            Assert.True(result);
+            Assert.Equal(Uri.UriSchemeHttps, uriResult.Scheme);
+            Assert.StartsWith("https://foobar.com/cache/get/testCacheName/%2f%2f%2f?token=", url);
+        }
+
+        [Fact]
         public void TestJwkError()
         {
             uint expiryEpochSeconds = uint.MaxValue;

--- a/MomentoTest/MomentoSignerTest.cs
+++ b/MomentoTest/MomentoSignerTest.cs
@@ -76,13 +76,14 @@ namespace MomentoTest
         {
             MomentoSigner signer = new MomentoSigner(RS256_JWK);
             uint expiryEpochSeconds = uint.MaxValue;
-            var url = signer.CreatePresignedUrl("foobar.com", new SigningRequest("testCacheName", "///", CacheOperation.GET, expiryEpochSeconds));
+            var testCacheKey = "#$&\\'+,/:;=?@[]";
+            var url = signer.CreatePresignedUrl("foobar.com", new SigningRequest("testCacheName", testCacheKey, CacheOperation.GET, expiryEpochSeconds));
 
             Uri uriResult;
             bool result = Uri.TryCreate(url, UriKind.Absolute, out uriResult);
             Assert.True(result);
             Assert.Equal(Uri.UriSchemeHttps, uriResult.Scheme);
-            Assert.StartsWith("https://foobar.com/cache/get/testCacheName/%2f%2f%2f?token=", url);
+            Assert.StartsWith("https://foobar.com/cache/get/testCacheName/%23%24%26%5c%27%2b%2c%2f%3a%3b%3d%3f%40%5b%5d?token=", url);
         }
 
         [Fact]


### PR DESCRIPTION
Closes https://github.com/momentohq/client-sdk-csharp/issues/43