### PR TITLE
chore: Use optional arguments where appropriate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -403,3 +403,6 @@ ASALocalRun/
 
 # Local History for Visual Studio
 .localhistory/
+
+# VS Code
+.vscode

--- a/Momento/ScsDataClient.cs
+++ b/Momento/ScsDataClient.cs
@@ -16,18 +16,11 @@ namespace MomentoSdk
         private readonly uint dataClientOperationTimeoutMilliseconds;
         private const uint DEFAULT_DEADLINE_MILLISECONDS = 5000;
 
-        public ScsDataClient(string authToken, string endpoint, uint defaultTtlSeconds)
+        public ScsDataClient(string authToken, string endpoint, uint defaultTtlSeconds, uint? dataClientOperationTimeoutMilliseconds = null)
         {
             this.grpcManager = new DataGrpcManager(authToken, endpoint);
             this.defaultTtlSeconds = defaultTtlSeconds;
-            this.dataClientOperationTimeoutMilliseconds = DEFAULT_DEADLINE_MILLISECONDS;
-        }
-
-        public ScsDataClient(string authToken, string endpoint, uint defaultTtlSeconds, uint dataClientOperationTimeoutMilliseconds)
-        {
-            this.grpcManager = new DataGrpcManager(authToken, endpoint);
-            this.defaultTtlSeconds = defaultTtlSeconds;
-            this.dataClientOperationTimeoutMilliseconds = dataClientOperationTimeoutMilliseconds;
+            this.dataClientOperationTimeoutMilliseconds = dataClientOperationTimeoutMilliseconds ?? DEFAULT_DEADLINE_MILLISECONDS;
         }
 
         public async Task<CacheSetResponse> SetAsync(string cacheName, byte[] key, byte[] value, uint ttlSeconds)

--- a/Momento/ScsDataClient.cs
+++ b/Momento/ScsDataClient.cs
@@ -276,6 +276,11 @@ namespace MomentoSdk
             return DateTime.UtcNow.AddMilliseconds(dataClientOperationTimeoutMilliseconds);
         }
 
+        /// <summary>
+        /// Converts TTL in seconds to milliseconds. Defaults to <c>defaultTtlSeconds</c>.
+        /// </summary>
+        /// <param name="ttlSeconds">The TTL to convert. Defaults to defaultTtlSeconds</param>
+        /// <returns></returns>
         private uint ttlSecondsToMilliseconds(uint? ttlSeconds = null)
         {
             return (ttlSeconds ?? defaultTtlSeconds) * 1000;

--- a/Momento/ScsDataClient.cs
+++ b/Momento/ScsDataClient.cs
@@ -23,15 +23,10 @@ namespace MomentoSdk
             this.dataClientOperationTimeoutMilliseconds = dataClientOperationTimeoutMilliseconds ?? DEFAULT_DEADLINE_MILLISECONDS;
         }
 
-        public async Task<CacheSetResponse> SetAsync(string cacheName, byte[] key, byte[] value, uint ttlSeconds)
+        public async Task<CacheSetResponse> SetAsync(string cacheName, byte[] key, byte[] value, uint? ttlSeconds = null)
         {
             _SetResponse response = await this.SendSetAsync(cacheName, value: Convert(value), key: Convert(key), ttlSeconds: ttlSeconds);
             return new CacheSetResponse(response);
-        }
-
-        public async Task<CacheSetResponse> SetAsync(string cacheName, byte[] key, byte[] value)
-        {
-            return await this.SetAsync(cacheName, key, value, defaultTtlSeconds);
         }
 
         public async Task<CacheGetResponse> GetAsync(string cacheName, byte[] key)
@@ -46,15 +41,10 @@ namespace MomentoSdk
             return new CacheDeleteResponse();
         }
 
-        public async Task<CacheSetResponse> SetAsync(string cacheName, string key, string value, uint ttlSeconds)
+        public async Task<CacheSetResponse> SetAsync(string cacheName, string key, string value, uint? ttlSeconds = null)
         {
             _SetResponse response = await this.SendSetAsync(cacheName, key: Convert(key), value: Convert(value), ttlSeconds: ttlSeconds);
             return new CacheSetResponse(response);
-        }
-
-        public async Task<CacheSetResponse> SetAsync(string cacheName, string key, string value)
-        {
-            return await this.SetAsync(cacheName, key, value, defaultTtlSeconds);
         }
 
         public async Task<CacheGetResponse> GetAsync(string cacheName, string key)
@@ -69,15 +59,10 @@ namespace MomentoSdk
             return new CacheDeleteResponse();
         }
 
-        public async Task<CacheSetResponse> SetAsync(string cacheName, string key, byte[] value, uint ttlSeconds)
+        public async Task<CacheSetResponse> SetAsync(string cacheName, string key, byte[] value, uint? ttlSeconds = null)
         {
             _SetResponse response = await this.SendSetAsync(cacheName, value: Convert(value), key: Convert(key), ttlSeconds: ttlSeconds);
             return new CacheSetResponse(response);
-        }
-
-        public async Task<CacheSetResponse> SetAsync(string cacheName, string key, byte[] value)
-        {
-            return await this.SetAsync(cacheName, key, value, defaultTtlSeconds);
         }
 
         public async Task<CacheMultiGetResponse> MultiGetAsync(string cacheName, List<string> keys)
@@ -125,15 +110,10 @@ namespace MomentoSdk
             return new CacheMultiGetResponse(successResponses, failedResponses);
         }
 
-        public CacheSetResponse Set(string cacheName, byte[] key, byte[] value, uint ttlSeconds)
+        public CacheSetResponse Set(string cacheName, byte[] key, byte[] value, uint? ttlSeconds = null)
         {
             _SetResponse resp = this.SendSet(cacheName, key: Convert(key), value: Convert(value), ttlSeconds: ttlSeconds);
             return new CacheSetResponse(resp);
-        }
-
-        public CacheSetResponse Set(string cacheName, byte[] key, byte[] value)
-        {
-            return this.Set(cacheName, key, value, defaultTtlSeconds);
         }
 
         public CacheGetResponse Get(string cacheName, byte[] key)
@@ -148,15 +128,10 @@ namespace MomentoSdk
             return new CacheDeleteResponse();
         }
 
-        public CacheSetResponse Set(string cacheName, string key, string value, uint ttlSeconds)
+        public CacheSetResponse Set(string cacheName, string key, string value, uint? ttlSeconds = null)
         {
             _SetResponse response = this.SendSet(cacheName, key: Convert(key), value: Convert(value), ttlSeconds: ttlSeconds);
             return new CacheSetResponse(response);
-        }
-
-        public CacheSetResponse Set(string cacheName, string key, string value)
-        {
-            return this.Set(cacheName, key, value, defaultTtlSeconds);
         }
 
         public CacheGetResponse Get(string cacheName, string key)
@@ -171,20 +146,15 @@ namespace MomentoSdk
             return new CacheDeleteResponse();
         }
 
-        public CacheSetResponse Set(string cacheName, string key, byte[] value, uint ttlSeconds)
+        public CacheSetResponse Set(string cacheName, string key, byte[] value, uint? ttlSeconds = null)
         {
             _SetResponse response = this.SendSet(cacheName, key: Convert(key), value: Convert(value), ttlSeconds: ttlSeconds);
             return new CacheSetResponse(response);
         }
 
-        public CacheSetResponse Set(string cacheName, string key, byte[] value)
+        private async Task<_SetResponse> SendSetAsync(string cacheName, ByteString key, ByteString value, uint? ttlSeconds = null)
         {
-            return this.Set(cacheName, key, value, defaultTtlSeconds);
-        }
-
-        private async Task<_SetResponse> SendSetAsync(string cacheName, ByteString key, ByteString value, uint ttlSeconds)
-        {
-            _SetRequest request = new _SetRequest() { CacheBody = value, CacheKey = key, TtlMilliseconds = ttlSeconds * 1000 };
+            _SetRequest request = new _SetRequest() { CacheBody = value, CacheKey = key, TtlMilliseconds = ttlSecondsToMilliseconds(ttlSeconds) };
             try
             {
                 return await this.grpcManager.Client().SetAsync(request, new Metadata { { "cache", cacheName } }, deadline: CalculateDeadline());
@@ -221,9 +191,9 @@ namespace MomentoSdk
             }
         }
 
-        private _SetResponse SendSet(string cacheName, ByteString key, ByteString value, uint ttlSeconds)
+        private _SetResponse SendSet(string cacheName, ByteString key, ByteString value, uint? ttlSeconds = null)
         {
-            _SetRequest request = new _SetRequest() { CacheBody = value, CacheKey = key, TtlMilliseconds = ttlSeconds * 1000 };
+            _SetRequest request = new _SetRequest() { CacheBody = value, CacheKey = key, TtlMilliseconds = ttlSecondsToMilliseconds(ttlSeconds) };
             try
             {
                 return this.grpcManager.Client().Set(request, new Metadata { { "cache", cacheName } }, deadline: CalculateDeadline());
@@ -304,6 +274,11 @@ namespace MomentoSdk
         private DateTime CalculateDeadline()
         {
             return DateTime.UtcNow.AddMilliseconds(dataClientOperationTimeoutMilliseconds);
+        }
+
+        private uint ttlSecondsToMilliseconds(uint? ttlSeconds = null)
+        {
+            return (ttlSeconds ?? defaultTtlSeconds) * 1000;
         }
 
         public void Dispose()

--- a/Momento/SimpleCacheClient.cs
+++ b/Momento/SimpleCacheClient.cs
@@ -73,7 +73,7 @@ namespace MomentoSdk
         /// <param name="cacheName">Name of the cache to store the item in.</param>
         /// <param name="key">The key to set.</param>
         /// <param name="value">The value to be stored.</param>
-        /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client.</param>
+        /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
         /// <returns>Future containing the result of the set operation.</returns>
         public async Task<CacheSetResponse> SetAsync(string cacheName, byte[] key, byte[] value, uint? ttlSeconds = null)
         {
@@ -139,7 +139,7 @@ namespace MomentoSdk
         /// <param name="cacheName">Name of the cache to store the item in.</param>
         /// <param name="key">The key to set.</param>
         /// <param name="value">The value to be stored.</param>
-        /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client.</param>
+        /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
         /// <returns>Future containing the result of the set operation</returns>
         public async Task<CacheSetResponse> SetAsync(string cacheName, string key, string value, uint? ttlSeconds = null)
         {
@@ -205,7 +205,7 @@ namespace MomentoSdk
         /// <param name="cacheName">Name of the cache to store the item in.</param>
         /// <param name="key">The key to set.</param>
         /// <param name="value">The value to be stored.</param>
-        /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client</param>
+        /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
         /// <returns>Future containing the result of the set operation</returns>
         public async Task<CacheSetResponse> SetAsync(string cacheName, string key, byte[] value, uint? ttlSeconds = null)
         {
@@ -291,7 +291,7 @@ namespace MomentoSdk
         /// <param name="cacheName">Name of the cache to store the item in.</param>
         /// <param name="key">The key to set.</param>
         /// <param name="value">The value to be stored.</param>
-        /// <param name="ttlSeconds">Time to live (TTL) for the item in Cache. This TTL takes precedence over the TTL used when initializing a cache client.</param>
+        /// <param name="ttlSeconds">Time to live (TTL) for the item in Cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
         /// <returns>Result of the set operation</returns>
         public CacheSetResponse Set(string cacheName, byte[] key, byte[] value, uint? ttlSeconds = null)
         {
@@ -356,7 +356,7 @@ namespace MomentoSdk
         /// </summary>
         /// <param name="key">The key to set.</param>
         /// <param name="value">The value to be stored.</param>
-        /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client.</param>
+        /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
         /// <returns>Result of the set operation.</returns>
         public CacheSetResponse Set(string cacheName, string key, string value, uint? ttlSeconds = null)
         {
@@ -422,7 +422,7 @@ namespace MomentoSdk
         /// <param name="cacheName">Name of the cache to store the item in.</param>
         /// <param name="key">The key to set.</param>
         /// <param name="value">The value to be stored.</param>
-        /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client.</param>
+        /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
         /// <returns>Result of the set operation</returns>
         public CacheSetResponse Set(string cacheName, string key, byte[] value, uint? ttlSeconds = null)
         {

--- a/Momento/SimpleCacheClient.cs
+++ b/Momento/SimpleCacheClient.cs
@@ -16,24 +16,8 @@ namespace MomentoSdk
         /// </summary>
         /// <param name="authToken">Momento JWT.</param>
         /// <param name="defaultTtlSeconds">Default time to live for the item in cache.</param>
-        public SimpleCacheClient(string authToken, uint defaultTtlSeconds)
-        {
-            Claims claims = JwtUtils.DecodeJwt(authToken);
-            string controlEndpoint = "https://" + claims.ControlEndpoint + ":443";
-            string cacheEndpoint = "https://" + claims.CacheEndpoint + ":443";
-            ScsControlClient controlClient = new ScsControlClient(authToken, controlEndpoint);
-            ScsDataClient dataClient = new ScsDataClient(authToken, cacheEndpoint, defaultTtlSeconds);
-            this.controlClient = controlClient;
-            this.dataClient = dataClient;
-        }
-
-        /// <summary>
-        /// Client to perform operations against the Simple Cache Service.
-        /// </summary>
-        /// <param name="authToken">Momento JWT.</param>
-        /// <param name="defaultTtlSeconds">Default time to live for the item in cache.</param>
-        /// <param name="dataClientOperationTimeoutMilliseconds">Deadline (timeout) for communicating to the server.</param>
-        public SimpleCacheClient(string authToken, uint defaultTtlSeconds, uint dataClientOperationTimeoutMilliseconds)
+        /// <param name="dataClientOperationTimeoutMilliseconds">Deadline (timeout) for communicating to the server. Defaults to 5 seconds.</param>
+        public SimpleCacheClient(string authToken, uint defaultTtlSeconds, uint? dataClientOperationTimeoutMilliseconds = null)
         {
             ValidateRequestTimeout(dataClientOperationTimeoutMilliseconds);
             Claims claims = JwtUtils.DecodeJwt(authToken);
@@ -619,8 +603,12 @@ namespace MomentoSdk
             GC.SuppressFinalize(this);
         }
 
-        private void ValidateRequestTimeout(uint requestTimeoutMilliseconds)
+        private void ValidateRequestTimeout(uint? requestTimeoutMilliseconds = null)
         {
+            if (requestTimeoutMilliseconds == null)
+            {
+                return;
+            }
             if (requestTimeoutMilliseconds == 0)
             {
                 throw new InvalidArgumentException("Request timeout must be greater than zero.");

--- a/Momento/SimpleCacheClient.cs
+++ b/Momento/SimpleCacheClient.cs
@@ -75,7 +75,7 @@ namespace MomentoSdk
         /// <param name="value">The value to be stored.</param>
         /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client.</param>
         /// <returns>Future containing the result of the set operation.</returns>
-        public async Task<CacheSetResponse> SetAsync(string cacheName, byte[] key, byte[] value, uint ttlSeconds)
+        public async Task<CacheSetResponse> SetAsync(string cacheName, byte[] key, byte[] value, uint? ttlSeconds = null)
         {
             if (cacheName == null)
             {
@@ -91,31 +91,6 @@ namespace MomentoSdk
             }
 
             return await this.dataClient.SetAsync(cacheName, key, value, ttlSeconds);
-        }
-
-        /// <summary>
-        /// Sets the value in cache with a given time to live (TTL) seconds.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to store the item in.</param>
-        /// <param name="key">The key to set.</param>
-        /// <param name="value">The value to be stored.</param>
-        /// <returns>Future containing the result of the set operation.</returns>
-        public async Task<CacheSetResponse> SetAsync(string cacheName, byte[] key, byte[] value)
-        {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-
-            return await this.dataClient.SetAsync(cacheName, key, value);
         }
 
         /// <summary>
@@ -166,7 +141,7 @@ namespace MomentoSdk
         /// <param name="value">The value to be stored.</param>
         /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client.</param>
         /// <returns>Future containing the result of the set operation</returns>
-        public async Task<CacheSetResponse> SetAsync(string cacheName, string key, string value, uint ttlSeconds)
+        public async Task<CacheSetResponse> SetAsync(string cacheName, string key, string value, uint? ttlSeconds = null)
         {
             if (cacheName == null)
             {
@@ -182,31 +157,6 @@ namespace MomentoSdk
             }
 
             return await this.dataClient.SetAsync(cacheName, key, value, ttlSeconds);
-        }
-
-        /// <summary>
-        /// Sets the value in cache with a default time to live (TTL) seconds used initializing a cache client.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to store the item in.</param>
-        /// <param name="key">The key to set.</param>
-        /// <param name="value">The value to be stored.</param>
-        /// <returns>Future containing the result of the set operation.</returns>
-        public async Task<CacheSetResponse> SetAsync(string cacheName, string key, string value)
-        {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-
-            return await this.dataClient.SetAsync(cacheName, key, value);
         }
 
         /// <summary>
@@ -257,7 +207,7 @@ namespace MomentoSdk
         /// <param name="value">The value to be stored.</param>
         /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client</param>
         /// <returns>Future containing the result of the set operation</returns>
-        public async Task<CacheSetResponse> SetAsync(string cacheName, string key, byte[] value, uint ttlSeconds)
+        public async Task<CacheSetResponse> SetAsync(string cacheName, string key, byte[] value, uint? ttlSeconds = null)
         {
             if (cacheName == null)
             {
@@ -273,31 +223,6 @@ namespace MomentoSdk
             }
 
             return await this.dataClient.SetAsync(cacheName, key, value, ttlSeconds);
-        }
-
-        /// <summary>
-        /// Sets the value in cache with a default time to live (TTL) seconds used initializing a cache client
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to store the item in.</param>
-        /// <param name="key">The value to be stored.</param>
-        /// <param name="value">The value to be stored.</param>
-        /// <returns>Future containing the result of the set operation.</returns>
-        public async Task<CacheSetResponse> SetAsync(string cacheName, string key, byte[] value)
-        {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-
-            return await this.dataClient.SetAsync(cacheName, key, value);
         }
 
         /// <summary>
@@ -368,7 +293,7 @@ namespace MomentoSdk
         /// <param name="value">The value to be stored.</param>
         /// <param name="ttlSeconds">Time to live (TTL) for the item in Cache. This TTL takes precedence over the TTL used when initializing a cache client.</param>
         /// <returns>Result of the set operation</returns>
-        public CacheSetResponse Set(string cacheName, byte[] key, byte[] value, uint ttlSeconds)
+        public CacheSetResponse Set(string cacheName, byte[] key, byte[] value, uint? ttlSeconds = null)
         {
             if (cacheName == null)
             {
@@ -384,31 +309,6 @@ namespace MomentoSdk
             }
 
             return this.dataClient.Set(cacheName, key, value, ttlSeconds);
-        }
-
-        /// <summary>
-        /// Sets the value in the cache. If a value for this key is already present it will be replaced by the new value.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to store the item in.</param>
-        /// <param name="key">The key to set.</param>
-        /// <param name="value">The value to be stored.</param>
-        /// <returns>Result of the set operation.</returns>
-        public CacheSetResponse Set(string cacheName, byte[] key, byte[] value)
-        {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-
-            return this.dataClient.Set(cacheName, key, value);
         }
 
         /// <summary>
@@ -458,7 +358,7 @@ namespace MomentoSdk
         /// <param name="value">The value to be stored.</param>
         /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client.</param>
         /// <returns>Result of the set operation.</returns>
-        public CacheSetResponse Set(string cacheName, string key, string value, uint ttlSeconds)
+        public CacheSetResponse Set(string cacheName, string key, string value, uint? ttlSeconds = null)
         {
             if (cacheName == null)
             {
@@ -474,33 +374,6 @@ namespace MomentoSdk
             }
 
             return this.dataClient.Set(cacheName, key, value, ttlSeconds);
-        }
-
-        /// <summary>
-        /// Sets the value in the cache. If a value for this key is already present it will be replaced by the new value.
-        /// The time to live (TTL) seconds defaults to the parameter used when initializing this cache client.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to store the item in.</param>
-        /// <param name="key">The key to set.</param>
-        /// <param name="value">The value to be stored.</param>
-        /// <param name="ttlSeconds">TTL for the item in Cache. This TTL takes precedence over the TTL used when initializing a cache client.</param>
-        /// <returns>Result of the set operation</returns>
-        public CacheSetResponse Set(string cacheName, string key, string value)
-        {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-
-            return this.dataClient.Set(cacheName, key, value);
         }
 
         /// <summary>
@@ -551,7 +424,7 @@ namespace MomentoSdk
         /// <param name="value">The value to be stored.</param>
         /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client.</param>
         /// <returns>Result of the set operation</returns>
-        public CacheSetResponse Set(string cacheName, string key, byte[] value, uint ttlSeconds)
+        public CacheSetResponse Set(string cacheName, string key, byte[] value, uint? ttlSeconds = null)
         {
             if (cacheName == null)
             {
@@ -567,33 +440,6 @@ namespace MomentoSdk
             }
 
             return this.dataClient.Set(cacheName, key, value, ttlSeconds);
-        }
-
-        /// <summary>
-        /// Sets the value in the cache. If a value for this key is already present it will be replaced by the new value.
-        /// The time to live (TTL) seconds defaults to the parameter used when initializing this cache client.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to store the item in.</param>
-        /// <param name="key">The key to set.</param>
-        /// <param name="value">The value to be stored.</param>
-        /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client.</param>
-        /// <returns>Result of the set operation</returns>
-        public CacheSetResponse Set(string cacheName, string key, byte[] value)
-        {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-
-            return this.dataClient.Set(cacheName, key, value);
         }
 
         public void Dispose()

--- a/MomentoIntegrationTest/SimpleCacheDataTest.cs
+++ b/MomentoIntegrationTest/SimpleCacheDataTest.cs
@@ -19,7 +19,6 @@ namespace MomentoIntegrationTest
         // Test initialization
         public SimpleCacheDataTest()
         {
-            uint defaultTtlSeconds = 10;
             client = new SimpleCacheClient(authKey, defaultTtlSeconds);
             try
             {


### PR DESCRIPTION
This PR refactors the code to use optional arguments where appropriate. Many methods were extraneous because of this, so we can now delete a lot of repeated code, eg:

```csharp
public CacheSetResponse Set(string cacheName, string key, string value, uint ttlSeconds) {}
// ...
public CacheSetResponse Set(string cacheName, string key, string value) {}
```

becomes
```csharp
public CacheSetResponse Set(string cacheName, string key, string value, uint? ttlSeconds = null)
```

Where the default for `ttlSeconds` is set in one place.