### PR TITLE
feat: Adding a rest keyword to get the rest endpoint

### DIFF
--- a/Momento/MomentoSigner.cs
+++ b/Momento/MomentoSigner.cs
@@ -27,7 +27,7 @@ namespace MomentoSdk
         /// <summary>
         /// Create a pre-signed HTTPS URL.
         /// </summary>
-        /// <param name="hostname">Hostname of the SimpleCacheService. Use the value returned from CreateSigningKey's response.</param>
+        /// <param name="hostname">Hostname of the SimpleCacheService. Use the value returned from CreateSigningKey's response. A rest keyword is prepended to the hostname</param>
         /// <param name="signingRequest">The parameters used for generating a pre-signed URL</param>
         /// <returns></returns>
         public string CreatePresignedUrl(string hostname, SigningRequest signingRequest)
@@ -38,8 +38,8 @@ namespace MomentoSdk
 
             return signingRequest.CacheOperation switch
             {
-                CacheOperation.GET => $"https://{hostname}/cache/get/{cacheName}/{cacheKey}?token={jwtToken}",
-                CacheOperation.SET => $"https://{hostname}/cache/set/{cacheName}/{cacheKey}?ttl_milliseconds={signingRequest.TtlSeconds * (ulong)1000}&token={jwtToken}",
+                CacheOperation.GET => $"https://rest.{hostname}/cache/get/{cacheName}/{cacheKey}?token={jwtToken}",
+                CacheOperation.SET => $"https://rest.{hostname}/cache/set/{cacheName}/{cacheKey}?ttl_milliseconds={signingRequest.TtlSeconds * (ulong)1000}&token={jwtToken}",
                 _ => throw new NotImplementedException($"Unhandled {signingRequest.CacheOperation}")
             };
         }

--- a/MomentoTest/MomentoSignerTest.cs
+++ b/MomentoTest/MomentoSignerTest.cs
@@ -50,7 +50,7 @@ namespace MomentoTest
             bool result = Uri.TryCreate(url, UriKind.Absolute, out uriResult);
             Assert.True(result);
             Assert.Equal(Uri.UriSchemeHttps, uriResult.Scheme);
-            Assert.StartsWith("https://foobar.com/cache/get/testCacheName/testCacheKey?token=", url);
+            Assert.StartsWith("https://rest.foobar.com/cache/get/testCacheName/testCacheKey?token=", url);
         }
 
         [Fact]
@@ -68,7 +68,7 @@ namespace MomentoTest
             bool result = Uri.TryCreate(url, UriKind.Absolute, out uriResult);
             Assert.True(result);
             Assert.Equal(Uri.UriSchemeHttps, uriResult.Scheme);
-            Assert.StartsWith("https://foobar.com/cache/set/testCacheName/testCacheKey?ttl_milliseconds=4294967295000&token=", url);
+            Assert.StartsWith("https://rest.foobar.com/cache/set/testCacheName/testCacheKey?ttl_milliseconds=4294967295000&token=", url);
         }
 
         [Fact]
@@ -83,7 +83,7 @@ namespace MomentoTest
             bool result = Uri.TryCreate(url, UriKind.Absolute, out uriResult);
             Assert.True(result);
             Assert.Equal(Uri.UriSchemeHttps, uriResult.Scheme);
-            Assert.StartsWith("https://foobar.com/cache/get/testCacheName/%23%24%26%5c%27%2b%2c%2f%3a%3b%3d%3f%40%5b%5d?token=", url);
+            Assert.StartsWith("https://rest.foobar.com/cache/get/testCacheName/%23%24%26%5c%27%2b%2c%2f%3a%3b%3d%3f%40%5b%5d?token=", url);
         }
 
         [Fact]


### PR DESCRIPTION
```
➜  client-sdk-csharp git:(rest) ✗ dotnet test --filter FullyQualifiedName~MomentoTest                  
  Determining projects to restore...
  All projects are up-to-date for restore.
  MomentoSdk -> /Users/mjindal/src/client-sdk-csharp/Momento/bin/Debug/netstandard2.1/MomentoSdk.dll
  MomentoTest -> /Users/mjindal/src/client-sdk-csharp/MomentoTest/bin/Debug/net6.0/MomentoTest.dll
  MomentoIntegrationTest -> /Users/mjindal/src/client-sdk-csharp/MomentoIntegrationTest/bin/Debug/net6.0/MomentoIntegrationTest.dll
Test run for /Users/mjindal/src/client-sdk-csharp/MomentoTest/bin/Debug/net6.0/MomentoTest.dll (.NETCoreApp,Version=v6.0)
Test run for /Users/mjindal/src/client-sdk-csharp/MomentoIntegrationTest/bin/Debug/net6.0/MomentoIntegrationTest.dll (.NETCoreApp,Version=v6.0)
Microsoft (R) Test Execution Command Line Tool Version 17.1.0
Microsoft (R) Test Execution Command Line Tool Version 17.1.0Copyright (c) Microsoft Corporation.  All rights reserved.


Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
A total of 1 test files matched the specified pattern.
No test matches the given testcase filter `FullyQualifiedName~MomentoTest` in /Users/mjindal/src/client-sdk-csharp/MomentoIntegrationTest/bin/Debug/net6.0/MomentoIntegrationTest.dll


Passed!  - Failed:     0, Passed:     8, Skipped:     0, Total:     8, Duration: 171 ms - /Users/mjindal/src/client-sdk-csharp/MomentoTest/bin/Debug/net6.0/MomentoTest.dll (net6.0)
```