### PR TITLE
feat: Refactor multi-get to be in sync with latest spec.

### DIFF
--- a/Momento/Responses/CacheGetResponse.cs
+++ b/Momento/Responses/CacheGetResponse.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿#nullable enable
+using System.Text;
 using CacheClient;
 using Google.Protobuf;
 using MomentoSdk.Exceptions;
@@ -16,12 +17,12 @@ namespace MomentoSdk.Responses
             Status = From(response.Result);
         }
 
-        public string String()
+        public string? String()
         {
             return String(Encoding.UTF8);
         }
 
-        public string String(Encoding encoding)
+        public string? String(Encoding encoding)
         {
             if (Status == CacheGetStatus.HIT)
             {
@@ -30,7 +31,7 @@ namespace MomentoSdk.Responses
             return null;
         }
 
-        public byte[] Bytes()
+        public byte[]? Bytes()
         {
             if (Status == CacheGetStatus.HIT)
             {

--- a/Momento/Responses/CacheMultiGetResponse.cs
+++ b/Momento/Responses/CacheMultiGetResponse.cs
@@ -1,69 +1,36 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+using System.Collections.Generic;
+using System.Linq;
 
 namespace MomentoSdk.Responses
 {
     public class CacheMultiGetResponse
     {
-        private readonly List<CacheGetResponse> successfulResponses;
-        private readonly List<CacheMultiGetFailureResponse> failedResponses;
+        private readonly List<CacheGetResponse> responses;
 
-        private readonly CacheGetResponse successfulResponse = null;
-        private readonly CacheMultiGetFailureResponse failedResponse = null;
-
-        public CacheMultiGetResponse(List<CacheGetResponse> cacheGetResponses, List<CacheMultiGetFailureResponse> cacheMultiGetFailureResponses)
+        public CacheMultiGetResponse(IEnumerable<CacheGetResponse> responses)
         {
-            successfulResponses = cacheGetResponses;
-            failedResponses = cacheMultiGetFailureResponses;
+            this.responses = new(responses);
         }
 
-        public CacheMultiGetResponse(CacheGetResponse cacheGetResponse)
+        public List<CacheGetResponse> ToList()
         {
-            successfulResponse = cacheGetResponse;
+            return responses;
         }
 
-        public CacheMultiGetResponse(CacheMultiGetFailureResponse cacheMultiGetFailureResponse)
+        public List<CacheGetStatus> Status()
         {
-            failedResponse = cacheMultiGetFailureResponse;
+            return responses.Select(response => response.Status).ToList();
         }
 
-        public CacheGetResponse SuccessfulResponse()
+        public List<string?> Strings()
         {
-            return successfulResponse;
+            return responses.Select(response => response.String()).ToList();
         }
 
-        public CacheMultiGetFailureResponse FailedResponse()
+        public List<byte[]?> Bytes()
         {
-            return failedResponse;
-        }
-
-        public List<CacheGetResponse> SuccessfulResponses()
-        {
-            return successfulResponses;
-        }
-
-        public List<CacheMultiGetFailureResponse> FailedResponses()
-        {
-            return failedResponses;
-        }
-
-        public List<string> Strings()
-        {
-            List<string> values = new();
-            foreach (CacheGetResponse response in successfulResponses)
-            {
-                values.Add(response.String());
-            }
-            return values;
-        }
-
-        public List<byte[]> Bytes()
-        {
-            List<byte[]> values = new();
-            foreach (CacheGetResponse response in successfulResponses)
-            {
-                values.Add(response.Bytes());
-            }
-            return values;
+            return responses.Select(response => response.Bytes()).ToList();
         }
     }
 }

--- a/Momento/SimpleCacheClient.cs
+++ b/Momento/SimpleCacheClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using MomentoSdk.Responses;
 using MomentoSdk.Exceptions;
@@ -231,13 +232,13 @@ namespace MomentoSdk
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>
         /// <returns>Future with CacheMultiGetResponse containing the status of the get operation and the associated value data.</returns>
-        public async Task<CacheMultiGetResponse> MultiGetAsync(string cacheName, List<byte[]> keys)
+        public async Task<CacheMultiGetResponse> MultiGetAsync(string cacheName, IEnumerable<byte[]> keys)
         {
             if (cacheName == null)
             {
                 throw new ArgumentNullException(nameof(cacheName));
             }
-            if (keys == null)
+            if (keys == null || keys.Any(key => key == null))
             {
                 throw new ArgumentNullException(nameof(keys));
             }
@@ -251,13 +252,13 @@ namespace MomentoSdk
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>
         /// <returns>Future with CacheMultiGetResponse containing the status of the get operation and the associated value data.</returns>
-        public async Task<CacheMultiGetResponse> MultiGetAsync(string cacheName, List<string> keys)
+        public async Task<CacheMultiGetResponse> MultiGetAsync(string cacheName, IEnumerable<string> keys)
         {
             if (cacheName == null)
             {
                 throw new ArgumentNullException(nameof(cacheName));
             }
-            if (keys == null)
+            if (keys == null || keys.Any(key => key == null))
             {
                 throw new ArgumentNullException(nameof(keys));
             }
@@ -269,20 +270,40 @@ namespace MomentoSdk
         /// Executes a list of passed Get operations in parallel.
         /// </summary>
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-        /// <param name="failureResponses">Failed responses to perform a cache lookup on.</param>
+        /// <param name="keys">The keys to get.</param>
         /// <returns>Future with CacheMultiGetResponse containing the status of the get operation and the associated value data.</returns>
-        public async Task<CacheMultiGetResponse> MultiGetAsync(string cacheName, List<CacheMultiGetFailureResponse> failureResponses)
+        public async Task<CacheMultiGetResponse> MultiGetAsync(string cacheName, params byte[][] keys)
         {
             if (cacheName == null)
             {
                 throw new ArgumentNullException(nameof(cacheName));
             }
-            if (failureResponses == null)
+            if (keys == null || keys.Any(key => key == null))
             {
-                throw new ArgumentNullException(nameof(failureResponses));
+                throw new ArgumentNullException(nameof(keys));
             }
 
-            return await this.dataClient.MultiGetAsync(cacheName, failureResponses);
+            return await this.dataClient.MultiGetAsync(cacheName, keys);
+        }
+
+        /// <summary>
+        /// Executes a list of passed Get operations in parallel.
+        /// </summary>
+        /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+        /// <param name="keys">The keys to get.</param>
+        /// <returns>Future with CacheMultiGetResponse containing the status of the get operation and the associated value data.</returns>
+        public async Task<CacheMultiGetResponse> MultiGetAsync(string cacheName, params string[] keys)
+        {
+            if (cacheName == null)
+            {
+                throw new ArgumentNullException(nameof(cacheName));
+            }
+            if (keys == null || keys.Any(key => key == null))
+            {
+                throw new ArgumentNullException(nameof(keys));
+            }
+
+            return await this.dataClient.MultiGetAsync(cacheName, keys);
         }
 
         /// <summary>

--- a/Momento/SimpleCacheClient.cs
+++ b/Momento/SimpleCacheClient.cs
@@ -418,6 +418,78 @@ namespace MomentoSdk
         }
 
         /// <summary>
+        /// Executes a list of passed Get operations in parallel.
+        /// </summary>
+        /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+        /// <param name="keys">The keys to get.</param>
+        /// <returns>Response object with the status of the get operation and the associated value data.</returns>
+        public CacheMultiGetResponse MultiGet(string cacheName, IEnumerable<byte[]> keys)
+        {
+            try
+            {
+                return MultiGetAsync(cacheName, keys).Result;
+            }
+            catch (AggregateException e)
+            {
+                throw e.GetBaseException();
+            }
+        }
+
+        /// <summary>
+        /// Executes a list of passed Get operations in parallel.
+        /// </summary>
+        /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+        /// <param name="keys">The keys to get.</param>
+        /// <returns>Response object with the status of the get operation and the associated value data.</returns>
+        public CacheMultiGetResponse MultiGet(string cacheName, IEnumerable<string> keys)
+        {
+            try
+            {
+                return MultiGetAsync(cacheName, keys).Result;
+            }
+            catch (AggregateException e)
+            {
+                throw e.GetBaseException();
+            }
+        }
+
+        /// <summary>
+        /// Executes a list of passed Get operations in parallel.
+        /// </summary>
+        /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+        /// <param name="keys">The keys to get.</param>
+        /// <returns>Future with CacheMultiGetResponse containing the status of the get operation and the associated value data.</returns>
+        public CacheMultiGetResponse MultiGet(string cacheName, params byte[][] keys)
+        {
+            try
+            {
+                return MultiGetAsync(cacheName, keys).Result;
+            }
+            catch (AggregateException e)
+            {
+                throw e.GetBaseException();
+            }
+        }
+
+        /// <summary>
+        /// Executes a list of passed Get operations in parallel.
+        /// </summary>
+        /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+        /// <param name="keys">The keys to get.</param>
+        /// <returns>Future with CacheMultiGetResponse containing the status of the get operation and the associated value data.</returns>
+        public CacheMultiGetResponse MultiGet(string cacheName, params string[] keys)
+        {
+            try
+            {
+                return MultiGetAsync(cacheName, keys).Result;
+            }
+            catch (AggregateException e)
+            {
+                throw e.GetBaseException();
+            }
+        }
+
+        /// <summary>
         /// Remove the key from the cache.
         /// </summary>
         /// <param name="cacheName">Name of the cache to delete the key from.</param>

--- a/MomentoIntegrationTest/SimpleCacheDataTest.cs
+++ b/MomentoIntegrationTest/SimpleCacheDataTest.cs
@@ -221,7 +221,7 @@ namespace MomentoIntegrationTest
             // Set very small timeout for dataClientOperationTimeoutMilliseconds
             SimpleCacheClient simpleCacheClient = new SimpleCacheClient(authKey, defaultTtlSeconds, 1);
             List<string> keys = new() { "key1", "key2", "key3", "key4" };
-            Assert.ThrowsAsync<MomentoServiceException>(() => simpleCacheClient.MultiGetAsync(cacheName, keys));
+            Assert.ThrowsAsync<MomentoSdk.Exceptions.TimeoutException>(() => simpleCacheClient.MultiGetAsync(cacheName, keys));
         }
 
         [Theory]
@@ -354,6 +354,92 @@ namespace MomentoIntegrationTest
             client.Set(cacheName, key, value, ttlSeconds: 15);
             setValue = client.Get(cacheName, key).Bytes();
             Assert.Equal(value, setValue);
+        }
+
+        [Fact]
+        public void MultiGet_NullCheckBytes_ThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>(() => client.MultiGet(null, new List<byte[]>()));
+            Assert.Throws<ArgumentNullException>(() => client.MultiGet("cache", (List<byte[]>)null));
+
+            var badList = new List<byte[]>(new byte[][] { Utf8ToBytes("asdf"), null });
+            Assert.Throws<ArgumentNullException>(() => client.MultiGet("cache", badList));
+
+            Assert.Throws<ArgumentNullException>(() => client.MultiGet("cache", Utf8ToBytes("key1"), null));
+        }
+
+        [Fact]
+        public void MultiGet_KeysAreBytes_HappyPath()
+        {
+            string cacheKey1 = "key1";
+            string cacheValue1 = "value1";
+            string cacheKey2 = "key2";
+            string cacheValue2 = "value2";
+            client.Set(cacheName, cacheKey1, cacheValue1);
+            client.Set(cacheName, cacheKey2, cacheValue2);
+
+            List<byte[]> keys = new() { Utf8ToBytes(cacheKey1), Utf8ToBytes(cacheKey2) };
+
+            CacheMultiGetResponse result = client.MultiGet(cacheName, keys);
+            string stringResult1 = result.Strings()[0];
+            string stringResult2 = result.Strings()[1];
+            Assert.Equal(cacheValue1, stringResult1);
+            Assert.Equal(cacheValue2, stringResult2);
+        }
+
+        [Fact]
+        public void MultiGet_KeysAreBytes_HappyPath2()
+        {
+            string cacheKey1 = "key1";
+            string cacheValue1 = "value1";
+            string cacheKey2 = "key2";
+            string cacheValue2 = "value2";
+            client.Set(cacheName, cacheKey1, cacheValue1);
+            client.Set(cacheName, cacheKey2, cacheValue2);
+
+            CacheMultiGetResponse result = client.MultiGet(cacheName, cacheKey1, cacheKey2);
+            string stringResult1 = result.Strings()[0];
+            string stringResult2 = result.Strings()[1];
+            Assert.Equal(cacheValue1, stringResult1);
+            Assert.Equal(cacheValue2, stringResult2);
+        }
+
+        [Fact]
+        public void MultiGet_NullCheckString_ThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>(() => client.MultiGet(null, new List<string>()));
+            Assert.Throws<ArgumentNullException>(() => client.MultiGet("cache", (List<string>)null));
+
+            List<string> strings = new(new string[] { "key1", "key2", null });
+            Assert.Throws<ArgumentNullException>(() => client.MultiGet("cache", strings));
+
+            Assert.Throws<ArgumentNullException>(() => client.MultiGet("cache", "key1", "key2", null));
+        }
+
+        [Fact]
+        public void MultiGet_KeysAreString_HappyPath()
+        {
+            string cacheKey1 = "key1";
+            string cacheValue1 = "value1";
+            string cacheKey2 = "key2";
+            string cacheValue2 = "value2";
+            client.Set(cacheName, cacheKey1, cacheValue1);
+            client.Set(cacheName, cacheKey2, cacheValue2);
+
+            List<string> keys = new() { cacheKey1, cacheKey2, "key123123" };
+            CacheMultiGetResponse result = client.MultiGet(cacheName, keys);
+
+            Assert.Equal(result.Strings(), new string[] { cacheValue1, cacheValue2, null });
+            Assert.Equal(result.Status(), new CacheGetStatus[] { CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS });
+        }
+
+        [Fact]
+        public void MultiGet_Failure()
+        {
+            // Set very small timeout for dataClientOperationTimeoutMilliseconds
+            SimpleCacheClient simpleCacheClient = new SimpleCacheClient(authKey, defaultTtlSeconds, 1);
+            List<string> keys = new() { "key1", "key2", "key3", "key4" };
+            Assert.Throws<MomentoSdk.Exceptions.TimeoutException>(() => simpleCacheClient.MultiGet(cacheName, keys));
         }
 
         [Theory]


### PR DESCRIPTION
Closes #66 

This refactors `MultiGet` to be in line with the latest specifications. Keys can be passed in as either variadic arguments or as an `IEnumerable`; the individual keys can be either  `string` or `byte[]`; and the method can be blocking or async.

To illustrate:

```csharp
var response = client.MultiGet("my-cache", "key1", "key2", "key3");
response.Status(); // [HIT, HIT, MISS]
response.Strings(); // ["value1", "value2", null]
response.ToList(); // list of `CacheGetResponse`, each of which wraps the corresponding key's status and value
```

Similarly:
```csharp
IEnumerable<string> keys;
var response = client.MultiGet("my-cache", keys);
```