### PR TITLE
fix: Cache client should be in the MomentoSdk namespace.

### DIFF
--- a/Momento/Incubating/SimpleCacheClient.cs
+++ b/Momento/Incubating/SimpleCacheClient.cs
@@ -5,7 +5,7 @@ using MomentoSdk.Incubating.Responses;
 
 namespace MomentoSdk.Incubating
 {
-    public class SimpleCacheClient : MomentoSdk.Responses.SimpleCacheClient
+    public class SimpleCacheClient : MomentoSdk.SimpleCacheClient
     {
         public SimpleCacheClient(string authToken, uint defaultTtlSeconds) : base(authToken, defaultTtlSeconds)
         {

--- a/Momento/SimpleCacheClient.cs
+++ b/Momento/SimpleCacheClient.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Threading.Tasks;
+using MomentoSdk.Responses;
 using MomentoSdk.Exceptions;
 using System.Collections.Generic;
 
-namespace MomentoSdk.Responses
+namespace MomentoSdk
 {
     public class SimpleCacheClient : IDisposable
     {

--- a/MomentoIntegrationTest/SimpleCacheControlTest.cs
+++ b/MomentoIntegrationTest/SimpleCacheControlTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Xunit;
+using MomentoSdk;
 using MomentoSdk.Exceptions;
 using MomentoSdk.Responses;
 using System.Collections.Generic;
@@ -78,7 +79,7 @@ namespace MomentoIntegrationTest
             SimpleCacheClient client = new SimpleCacheClient(authKey, defaultTtlSeconds: 10);
             List<String> cacheNames = new List<String>();
 
-	    // TODO: increase limit after pagination is enabled
+            // TODO: increase limit after pagination is enabled
             foreach (int val in Enumerable.Range(1, 5))
             {
                 String cacheName = Guid.NewGuid().ToString();

--- a/MomentoIntegrationTest/SimpleCacheDataTest.cs
+++ b/MomentoIntegrationTest/SimpleCacheDataTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Xunit;
+using MomentoSdk;
 using MomentoSdk.Responses;
 using MomentoSdk.Exceptions;
 using System.Text;
@@ -242,7 +243,7 @@ namespace MomentoIntegrationTest
         public void Get_NullChecksBytes_ThrowsException()
         {
             Assert.Throws<ArgumentNullException>(() => client.Get("cache", (byte[])null));
-            Assert.Throws<ArgumentNullException>(() => client.Get(null, new byte[] {0x00}));
+            Assert.Throws<ArgumentNullException>(() => client.Get(null, new byte[] { 0x00 }));
         }
 
         [Fact]
@@ -350,7 +351,7 @@ namespace MomentoIntegrationTest
         {
             Assert.Throws<ArgumentNullException>(() => client.Delete(cacheName, key));
         }
-	
+
         [Fact]
         public void Delete_KeyIsBytes_HappyPath()
         {


### PR DESCRIPTION
This commit changes the `SimpleCacheClient` namespace from `MomentoSdk.Responses` to `MomentoSdk`.