### PR TITLE
feat: implement multi-set

### DIFF
--- a/Momento/Responses/CacheGetResponse.cs
+++ b/Momento/Responses/CacheGetResponse.cs
@@ -17,13 +17,10 @@ namespace MomentoSdk.Responses
             Status = From(response.Result);
         }
 
-        public string? String()
+        public string? String(Encoding? encoding = null)
         {
-            return String(Encoding.UTF8);
-        }
+            encoding ??= Encoding.UTF8;
 
-        public string? String(Encoding encoding)
-        {
             if (Status == CacheGetStatus.HIT)
             {
                 return body.ToString(encoding);

--- a/Momento/Responses/CacheMultiSetResponse.cs
+++ b/Momento/Responses/CacheMultiSetResponse.cs
@@ -4,11 +4,16 @@ namespace MomentoSdk.Responses
 {
     public class CacheMultiSetResponse
     {
-        private readonly IDictionary<object, object> items;
+        private readonly object items;
 
-        public CacheMultiSetResponse(IDictionary<object, object> items)
+        public CacheMultiSetResponse(IDictionary<byte[], byte[]> items)
         {
-            this.items = items;
+            this.items = (object)items;
+        }
+
+        public CacheMultiSetResponse(IDictionary<string, string> items)
+        {
+            this.items = (object)items;
         }
 
         public IDictionary<string, string> Strings()

--- a/Momento/Responses/CacheMultiSetResponse.cs
+++ b/Momento/Responses/CacheMultiSetResponse.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace MomentoSdk.Responses
+{
+    public class CacheMultiSetResponse
+    {
+        private readonly IDictionary<object, object> items;
+
+        public CacheMultiSetResponse(IDictionary<object, object> items)
+        {
+            this.items = items;
+        }
+
+        public IDictionary<string, string> Strings()
+        {
+            return (IDictionary<string, string>)items;
+        }
+
+        public IDictionary<byte[], byte[]> Bytes()
+        {
+            return (IDictionary<byte[], byte[]>)items;
+        }
+    }
+}

--- a/Momento/SimpleCacheClient.cs
+++ b/Momento/SimpleCacheClient.cs
@@ -557,6 +557,42 @@ namespace MomentoSdk
         }
 
         /// <summary>
+        /// Stores multiple items in the cache. Overwrites existing items.
+        /// </summary>
+        /// <param name="cacheName">Name of the cache to store the items in.</param>
+        /// <param name="items">The items to set.</param>
+        /// <returns>Future with CacheMultiSetResponse containing the data set.</returns>
+        public CacheMultiSetResponse MultiSet(string cacheName, IDictionary<byte[], byte[]> items, uint? ttlSeconds = null)
+        {
+            try
+            {
+                return MultiSetAsync(cacheName, items, ttlSeconds).Result;
+            }
+            catch (AggregateException e)
+            {
+                throw e.GetBaseException();
+            }
+        }
+
+        /// <summary>
+        /// Stores multiple items in the cache. Overwrites existing items.
+        /// </summary>
+        /// <param name="cacheName">Name of the cache to store the items in.</param>
+        /// <param name="items">The items to set.</param>
+        /// <returns>Future with CacheMultiSetResponse containing the data set.</returns>
+        public CacheMultiSetResponse MultiSet(string cacheName, IDictionary<string, string> items, uint? ttlSeconds = null)
+        {
+            try
+            {
+                return MultiSetAsync(cacheName, items, ttlSeconds).Result;
+            }
+            catch (AggregateException e)
+            {
+                throw e.GetBaseException();
+            }
+        }
+
+        /// <summary>
         /// Remove the key from the cache.
         /// </summary>
         /// <param name="cacheName">Name of the cache to delete the key from.</param>

--- a/Momento/SimpleCacheClient.cs
+++ b/Momento/SimpleCacheClient.cs
@@ -307,6 +307,48 @@ namespace MomentoSdk
         }
 
         /// <summary>
+        /// Stores multiple items in the cache. Overwrites existing items.
+        /// </summary>
+        /// <param name="cacheName">Name of the cache to store the items in.</param>
+        /// <param name="items">The items to set.</param>
+        /// <returns>Future with CacheMultiSetResponse containing the data set.</returns>
+        public async Task<CacheMultiSetResponse> MultiSetAsync(string cacheName, IDictionary<byte[], byte[]> items, uint? ttlSeconds = null)
+        {
+            if (cacheName == null)
+            {
+                throw new ArgumentNullException(nameof(cacheName));
+            }
+            if (items == null || items.Values.Any(value => value == null))
+            {
+                throw new ArgumentNullException(nameof(items));
+            }
+
+            await this.dataClient.MultiSetAsync(cacheName, items, ttlSeconds);
+            return new CacheMultiSetResponse((IDictionary<object, object>)items);
+        }
+
+        /// <summary>
+        /// Stores multiple items in the cache. Overwrites existing items.
+        /// </summary>
+        /// <param name="cacheName">Name of the cache to store the items in.</param>
+        /// <param name="items">The items to set.</param>
+        /// <returns>Future with CacheMultiSetResponse containing the data set.</returns>
+        public async Task<CacheMultiSetResponse> MultiSetAsync(string cacheName, IDictionary<string, string> items, uint? ttlSeconds = null)
+        {
+            if (cacheName == null)
+            {
+                throw new ArgumentNullException(nameof(cacheName));
+            }
+            if (items == null || items.Any(item => item.Value == null))
+            {
+                throw new ArgumentNullException(nameof(items));
+            }
+
+            await this.dataClient.MultiSetAsync(cacheName, items, ttlSeconds);
+            return new CacheMultiSetResponse((IDictionary<object, object>)items);
+        }
+
+        /// <summary>
         ///  Sets the value in the cache. If a value for this key is already present it will be replaced by the new value.
         /// </summary>
         /// <param name="cacheName">Name of the cache to store the item in.</param>

--- a/Momento/SimpleCacheClient.cs
+++ b/Momento/SimpleCacheClient.cs
@@ -227,7 +227,7 @@ namespace MomentoSdk
         }
 
         /// <summary>
-        /// Gets a multiple values from the cache.
+        /// Gets multiple values from the cache.
         /// </summary>
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>
@@ -251,7 +251,7 @@ namespace MomentoSdk
         }
 
         /// <summary>
-        /// Gets a multiple values from the cache.
+        /// Gets multiple values from the cache.
         /// </summary>
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>
@@ -276,7 +276,7 @@ namespace MomentoSdk
         }
 
         /// <summary>
-        /// Gets a multiple values from the cache.
+        /// Gets multiple values from the cache.
         /// </summary>
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>
@@ -300,7 +300,7 @@ namespace MomentoSdk
         }
 
         /// <summary>
-        /// Gets a multiple values from the cache.
+        /// Gets multiple values from the cache.
         /// </summary>
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>
@@ -485,7 +485,7 @@ namespace MomentoSdk
         }
 
         /// <summary>
-        /// Gets a multiple values from the cache.
+        /// Gets multiple values from the cache.
         /// </summary>
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>
@@ -503,7 +503,7 @@ namespace MomentoSdk
         }
 
         /// <summary>
-        /// Gets a multiple values from the cache.
+        /// Gets multiple values from the cache.
         /// </summary>
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>
@@ -521,7 +521,7 @@ namespace MomentoSdk
         }
 
         /// <summary>
-        /// Gets a multiple values from the cache.
+        /// Gets multiple values from the cache.
         /// </summary>
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>

--- a/Momento/SimpleCacheClient.cs
+++ b/Momento/SimpleCacheClient.cs
@@ -238,9 +238,13 @@ namespace MomentoSdk
             {
                 throw new ArgumentNullException(nameof(cacheName));
             }
-            if (keys == null || keys.Any(key => key == null))
+            if (keys == null)
             {
                 throw new ArgumentNullException(nameof(keys));
+            }
+            if (keys.Any(key => key == null))
+            {
+                throw new ArgumentNullException(nameof(keys), "Each key must be non-null");
             }
 
             return await this.dataClient.MultiGetAsync(cacheName, keys);
@@ -258,10 +262,15 @@ namespace MomentoSdk
             {
                 throw new ArgumentNullException(nameof(cacheName));
             }
-            if (keys == null || keys.Any(key => key == null))
+            if (keys == null)
             {
                 throw new ArgumentNullException(nameof(keys));
             }
+            if (keys.Any(key => key == null))
+            {
+                throw new ArgumentNullException(nameof(keys), "Each key must be non-null");
+            }
+
 
             return await this.dataClient.MultiGetAsync(cacheName, keys);
         }
@@ -278,9 +287,13 @@ namespace MomentoSdk
             {
                 throw new ArgumentNullException(nameof(cacheName));
             }
-            if (keys == null || keys.Any(key => key == null))
+            if (keys == null)
             {
                 throw new ArgumentNullException(nameof(keys));
+            }
+            if (keys.Any(key => key == null))
+            {
+                throw new ArgumentNullException(nameof(keys), "Each key must be non-null");
             }
 
             return await this.dataClient.MultiGetAsync(cacheName, keys);
@@ -302,6 +315,10 @@ namespace MomentoSdk
             {
                 throw new ArgumentNullException(nameof(keys));
             }
+            if (keys.Any(key => key == null))
+            {
+                throw new ArgumentNullException(nameof(keys), "Each key must be non-null");
+            }
 
             return await this.dataClient.MultiGetAsync(cacheName, keys);
         }
@@ -318,9 +335,13 @@ namespace MomentoSdk
             {
                 throw new ArgumentNullException(nameof(cacheName));
             }
-            if (items == null || items.Values.Any(value => value == null))
+            if (items == null)
             {
                 throw new ArgumentNullException(nameof(items));
+            }
+            if (items.Values.Any(value => value == null))
+            {
+                throw new ArgumentNullException(nameof(items), "Each key and value must be non-null");
             }
 
             await this.dataClient.MultiSetAsync(cacheName, items, ttlSeconds);
@@ -339,9 +360,13 @@ namespace MomentoSdk
             {
                 throw new ArgumentNullException(nameof(cacheName));
             }
-            if (items == null || items.Any(item => item.Value == null))
+            if (items == null)
             {
                 throw new ArgumentNullException(nameof(items));
+            }
+            if (items.Values.Any(value => value == null))
+            {
+                throw new ArgumentNullException(nameof(items), "Each key and value must be non-null");
             }
 
             await this.dataClient.MultiSetAsync(cacheName, items, ttlSeconds);

--- a/Momento/SimpleCacheClient.cs
+++ b/Momento/SimpleCacheClient.cs
@@ -227,7 +227,7 @@ namespace MomentoSdk
         }
 
         /// <summary>
-        /// Executes a list of passed Get operations in parallel.
+        /// Gets a multiple values from the cache.
         /// </summary>
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>
@@ -247,7 +247,7 @@ namespace MomentoSdk
         }
 
         /// <summary>
-        /// Executes a list of passed Get operations in parallel.
+        /// Gets a multiple values from the cache.
         /// </summary>
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>
@@ -267,7 +267,7 @@ namespace MomentoSdk
         }
 
         /// <summary>
-        /// Executes a list of passed Get operations in parallel.
+        /// Gets a multiple values from the cache.
         /// </summary>
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>
@@ -287,7 +287,7 @@ namespace MomentoSdk
         }
 
         /// <summary>
-        /// Executes a list of passed Get operations in parallel.
+        /// Gets a multiple values from the cache.
         /// </summary>
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>
@@ -460,7 +460,7 @@ namespace MomentoSdk
         }
 
         /// <summary>
-        /// Executes a list of passed Get operations in parallel.
+        /// Gets a multiple values from the cache.
         /// </summary>
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>
@@ -478,7 +478,7 @@ namespace MomentoSdk
         }
 
         /// <summary>
-        /// Executes a list of passed Get operations in parallel.
+        /// Gets a multiple values from the cache.
         /// </summary>
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>
@@ -496,7 +496,7 @@ namespace MomentoSdk
         }
 
         /// <summary>
-        /// Executes a list of passed Get operations in parallel.
+        /// Gets a multiple values from the cache.
         /// </summary>
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>
@@ -514,7 +514,7 @@ namespace MomentoSdk
         }
 
         /// <summary>
-        /// Executes a list of passed Get operations in parallel.
+        /// Gets multiple values from the cache.
         /// </summary>
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>

--- a/Momento/SimpleCacheClient.cs
+++ b/Momento/SimpleCacheClient.cs
@@ -345,7 +345,7 @@ namespace MomentoSdk
             }
 
             await this.dataClient.MultiSetAsync(cacheName, items, ttlSeconds);
-            return new CacheMultiSetResponse((IDictionary<object, object>)items);
+            return new CacheMultiSetResponse(items);
         }
 
         /// <summary>
@@ -370,7 +370,7 @@ namespace MomentoSdk
             }
 
             await this.dataClient.MultiSetAsync(cacheName, items, ttlSeconds);
-            return new CacheMultiSetResponse((IDictionary<object, object>)items);
+            return new CacheMultiSetResponse(items);
         }
 
         /// <summary>

--- a/Momento/SimpleCacheClient.cs
+++ b/Momento/SimpleCacheClient.cs
@@ -341,7 +341,7 @@ namespace MomentoSdk
             }
             if (items.Values.Any(value => value == null))
             {
-                throw new ArgumentNullException(nameof(items), "Each key and value must be non-null");
+                throw new ArgumentNullException(nameof(items), "Each value must be non-null");
             }
 
             await this.dataClient.MultiSetAsync(cacheName, items, ttlSeconds);
@@ -366,7 +366,7 @@ namespace MomentoSdk
             }
             if (items.Values.Any(value => value == null))
             {
-                throw new ArgumentNullException(nameof(items), "Each key and value must be non-null");
+                throw new ArgumentNullException(nameof(items), "Each value must be non-null");
             }
 
             await this.dataClient.MultiSetAsync(cacheName, items, ttlSeconds);

--- a/MomentoIntegrationTest/SimpleCacheDataTest.cs
+++ b/MomentoIntegrationTest/SimpleCacheDataTest.cs
@@ -224,6 +224,60 @@ namespace MomentoIntegrationTest
             Assert.ThrowsAsync<MomentoSdk.Exceptions.TimeoutException>(() => simpleCacheClient.MultiGetAsync(cacheName, keys));
         }
 
+        [Fact]
+        public async void MultiSetAsync_NullCheckBytes_ThrowsException()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.MultiSetAsync(null, new Dictionary<byte[], byte[]>()));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.MultiSetAsync("cache", (Dictionary<byte[], byte[]>)null));
+
+            var badDictionary = new Dictionary<byte[], byte[]>() { { Utf8ToBytes("asdf"), null } };
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.MultiSetAsync("cache", badDictionary));
+        }
+
+        [Fact]
+        public async void MultiSetAsync_ItemsAreBytes_HappyPath()
+        {
+            var dictionary = new Dictionary<byte[], byte[]>() {
+                { Utf8ToBytes("key1"), Utf8ToBytes("value1") },
+                { Utf8ToBytes("key2"), Utf8ToBytes("value2") }
+            };
+            CacheMultiSetResponse response = await client.MultiSetAsync(cacheName, dictionary);
+            Assert.Equal(dictionary, response.Bytes());
+
+            var getResponse = await client.GetAsync(cacheName, Utf8ToBytes("key1"));
+            Assert.Equal("value1", getResponse.String());
+
+            getResponse = await client.GetAsync(cacheName, Utf8ToBytes("key2"));
+            Assert.Equal("value2", getResponse.String());
+        }
+
+        [Fact]
+        public async void MultiSetAsync_NullCheckStrings_ThrowsException()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.MultiSetAsync(null, new Dictionary<string, string>()));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.MultiSetAsync("cache", (Dictionary<string, string>)null));
+
+            var badDictionary = new Dictionary<string, string>() { { "asdf", null } };
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.MultiSetAsync("cache", badDictionary));
+        }
+
+        [Fact]
+        public async void MultiSetAsync_KeysAreString_HappyPath()
+        {
+            var dictionary = new Dictionary<string, string>() {
+                { "key1", "value1" },
+                { "key2", "value2" }
+            };
+            CacheMultiSetResponse response = await client.MultiSetAsync(cacheName, dictionary);
+            Assert.Equal(dictionary, response.Strings());
+
+            var getResponse = await client.GetAsync(cacheName, "key1");
+            Assert.Equal("value1", getResponse.String());
+
+            getResponse = await client.GetAsync(cacheName, "key2");
+            Assert.Equal("value2", getResponse.String());
+        }
+
         [Theory]
         [InlineData(null, new byte[] { 0x00 }, new byte[] { 0x00 })]
         [InlineData("cache", null, new byte[] { 0x00 })]

--- a/MomentoIntegrationTest/SimpleCacheDataTest.cs
+++ b/MomentoIntegrationTest/SimpleCacheDataTest.cs
@@ -496,6 +496,61 @@ namespace MomentoIntegrationTest
             Assert.Throws<MomentoSdk.Exceptions.TimeoutException>(() => simpleCacheClient.MultiGet(cacheName, keys));
         }
 
+        [Fact]
+        public void MultiSet_NullCheckBytes_ThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>(() => client.MultiSet(null, new Dictionary<byte[], byte[]>()));
+            Assert.Throws<ArgumentNullException>(() => client.MultiSet("cache", (Dictionary<byte[], byte[]>)null));
+
+            var badDictionary = new Dictionary<byte[], byte[]>() { { Utf8ToBytes("asdf"), null } };
+            Assert.Throws<ArgumentNullException>(() => client.MultiSet("cache", badDictionary));
+        }
+
+        [Fact]
+        public void MultiSet_ItemsAreBytes_HappyPath()
+        {
+            var dictionary = new Dictionary<byte[], byte[]>() {
+                    { Utf8ToBytes("key1"), Utf8ToBytes("value1") },
+                    { Utf8ToBytes("key2"), Utf8ToBytes("value2") }
+                };
+            CacheMultiSetResponse response = client.MultiSet(cacheName, dictionary);
+            Assert.Equal(dictionary, response.Bytes());
+
+            var getResponse = client.Get(cacheName, Utf8ToBytes("key1"));
+            Assert.Equal("value1", getResponse.String());
+
+            getResponse = client.Get(cacheName, Utf8ToBytes("key2"));
+            Assert.Equal("value2", getResponse.String());
+        }
+
+
+        [Fact]
+        public void MultiSet_NullCheckString_ThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>(() => client.MultiSet(null, new Dictionary<string, string>()));
+            Assert.Throws<ArgumentNullException>(() => client.MultiSet("cache", (Dictionary<string, string>)null));
+
+            var badDictionary = new Dictionary<string, string>() { { "asdf", null } };
+            Assert.Throws<ArgumentNullException>(() => client.MultiSet("cache", badDictionary));
+        }
+
+        [Fact]
+        public void MultiSet_KeysAreString_HappyPath()
+        {
+            var dictionary = new Dictionary<string, string>() {
+                    { "key1", "value1" },
+                    { "key2", "value2" }
+                };
+            CacheMultiSetResponse response = client.MultiSet(cacheName, dictionary);
+            Assert.Equal(dictionary, response.Strings());
+
+            var getResponse = client.Get(cacheName, "key1");
+            Assert.Equal("value1", getResponse.String());
+
+            getResponse = client.Get(cacheName, "key2");
+            Assert.Equal("value2", getResponse.String());
+        }
+
         [Theory]
         [InlineData(null, new byte[] { 0x00 })]
         [InlineData("cache", null)]


### PR DESCRIPTION
Closes #70 

This PR introduces a client-side implementation of multi-set. The user specifies multiple values to set by passing an object that implements the `IDictionary` interface. As usual the user also passes in a TTL:

```csharp
var items = new Dictionary<string, string>() { "key1": "value1", "key2": "value2" };
client.MultiSet(cacheName: "my-cache", items: items, ttlSeconds: 300);
```

Ultimately there are a variety of ways to specify items to set. For example a user may feel more comfortable passing in `IEnumerable<KeyValuePair<string, string>>` as opposed to `IDictionary<string, string>`. We can implement these on demand per feedback.