### PR TITLE
feat: Add delete method.

### DIFF
--- a/Momento/MomentoSdk.csproj
+++ b/Momento/MomentoSdk.csproj
@@ -18,7 +18,7 @@
 		<PackageReference Include="Google.Protobuf" Version="3.19.0" />
 		<PackageReference Include="Grpc.Net.Client" Version="2.40.0" />
 		<PackageReference Include="Grpc.Core" Version="2.41.1" />
-		<PackageReference Include="Momento" Version="0.8.0" />
+		<PackageReference Include="Momento" Version="0.18.0" />
 		<PackageReference Include="JWT" Version="8.4.2" />
 		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.16.0" />
 	</ItemGroup>

--- a/Momento/Responses/CacheDeleteResponse.cs
+++ b/Momento/Responses/CacheDeleteResponse.cs
@@ -1,0 +1,10 @@
+﻿using System;
+namespace MomentoSdk.Responses
+{
+    public class CacheDeleteResponse
+    {
+        public CacheDeleteResponse()
+        {
+        }
+    }
+}

--- a/Momento/ScsDataClient.cs
+++ b/Momento/ScsDataClient.cs
@@ -47,6 +47,12 @@ namespace MomentoSdk
             return new CacheGetResponse(resp);
         }
 
+        public async Task<CacheDeleteResponse> DeleteAsync(string cacheName, byte[] key)
+        {
+            await this.SendDeleteAsync(cacheName, Convert(key));
+            return new CacheDeleteResponse();
+        }
+
         public async Task<CacheSetResponse> SetAsync(string cacheName, string key, string value, uint ttlSeconds)
         {
             _SetResponse response = await this.SendSetAsync(cacheName, key: Convert(key), value: Convert(value), ttlSeconds: ttlSeconds, dataClientOperationTimeoutMilliseconds: this.dataClientOperationTimeoutMilliseconds);
@@ -62,6 +68,12 @@ namespace MomentoSdk
         {
             _GetResponse resp = await this.SendGetAsync(cacheName, Convert(key), dataClientOperationTimeoutMilliseconds: this.dataClientOperationTimeoutMilliseconds);
             return new CacheGetResponse(resp);
+        }
+
+        public async Task<CacheDeleteResponse> DeleteAsync(string cacheName, string key)
+        {
+            await this.SendDeleteAsync(cacheName, Convert(key));
+            return new CacheDeleteResponse();
         }
 
         public async Task<CacheSetResponse> SetAsync(string cacheName, string key, byte[] value, uint ttlSeconds)
@@ -137,6 +149,12 @@ namespace MomentoSdk
             return new CacheGetResponse(resp);
         }
 
+        public CacheDeleteResponse Delete(string cacheName, byte[] key)
+        {
+            this.SendDelete(cacheName, Convert(key));
+            return new CacheDeleteResponse();
+        }
+
         public CacheSetResponse Set(string cacheName, string key, string value, uint ttlSeconds)
         {
             _SetResponse response = this.SendSet(cacheName, key: Convert(key), value: Convert(value), ttlSeconds: ttlSeconds, dataClientOperationTimeoutMilliseconds: this.dataClientOperationTimeoutMilliseconds);
@@ -152,6 +170,12 @@ namespace MomentoSdk
         {
             _GetResponse resp = this.SendGet(cacheName, Convert(key), dataClientOperationTimeoutMilliseconds: this.dataClientOperationTimeoutMilliseconds);
             return new CacheGetResponse(resp);
+        }
+
+        public CacheDeleteResponse Delete(string cacheName, string key)
+        {
+            this.SendDelete(cacheName, Convert(key));
+            return new CacheDeleteResponse();
         }
 
         public CacheSetResponse Set(string cacheName, string key, byte[] value, uint ttlSeconds)
@@ -214,6 +238,34 @@ namespace MomentoSdk
             try
             {
                 return this.grpcManager.Client().Set(request, new Metadata { { "cache", cacheName } }, deadline: deadline);
+            }
+            catch (Exception e)
+            {
+                throw CacheExceptionMapper.Convert(e);
+            }
+        }
+
+        private _DeleteResponse SendDelete(string cacheName, ByteString key)
+        {
+            _DeleteRequest request = new _DeleteRequest() { CacheKey = key };
+            DateTime deadline = DateTime.UtcNow.AddMilliseconds(dataClientOperationTimeoutMilliseconds);
+            try
+            {
+                return this.grpcManager.Client().Delete(request, new Metadata { { "cache", cacheName } }, deadline: deadline);
+            }
+            catch (Exception e)
+            {
+                throw CacheExceptionMapper.Convert(e);
+            }
+        }
+
+        private async Task<_DeleteResponse> SendDeleteAsync(string cacheName, ByteString key)
+        {
+            _DeleteRequest request = new _DeleteRequest() { CacheKey = key };
+            DateTime deadline = DateTime.UtcNow.AddMilliseconds(dataClientOperationTimeoutMilliseconds);
+            try
+            {
+                return await this.grpcManager.Client().DeleteAsync(request, new Metadata { { "cache", cacheName } }, deadline: deadline);
             }
             catch (Exception e)
             {

--- a/Momento/SimpleCacheClient.cs
+++ b/Momento/SimpleCacheClient.cs
@@ -102,6 +102,17 @@ namespace MomentoSdk.Responses
         }
 
         /// <summary>
+        /// Remove the key from the cache.
+        /// </summary>
+        /// <param name="cacheName">Name of the cache to delete the key from.</param>
+        /// <param name="key">The key to perform a cache lookup on.</param>
+        /// <returns>Future containing the result of the delete operation.</returns>
+        public async Task<CacheDeleteResponse> DeleteAsync(string cacheName, byte[] key)
+        {
+            return await this.dataClient.DeleteAsync(cacheName, key);
+        }
+
+        /// <summary>
         /// Sets the value in cache with a given Time To Live (TTL) seconds.
         /// </summary>
         /// <param name="key">The key under which the value is to be added</param>
@@ -133,6 +144,18 @@ namespace MomentoSdk.Responses
         {
             return await this.dataClient.GetAsync(cacheName, key);
         }
+
+        /// <summary>
+        /// Remove the key from the cache.
+        /// </summary>
+        /// <param name="cacheName">Name of the cache to delete the key from.</param>
+        /// <param name="key">The key to perform a cache lookup on.</param>
+        /// <returns>Future containing the result of the delete operation.</returns>
+        public async Task<CacheDeleteResponse> DeleteAsync(string cacheName, string key)
+        {
+            return await this.dataClient.DeleteAsync(cacheName, key);
+        }
+
         /// <summary>
         /// Sets the value in cache with a given Time To Live (TTL) seconds.
         /// </summary>
@@ -221,6 +244,17 @@ namespace MomentoSdk.Responses
         }
 
         /// <summary>
+        /// Remove the key from the cache.
+        /// </summary>
+        /// <param name="cacheName">Name of the cache to delete the key from.</param>
+        /// <param name="key">The key to perform a cache lookup on.</param>
+        /// <returns>Future containing the result of the delete operation.</returns>
+        public CacheDeleteResponse Delete(string cacheName, byte[] key)
+        {
+            return this.dataClient.Delete(cacheName, key);
+        }
+
+        /// <summary>
         /// Sets the value in cache with a given Time To Live (TTL) seconds. If a value for this key is already present it will be replaced by the new value.
         /// </summary>
         /// <param name="key">The key under which the value is to be added</param>
@@ -254,6 +288,18 @@ namespace MomentoSdk.Responses
         {
             return this.dataClient.Get(cacheName, key);
         }
+
+        /// <summary>
+        /// Remove the key from the cache.
+        /// </summary>
+        /// <param name="cacheName">Name of the cache to delete the key from.</param>
+        /// <param name="key">The key to perform a cache lookup on.</param>
+        /// <returns>Future containing the result of the delete operation.</returns>
+        public CacheDeleteResponse Delete(string cacheName, string key)
+        {
+            return this.dataClient.Delete(cacheName, key);
+        }
+
         /// <summary>
         /// Sets the value in cache with a given Time To Live (TTL) seconds. If a value for this key is already present it will be replaced by the new value.
         /// </summary>

--- a/MomentoIntegrationTest/CacheTest.cs
+++ b/MomentoIntegrationTest/CacheTest.cs
@@ -163,5 +163,77 @@ namespace MomentoIntegrationTest
             SimpleCacheClient client = new SimpleCacheClient(authKey, defaultTtlSeconds);
             Assert.Throws<NotFoundException>(() => client.Set("non-existent-cache", Guid.NewGuid().ToString(), Guid.NewGuid().ToString()));
         }
+
+        [Fact]
+        public void HappyPathDelete_KeyIsByteArray()
+        {
+            // Set a key to then delete
+            byte[] key = new byte[] { 0x01, 0x02, 0x03, 0x04 };
+            byte[] value = new byte[] { 0x05, 0x06, 0x07, 0x08 };
+            client.Set(cacheName, key, value, ttlSeconds: 60);
+            CacheGetResponse getResponse = client.Get(cacheName, key);
+            Assert.Equal(CacheGetStatus.HIT, getResponse.Status);
+
+            // Delete
+            client.Delete(cacheName, key);
+
+            // Check deleted
+            getResponse = client.Get(cacheName, key);
+            Assert.Equal(CacheGetStatus.MISS, getResponse.Status);
+        }
+
+        [Fact]
+        public async Task HappyPathDeleteAsync_KeyIsByteArray()
+        {
+            // Set a key to then delete
+            byte[] key = new byte[] { 0x01, 0x02, 0x03, 0x04 };
+            byte[] value = new byte[] { 0x05, 0x06, 0x07, 0x08 };
+            await client.SetAsync(cacheName, key, value, ttlSeconds: 60);
+            CacheGetResponse getResponse = await client.GetAsync(cacheName, key);
+            Assert.Equal(CacheGetStatus.HIT, getResponse.Status);
+
+            // Delete
+            await client.DeleteAsync(cacheName, key);
+
+            // Check deleted
+            getResponse = await client.GetAsync(cacheName, key);
+            Assert.Equal(CacheGetStatus.MISS, getResponse.Status);
+        }
+
+        [Fact]
+        public void HappyPathDelete_KeyIsString()
+        {
+            // Set a key to then delete
+            string key = "key";
+            string value = "value";
+            client.Set(cacheName, key, value, ttlSeconds: 60);
+            CacheGetResponse getResponse = client.Get(cacheName, key);
+            Assert.Equal(CacheGetStatus.HIT, getResponse.Status);
+
+            // Delete
+            client.Delete(cacheName, key);
+
+            // Check deleted
+            getResponse = client.Get(cacheName, key);
+            Assert.Equal(CacheGetStatus.MISS, getResponse.Status);
+        }
+
+        [Fact]
+        public async Task HappyPathDeleteAsync_KeyIsString()
+        {
+            // Set a key to then delete
+            string key = "key";
+            string value = "value";
+            await client.SetAsync(cacheName, key, value, ttlSeconds: 60);
+            CacheGetResponse getResponse = await client.GetAsync(cacheName, key);
+            Assert.Equal(CacheGetStatus.HIT, getResponse.Status);
+
+            // Delete
+            await client.DeleteAsync(cacheName, key);
+
+            // Check deleted
+            getResponse = await client.GetAsync(cacheName, key);
+            Assert.Equal(CacheGetStatus.MISS, getResponse.Status);
+        }
     }
 }


### PR DESCRIPTION
Closes #50 

Update the gRPC client and add support for the data client's delete method. Example usage is as follows:
`client.Delete(cacheName, key)
`

And the corresponding async implementation:
`await client.Delete(cacheName, key)`