### PR TITLE
chore: fix return types and typos in dictionary stubs

### DIFF
--- a/Momento/Incubating/Responses/CacheDictionaryGetAllResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictionaryGetAllResponse.cs
@@ -17,12 +17,12 @@ namespace MomentoSdk.Incubating.Responses
             throw new NotImplementedException();
         }
 
-        public IDictionary<byte[], byte[]>? DictionaryAsBytes()
+        public Dictionary<byte[], byte[]>? DictionaryAsBytes()
         {
             throw new NotImplementedException();
         }
 
-        public IDictionary<string, string>? Dictionary(Encoding? encoding = null)
+        public Dictionary<string, string>? Dictionary(Encoding? encoding = null)
         {
             throw new NotImplementedException();
         }

--- a/Momento/Incubating/Responses/CacheDictionaryMultiSetResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictionaryMultiSetResponse.cs
@@ -15,11 +15,11 @@ namespace MomentoSdk.Incubating.Responses
         {
             throw new NotImplementedException();
         }
-        public IDictionary<byte[], byte>? DictionaryAsBytes()
+        public Dictionary<byte[], byte>? DictionaryAsBytes()
         {
             throw new NotImplementedException();
         }
-        public IDictionary<string, string>? Dictionary(Encoding? encoding = null)
+        public Dictionary<string, string>? Dictionary(Encoding? encoding = null)
         {
             throw new NotImplementedException();
         }

--- a/Momento/Incubating/Responses/CacheDictonaryMultiGetResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictonaryMultiGetResponse.cs
@@ -14,24 +14,23 @@ namespace MomentoSdk.Incubating.Responses
         {
         }
 
-        public IList<CacheGetStatus> Status()
+        public List<CacheGetStatus> Status()
         {
             throw new NotImplementedException();
         }
 
-        public IList<string?> Values(Encoding? encoding = null)
+        public List<string?> Values(Encoding? encoding = null)
         {
             throw new NotImplementedException();
         }
 
-        public IList<byte[]?> ValuesAsBytes()
+        public List<byte[]?> ValuesAsBytes()
         {
             throw new NotImplementedException();
         }
 
-        public IList<CacheGetResponse> ToList()
+        public List<CacheGetResponse> ToList()
         {
-
             throw new NotImplementedException();
         }
     }

--- a/Momento/Incubating/SimpleCacheClient.cs
+++ b/Momento/Incubating/SimpleCacheClient.cs
@@ -76,17 +76,17 @@ namespace MomentoSdk.Incubating
             throw new NotImplementedException();
         }
 
-        public CacheDictionaryMultiGetResponse DictionaryMultiGet(string cacheName, string dictionaryName, params string[] key)
+        public CacheDictionaryMultiGetResponse DictionaryMultiGet(string cacheName, string dictionaryName, params string[] keys)
         {
             throw new NotImplementedException();
         }
 
-        public async Task<CacheDictionaryMultiGetResponse> DictionaryMultiGetAsync(string cacheName, string dictionaryName, params byte[][] key)
+        public async Task<CacheDictionaryMultiGetResponse> DictionaryMultiGetAsync(string cacheName, string dictionaryName, params byte[][] keys)
         {
             return await Task.FromException<CacheDictionaryMultiGetResponse>(new NotImplementedException());
         }
 
-        public async Task<CacheDictionaryMultiGetResponse> DictionaryMultiGetAsync(string cacheName, string dictionaryName, params string[] key)
+        public async Task<CacheDictionaryMultiGetResponse> DictionaryMultiGetAsync(string cacheName, string dictionaryName, params string[] keys)
         {
             return await Task.FromException<CacheDictionaryMultiGetResponse>(new NotImplementedException());
         }


### PR DESCRIPTION
Use concrete types from functions. Initially these were interface
types. While it makes sense to broader function arguments to
interfaces, when the return types are known, we should be explicit
about them.

Additionally there were a couple typos in the argument names.