### PR TITLE
chore: Rename MultiGet and MultiSet to GetMulti and SetMulti.

### DIFF
--- a/Momento/Incubating/README.md
+++ b/Momento/Incubating/README.md
@@ -24,7 +24,7 @@ class Driver
             key: "my-key", value: "my-value", ttlSeconds: 60, refreshTtl: false);
 
         // Set multiple values
-        scc.DictionaryMultiSet(
+        scc.DictionarySetMulti(
             cacheName: "my-cache",
             dictionaryName: "my-dictionary",
             new Dictionary<string, string>() {
@@ -42,7 +42,7 @@ class Driver
         string value = gr.String(); // "value1"
 
         // Get multiple values
-        CacheDictionaryMultiGetResponse mgr = scc.DictionaryMultiGet(
+        CacheDictionaryGetMultiResponse mgr = scc.DictionaryGetMulti(
             cacheName: "my-cache",
             dictionaryName: "my-dictionary",
             "key1", "key2", "key3", "key4");

--- a/Momento/Incubating/Responses/CacheDictionaryGetMultiResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictionaryGetMultiResponse.cs
@@ -8,9 +8,9 @@ using MomentoSdk.Responses;
 
 namespace MomentoSdk.Incubating.Responses
 {
-    public class CacheDictionaryMultiGetResponse
+    public class CacheDictionaryGetMultiResponse
     {
-        public CacheDictionaryMultiGetResponse()
+        public CacheDictionaryGetMultiResponse()
         {
         }
 

--- a/Momento/Incubating/Responses/CacheDictionarySetMultiResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictionarySetMultiResponse.cs
@@ -5,9 +5,9 @@ using System.Text;
 
 namespace MomentoSdk.Incubating.Responses
 {
-    public class CacheDictionaryMultiSetResponse
+    public class CacheDictionarySetMultiResponse
     {
-        public CacheDictionaryMultiSetResponse()
+        public CacheDictionarySetMultiResponse()
         {
         }
 

--- a/Momento/Incubating/SimpleCacheClient.cs
+++ b/Momento/Incubating/SimpleCacheClient.cs
@@ -51,44 +51,44 @@ namespace MomentoSdk.Incubating
             return await Task.FromException<CacheDictionaryGetResponse>(new NotImplementedException());
         }
 
-        public CacheDictionaryMultiSetResponse DictionaryMultiSet(string cacheName, string dictionaryName, IDictionary<byte[], byte[]> dictionary, bool refreshTtl, uint? ttlSeconds = null)
+        public CacheDictionarySetMultiResponse DictionarySetMulti(string cacheName, string dictionaryName, IDictionary<byte[], byte[]> dictionary, bool refreshTtl, uint? ttlSeconds = null)
         {
             throw new NotImplementedException();
         }
 
-        public CacheDictionaryMultiSetResponse DictionaryMultiSet(string cacheName, string dictionaryName, IDictionary<string, string> dictionary, bool refreshTtl, uint? ttlSeconds = null)
+        public CacheDictionarySetMultiResponse DictionarySetMulti(string cacheName, string dictionaryName, IDictionary<string, string> dictionary, bool refreshTtl, uint? ttlSeconds = null)
         {
             throw new NotImplementedException();
         }
 
-        public async Task<CacheDictionaryMultiSetResponse> DictionaryMultiSetAsync(string cacheName, string dictionaryName, IDictionary<string, string> dictionary, bool refreshTtl, uint? ttlSeconds = null)
+        public async Task<CacheDictionarySetMultiResponse> DictionarySetMultiAsync(string cacheName, string dictionaryName, IDictionary<string, string> dictionary, bool refreshTtl, uint? ttlSeconds = null)
         {
-            return await Task.FromException<CacheDictionaryMultiSetResponse>(new NotImplementedException());
+            return await Task.FromException<CacheDictionarySetMultiResponse>(new NotImplementedException());
         }
 
-        public async Task<CacheDictionaryMultiSetResponse> DictionaryMultiSetAsync(string cacheName, string dictionaryName, IDictionary<byte[], byte[]> dictionary, bool refreshTtl, uint? ttlSeconds = null)
+        public async Task<CacheDictionarySetMultiResponse> DictionarySetMultiAsync(string cacheName, string dictionaryName, IDictionary<byte[], byte[]> dictionary, bool refreshTtl, uint? ttlSeconds = null)
         {
-            return await Task.FromException<CacheDictionaryMultiSetResponse>(new NotImplementedException());
+            return await Task.FromException<CacheDictionarySetMultiResponse>(new NotImplementedException());
         }
 
-        public CacheDictionaryMultiGetResponse DictionaryMultiGet(string cacheName, string dictionaryName, params byte[][] keys)
+        public CacheDictionaryGetMultiResponse DictionaryGetMulti(string cacheName, string dictionaryName, params byte[][] keys)
         {
             throw new NotImplementedException();
         }
 
-        public CacheDictionaryMultiGetResponse DictionaryMultiGet(string cacheName, string dictionaryName, params string[] keys)
+        public CacheDictionaryGetMultiResponse DictionaryGetMulti(string cacheName, string dictionaryName, params string[] keys)
         {
             throw new NotImplementedException();
         }
 
-        public async Task<CacheDictionaryMultiGetResponse> DictionaryMultiGetAsync(string cacheName, string dictionaryName, params byte[][] keys)
+        public async Task<CacheDictionaryGetMultiResponse> DictionaryGetMultiAsync(string cacheName, string dictionaryName, params byte[][] keys)
         {
-            return await Task.FromException<CacheDictionaryMultiGetResponse>(new NotImplementedException());
+            return await Task.FromException<CacheDictionaryGetMultiResponse>(new NotImplementedException());
         }
 
-        public async Task<CacheDictionaryMultiGetResponse> DictionaryMultiGetAsync(string cacheName, string dictionaryName, params string[] keys)
+        public async Task<CacheDictionaryGetMultiResponse> DictionaryGetMultiAsync(string cacheName, string dictionaryName, params string[] keys)
         {
-            return await Task.FromException<CacheDictionaryMultiGetResponse>(new NotImplementedException());
+            return await Task.FromException<CacheDictionaryGetMultiResponse>(new NotImplementedException());
         }
 
         public CacheDictionaryGetAllResponse DictionaryGetAll(string cacheName, string dictionaryName)

--- a/Momento/Responses/CacheGetMultiResponse.cs
+++ b/Momento/Responses/CacheGetMultiResponse.cs
@@ -4,11 +4,11 @@ using System.Linq;
 
 namespace MomentoSdk.Responses
 {
-    public class CacheMultiGetResponse
+    public class CacheGetMultiResponse
     {
         private readonly List<CacheGetResponse> responses;
 
-        public CacheMultiGetResponse(IEnumerable<CacheGetResponse> responses)
+        public CacheGetMultiResponse(IEnumerable<CacheGetResponse> responses)
         {
             this.responses = new(responses);
         }

--- a/Momento/Responses/CacheSetMultiResponse.cs
+++ b/Momento/Responses/CacheSetMultiResponse.cs
@@ -2,16 +2,16 @@ using System.Collections.Generic;
 
 namespace MomentoSdk.Responses
 {
-    public class CacheMultiSetResponse
+    public class CacheSetMultiResponse
     {
         private readonly object items;
 
-        public CacheMultiSetResponse(IDictionary<byte[], byte[]> items)
+        public CacheSetMultiResponse(IDictionary<byte[], byte[]> items)
         {
             this.items = (object)items;
         }
 
-        public CacheMultiSetResponse(IDictionary<string, string> items)
+        public CacheSetMultiResponse(IDictionary<string, string> items)
         {
             this.items = (object)items;
         }

--- a/Momento/ScsDataClient.cs
+++ b/Momento/ScsDataClient.cs
@@ -66,17 +66,17 @@ namespace MomentoSdk
             return new CacheSetResponse(response);
         }
 
-        public async Task<CacheMultiGetResponse> MultiGetAsync(string cacheName, IEnumerable<string> keys)
+        public async Task<CacheGetMultiResponse> GetMultiAsync(string cacheName, IEnumerable<string> keys)
         {
-            return await MultiGetAsync(cacheName, keys.Select(key => Convert(key)));
+            return await GetMultiAsync(cacheName, keys.Select(key => Convert(key)));
         }
 
-        public async Task<CacheMultiGetResponse> MultiGetAsync(string cacheName, IEnumerable<byte[]> keys)
+        public async Task<CacheGetMultiResponse> GetMultiAsync(string cacheName, IEnumerable<byte[]> keys)
         {
-            return await MultiGetAsync(cacheName, keys.Select(key => Convert(key)));
+            return await GetMultiAsync(cacheName, keys.Select(key => Convert(key)));
         }
 
-        public async Task<CacheMultiGetResponse> MultiGetAsync(string cacheName, IEnumerable<ByteString> keys)
+        public async Task<CacheGetMultiResponse> GetMultiAsync(string cacheName, IEnumerable<ByteString> keys)
         {
             // Gather the tasks
             var tasks = keys.Select(key => SendGetAsync(cacheName, key));
@@ -104,24 +104,24 @@ namespace MomentoSdk
 
             // Package results
             var results = continuation.Result.Select(response => new CacheGetResponse(response));
-            return new CacheMultiGetResponse(results);
+            return new CacheGetMultiResponse(results);
         }
 
-        public async Task MultiSetAsync(string cacheName, IDictionary<string, string> items, uint? ttlSeconds = null)
+        public async Task SetMultiAsync(string cacheName, IDictionary<string, string> items, uint? ttlSeconds = null)
         {
-            await MultiSetAsync(cacheName: cacheName,
+            await SetMultiAsync(cacheName: cacheName,
                 items: items.ToDictionary(item => Convert(item.Key), item => Convert(item.Value)),
                 ttlSeconds: ttlSeconds);
         }
 
-        public async Task MultiSetAsync(string cacheName, IDictionary<byte[], byte[]> items, uint? ttlSeconds = null)
+        public async Task SetMultiAsync(string cacheName, IDictionary<byte[], byte[]> items, uint? ttlSeconds = null)
         {
-            await MultiSetAsync(cacheName: cacheName,
+            await SetMultiAsync(cacheName: cacheName,
                 items: items.ToDictionary(item => Convert(item.Key), item => Convert(item.Value)),
                 ttlSeconds: ttlSeconds);
         }
 
-        public async Task MultiSetAsync(string cacheName, IDictionary<ByteString, ByteString> items, uint? ttlSeconds = null)
+        public async Task SetMultiAsync(string cacheName, IDictionary<ByteString, ByteString> items, uint? ttlSeconds = null)
         {
             // Gather the tasks
             var tasks = items.Select(item => SendSetAsync(cacheName, item.Key, item.Value, ttlSeconds));

--- a/Momento/SimpleCacheClient.cs
+++ b/Momento/SimpleCacheClient.cs
@@ -231,8 +231,8 @@ namespace MomentoSdk
         /// </summary>
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>
-        /// <returns>Future with CacheMultiGetResponse containing the status of the get operation and the associated value data.</returns>
-        public async Task<CacheMultiGetResponse> MultiGetAsync(string cacheName, IEnumerable<byte[]> keys)
+        /// <returns>Future with CacheGetMultiResponse containing the status of the get operation and the associated value data.</returns>
+        public async Task<CacheGetMultiResponse> GetMultiAsync(string cacheName, IEnumerable<byte[]> keys)
         {
             if (cacheName == null)
             {
@@ -247,7 +247,7 @@ namespace MomentoSdk
                 throw new ArgumentNullException(nameof(keys), "Each key must be non-null");
             }
 
-            return await this.dataClient.MultiGetAsync(cacheName, keys);
+            return await this.dataClient.GetMultiAsync(cacheName, keys);
         }
 
         /// <summary>
@@ -255,8 +255,8 @@ namespace MomentoSdk
         /// </summary>
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>
-        /// <returns>Future with CacheMultiGetResponse containing the status of the get operation and the associated value data.</returns>
-        public async Task<CacheMultiGetResponse> MultiGetAsync(string cacheName, IEnumerable<string> keys)
+        /// <returns>Future with CacheGetMultiResponse containing the status of the get operation and the associated value data.</returns>
+        public async Task<CacheGetMultiResponse> GetMultiAsync(string cacheName, IEnumerable<string> keys)
         {
             if (cacheName == null)
             {
@@ -272,7 +272,7 @@ namespace MomentoSdk
             }
 
 
-            return await this.dataClient.MultiGetAsync(cacheName, keys);
+            return await this.dataClient.GetMultiAsync(cacheName, keys);
         }
 
         /// <summary>
@@ -280,8 +280,8 @@ namespace MomentoSdk
         /// </summary>
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>
-        /// <returns>Future with CacheMultiGetResponse containing the status of the get operation and the associated value data.</returns>
-        public async Task<CacheMultiGetResponse> MultiGetAsync(string cacheName, params byte[][] keys)
+        /// <returns>Future with CacheGetMultiResponse containing the status of the get operation and the associated value data.</returns>
+        public async Task<CacheGetMultiResponse> GetMultiAsync(string cacheName, params byte[][] keys)
         {
             if (cacheName == null)
             {
@@ -296,7 +296,7 @@ namespace MomentoSdk
                 throw new ArgumentNullException(nameof(keys), "Each key must be non-null");
             }
 
-            return await this.dataClient.MultiGetAsync(cacheName, keys);
+            return await this.dataClient.GetMultiAsync(cacheName, keys);
         }
 
         /// <summary>
@@ -304,8 +304,8 @@ namespace MomentoSdk
         /// </summary>
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>
-        /// <returns>Future with CacheMultiGetResponse containing the status of the get operation and the associated value data.</returns>
-        public async Task<CacheMultiGetResponse> MultiGetAsync(string cacheName, params string[] keys)
+        /// <returns>Future with CacheGetMultiResponse containing the status of the get operation and the associated value data.</returns>
+        public async Task<CacheGetMultiResponse> GetMultiAsync(string cacheName, params string[] keys)
         {
             if (cacheName == null)
             {
@@ -320,7 +320,7 @@ namespace MomentoSdk
                 throw new ArgumentNullException(nameof(keys), "Each key must be non-null");
             }
 
-            return await this.dataClient.MultiGetAsync(cacheName, keys);
+            return await this.dataClient.GetMultiAsync(cacheName, keys);
         }
 
         /// <summary>
@@ -328,8 +328,8 @@ namespace MomentoSdk
         /// </summary>
         /// <param name="cacheName">Name of the cache to store the items in.</param>
         /// <param name="items">The items to set.</param>
-        /// <returns>Future with CacheMultiSetResponse containing the data set.</returns>
-        public async Task<CacheMultiSetResponse> MultiSetAsync(string cacheName, IDictionary<byte[], byte[]> items, uint? ttlSeconds = null)
+        /// <returns>Future with CacheSetMultiResponse containing the data set.</returns>
+        public async Task<CacheSetMultiResponse> SetMultiAsync(string cacheName, IDictionary<byte[], byte[]> items, uint? ttlSeconds = null)
         {
             if (cacheName == null)
             {
@@ -344,8 +344,8 @@ namespace MomentoSdk
                 throw new ArgumentNullException(nameof(items), "Each value must be non-null");
             }
 
-            await this.dataClient.MultiSetAsync(cacheName, items, ttlSeconds);
-            return new CacheMultiSetResponse(items);
+            await this.dataClient.SetMultiAsync(cacheName, items, ttlSeconds);
+            return new CacheSetMultiResponse(items);
         }
 
         /// <summary>
@@ -353,8 +353,8 @@ namespace MomentoSdk
         /// </summary>
         /// <param name="cacheName">Name of the cache to store the items in.</param>
         /// <param name="items">The items to set.</param>
-        /// <returns>Future with CacheMultiSetResponse containing the data set.</returns>
-        public async Task<CacheMultiSetResponse> MultiSetAsync(string cacheName, IDictionary<string, string> items, uint? ttlSeconds = null)
+        /// <returns>Future with CacheSetMultiResponse containing the data set.</returns>
+        public async Task<CacheSetMultiResponse> SetMultiAsync(string cacheName, IDictionary<string, string> items, uint? ttlSeconds = null)
         {
             if (cacheName == null)
             {
@@ -369,8 +369,8 @@ namespace MomentoSdk
                 throw new ArgumentNullException(nameof(items), "Each value must be non-null");
             }
 
-            await this.dataClient.MultiSetAsync(cacheName, items, ttlSeconds);
-            return new CacheMultiSetResponse(items);
+            await this.dataClient.SetMultiAsync(cacheName, items, ttlSeconds);
+            return new CacheSetMultiResponse(items);
         }
 
         /// <summary>
@@ -490,11 +490,11 @@ namespace MomentoSdk
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>
         /// <returns>Response object with the status of the get operation and the associated value data.</returns>
-        public CacheMultiGetResponse MultiGet(string cacheName, IEnumerable<byte[]> keys)
+        public CacheGetMultiResponse GetMulti(string cacheName, IEnumerable<byte[]> keys)
         {
             try
             {
-                return MultiGetAsync(cacheName, keys).Result;
+                return GetMultiAsync(cacheName, keys).Result;
             }
             catch (AggregateException e)
             {
@@ -508,11 +508,11 @@ namespace MomentoSdk
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>
         /// <returns>Response object with the status of the get operation and the associated value data.</returns>
-        public CacheMultiGetResponse MultiGet(string cacheName, IEnumerable<string> keys)
+        public CacheGetMultiResponse GetMulti(string cacheName, IEnumerable<string> keys)
         {
             try
             {
-                return MultiGetAsync(cacheName, keys).Result;
+                return GetMultiAsync(cacheName, keys).Result;
             }
             catch (AggregateException e)
             {
@@ -525,12 +525,12 @@ namespace MomentoSdk
         /// </summary>
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>
-        /// <returns>Future with CacheMultiGetResponse containing the status of the get operation and the associated value data.</returns>
-        public CacheMultiGetResponse MultiGet(string cacheName, params byte[][] keys)
+        /// <returns>Future with CacheGetMultiResponse containing the status of the get operation and the associated value data.</returns>
+        public CacheGetMultiResponse GetMulti(string cacheName, params byte[][] keys)
         {
             try
             {
-                return MultiGetAsync(cacheName, keys).Result;
+                return GetMultiAsync(cacheName, keys).Result;
             }
             catch (AggregateException e)
             {
@@ -543,12 +543,12 @@ namespace MomentoSdk
         /// </summary>
         /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
         /// <param name="keys">The keys to get.</param>
-        /// <returns>Future with CacheMultiGetResponse containing the status of the get operation and the associated value data.</returns>
-        public CacheMultiGetResponse MultiGet(string cacheName, params string[] keys)
+        /// <returns>Future with CacheGetMultiResponse containing the status of the get operation and the associated value data.</returns>
+        public CacheGetMultiResponse GetMulti(string cacheName, params string[] keys)
         {
             try
             {
-                return MultiGetAsync(cacheName, keys).Result;
+                return GetMultiAsync(cacheName, keys).Result;
             }
             catch (AggregateException e)
             {
@@ -561,12 +561,12 @@ namespace MomentoSdk
         /// </summary>
         /// <param name="cacheName">Name of the cache to store the items in.</param>
         /// <param name="items">The items to set.</param>
-        /// <returns>Future with CacheMultiSetResponse containing the data set.</returns>
-        public CacheMultiSetResponse MultiSet(string cacheName, IDictionary<byte[], byte[]> items, uint? ttlSeconds = null)
+        /// <returns>Future with CacheSetMultiResponse containing the data set.</returns>
+        public CacheSetMultiResponse SetMulti(string cacheName, IDictionary<byte[], byte[]> items, uint? ttlSeconds = null)
         {
             try
             {
-                return MultiSetAsync(cacheName, items, ttlSeconds).Result;
+                return SetMultiAsync(cacheName, items, ttlSeconds).Result;
             }
             catch (AggregateException e)
             {
@@ -579,12 +579,12 @@ namespace MomentoSdk
         /// </summary>
         /// <param name="cacheName">Name of the cache to store the items in.</param>
         /// <param name="items">The items to set.</param>
-        /// <returns>Future with CacheMultiSetResponse containing the data set.</returns>
-        public CacheMultiSetResponse MultiSet(string cacheName, IDictionary<string, string> items, uint? ttlSeconds = null)
+        /// <returns>Future with CacheSetMultiResponse containing the data set.</returns>
+        public CacheSetMultiResponse SetMulti(string cacheName, IDictionary<string, string> items, uint? ttlSeconds = null)
         {
             try
             {
-                return MultiSetAsync(cacheName, items, ttlSeconds).Result;
+                return SetMultiAsync(cacheName, items, ttlSeconds).Result;
             }
             catch (AggregateException e)
             {

--- a/MomentoIntegrationTest/SimpleCacheDataTest.cs
+++ b/MomentoIntegrationTest/SimpleCacheDataTest.cs
@@ -139,19 +139,19 @@ namespace MomentoIntegrationTest
         }
 
         [Fact]
-        public async void MultiGetAsync_NullCheckBytes_ThrowsException()
+        public async void GetMultiAsync_NullCheckBytes_ThrowsException()
         {
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.MultiGetAsync(null, new List<byte[]>()));
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.MultiGetAsync("cache", (List<byte[]>)null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync(null, new List<byte[]>()));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", (List<byte[]>)null));
 
             var badList = new List<byte[]>(new byte[][] { Utf8ToBytes("asdf"), null });
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.MultiGetAsync("cache", badList));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", badList));
 
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.MultiGetAsync("cache", Utf8ToBytes("key1"), null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", Utf8ToBytes("key1"), null));
         }
 
         [Fact]
-        public async void MultiGetAsync_KeysAreBytes_HappyPath()
+        public async void GetMultiAsync_KeysAreBytes_HappyPath()
         {
             string cacheKey1 = "key1";
             string cacheValue1 = "value1";
@@ -162,7 +162,7 @@ namespace MomentoIntegrationTest
 
             List<byte[]> keys = new() { Utf8ToBytes(cacheKey1), Utf8ToBytes(cacheKey2) };
 
-            CacheMultiGetResponse result = await client.MultiGetAsync(cacheName, keys);
+            CacheGetMultiResponse result = await client.GetMultiAsync(cacheName, keys);
             string stringResult1 = result.Strings()[0];
             string stringResult2 = result.Strings()[1];
             Assert.Equal(cacheValue1, stringResult1);
@@ -170,7 +170,7 @@ namespace MomentoIntegrationTest
         }
 
         [Fact]
-        public async void MultiGetAsync_KeysAreBytes_HappyPath2()
+        public async void GetMultiAsync_KeysAreBytes_HappyPath2()
         {
             string cacheKey1 = "key1";
             string cacheValue1 = "value1";
@@ -179,7 +179,7 @@ namespace MomentoIntegrationTest
             client.Set(cacheName, cacheKey1, cacheValue1);
             client.Set(cacheName, cacheKey2, cacheValue2);
 
-            CacheMultiGetResponse result = await client.MultiGetAsync(cacheName, cacheKey1, cacheKey2);
+            CacheGetMultiResponse result = await client.GetMultiAsync(cacheName, cacheKey1, cacheKey2);
             string stringResult1 = result.Strings()[0];
             string stringResult2 = result.Strings()[1];
             Assert.Equal(cacheValue1, stringResult1);
@@ -187,19 +187,19 @@ namespace MomentoIntegrationTest
         }
 
         [Fact]
-        public async void MultiGetAsync_NullCheckString_ThrowsException()
+        public async void GetMultiAsync_NullCheckString_ThrowsException()
         {
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.MultiGetAsync(null, new List<string>()));
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.MultiGetAsync("cache", (List<string>)null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync(null, new List<string>()));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", (List<string>)null));
 
             List<string> strings = new(new string[] { "key1", "key2", null });
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.MultiGetAsync("cache", strings));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", strings));
 
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.MultiGetAsync("cache", "key1", "key2", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", "key1", "key2", null));
         }
 
         [Fact]
-        public async void MultiGetAsync_KeysAreString_HappyPath()
+        public async void GetMultiAsync_KeysAreString_HappyPath()
         {
             string cacheKey1 = "key1";
             string cacheValue1 = "value1";
@@ -209,39 +209,39 @@ namespace MomentoIntegrationTest
             client.Set(cacheName, cacheKey2, cacheValue2);
 
             List<string> keys = new() { cacheKey1, cacheKey2, "key123123" };
-            CacheMultiGetResponse result = await client.MultiGetAsync(cacheName, keys);
+            CacheGetMultiResponse result = await client.GetMultiAsync(cacheName, keys);
 
             Assert.Equal(result.Strings(), new string[] { cacheValue1, cacheValue2, null });
             Assert.Equal(result.Status(), new CacheGetStatus[] { CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS });
         }
 
         [Fact]
-        public void MultiGetAsync_Failure()
+        public void GetMultiAsync_Failure()
         {
             // Set very small timeout for dataClientOperationTimeoutMilliseconds
             SimpleCacheClient simpleCacheClient = new SimpleCacheClient(authKey, defaultTtlSeconds, 1);
             List<string> keys = new() { "key1", "key2", "key3", "key4" };
-            Assert.ThrowsAsync<MomentoSdk.Exceptions.TimeoutException>(() => simpleCacheClient.MultiGetAsync(cacheName, keys));
+            Assert.ThrowsAsync<MomentoSdk.Exceptions.TimeoutException>(() => simpleCacheClient.GetMultiAsync(cacheName, keys));
         }
 
         [Fact]
-        public async void MultiSetAsync_NullCheckBytes_ThrowsException()
+        public async void SetMultiAsync_NullCheckBytes_ThrowsException()
         {
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.MultiSetAsync(null, new Dictionary<byte[], byte[]>()));
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.MultiSetAsync("cache", (Dictionary<byte[], byte[]>)null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync(null, new Dictionary<byte[], byte[]>()));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync("cache", (Dictionary<byte[], byte[]>)null));
 
             var badDictionary = new Dictionary<byte[], byte[]>() { { Utf8ToBytes("asdf"), null } };
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.MultiSetAsync("cache", badDictionary));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync("cache", badDictionary));
         }
 
         [Fact]
-        public async void MultiSetAsync_ItemsAreBytes_HappyPath()
+        public async void SetMultiAsync_ItemsAreBytes_HappyPath()
         {
             var dictionary = new Dictionary<byte[], byte[]>() {
                 { Utf8ToBytes("key1"), Utf8ToBytes("value1") },
                 { Utf8ToBytes("key2"), Utf8ToBytes("value2") }
             };
-            CacheMultiSetResponse response = await client.MultiSetAsync(cacheName, dictionary);
+            CacheSetMultiResponse response = await client.SetMultiAsync(cacheName, dictionary);
             Assert.Equal(dictionary, response.Bytes());
 
             var getResponse = await client.GetAsync(cacheName, Utf8ToBytes("key1"));
@@ -252,23 +252,23 @@ namespace MomentoIntegrationTest
         }
 
         [Fact]
-        public async void MultiSetAsync_NullCheckStrings_ThrowsException()
+        public async void SetMultiAsync_NullCheckStrings_ThrowsException()
         {
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.MultiSetAsync(null, new Dictionary<string, string>()));
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.MultiSetAsync("cache", (Dictionary<string, string>)null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync(null, new Dictionary<string, string>()));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync("cache", (Dictionary<string, string>)null));
 
             var badDictionary = new Dictionary<string, string>() { { "asdf", null } };
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.MultiSetAsync("cache", badDictionary));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync("cache", badDictionary));
         }
 
         [Fact]
-        public async void MultiSetAsync_KeysAreString_HappyPath()
+        public async void SetMultiAsync_KeysAreString_HappyPath()
         {
             var dictionary = new Dictionary<string, string>() {
                 { "key1", "value1" },
                 { "key2", "value2" }
             };
-            CacheMultiSetResponse response = await client.MultiSetAsync(cacheName, dictionary);
+            CacheSetMultiResponse response = await client.SetMultiAsync(cacheName, dictionary);
             Assert.Equal(dictionary, response.Strings());
 
             var getResponse = await client.GetAsync(cacheName, "key1");
@@ -411,19 +411,19 @@ namespace MomentoIntegrationTest
         }
 
         [Fact]
-        public void MultiGet_NullCheckBytes_ThrowsException()
+        public void GetMulti_NullCheckBytes_ThrowsException()
         {
-            Assert.Throws<ArgumentNullException>(() => client.MultiGet(null, new List<byte[]>()));
-            Assert.Throws<ArgumentNullException>(() => client.MultiGet("cache", (List<byte[]>)null));
+            Assert.Throws<ArgumentNullException>(() => client.GetMulti(null, new List<byte[]>()));
+            Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", (List<byte[]>)null));
 
             var badList = new List<byte[]>(new byte[][] { Utf8ToBytes("asdf"), null });
-            Assert.Throws<ArgumentNullException>(() => client.MultiGet("cache", badList));
+            Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", badList));
 
-            Assert.Throws<ArgumentNullException>(() => client.MultiGet("cache", Utf8ToBytes("key1"), null));
+            Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", Utf8ToBytes("key1"), null));
         }
 
         [Fact]
-        public void MultiGet_KeysAreBytes_HappyPath()
+        public void GetMulti_KeysAreBytes_HappyPath()
         {
             string cacheKey1 = "key1";
             string cacheValue1 = "value1";
@@ -434,7 +434,7 @@ namespace MomentoIntegrationTest
 
             List<byte[]> keys = new() { Utf8ToBytes(cacheKey1), Utf8ToBytes(cacheKey2) };
 
-            CacheMultiGetResponse result = client.MultiGet(cacheName, keys);
+            CacheGetMultiResponse result = client.GetMulti(cacheName, keys);
             string stringResult1 = result.Strings()[0];
             string stringResult2 = result.Strings()[1];
             Assert.Equal(cacheValue1, stringResult1);
@@ -442,7 +442,7 @@ namespace MomentoIntegrationTest
         }
 
         [Fact]
-        public void MultiGet_KeysAreBytes_HappyPath2()
+        public void GetMulti_KeysAreBytes_HappyPath2()
         {
             string cacheKey1 = "key1";
             string cacheValue1 = "value1";
@@ -451,7 +451,7 @@ namespace MomentoIntegrationTest
             client.Set(cacheName, cacheKey1, cacheValue1);
             client.Set(cacheName, cacheKey2, cacheValue2);
 
-            CacheMultiGetResponse result = client.MultiGet(cacheName, cacheKey1, cacheKey2);
+            CacheGetMultiResponse result = client.GetMulti(cacheName, cacheKey1, cacheKey2);
             string stringResult1 = result.Strings()[0];
             string stringResult2 = result.Strings()[1];
             Assert.Equal(cacheValue1, stringResult1);
@@ -459,19 +459,19 @@ namespace MomentoIntegrationTest
         }
 
         [Fact]
-        public void MultiGet_NullCheckString_ThrowsException()
+        public void GetMulti_NullCheckString_ThrowsException()
         {
-            Assert.Throws<ArgumentNullException>(() => client.MultiGet(null, new List<string>()));
-            Assert.Throws<ArgumentNullException>(() => client.MultiGet("cache", (List<string>)null));
+            Assert.Throws<ArgumentNullException>(() => client.GetMulti(null, new List<string>()));
+            Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", (List<string>)null));
 
             List<string> strings = new(new string[] { "key1", "key2", null });
-            Assert.Throws<ArgumentNullException>(() => client.MultiGet("cache", strings));
+            Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", strings));
 
-            Assert.Throws<ArgumentNullException>(() => client.MultiGet("cache", "key1", "key2", null));
+            Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", "key1", "key2", null));
         }
 
         [Fact]
-        public void MultiGet_KeysAreString_HappyPath()
+        public void GetMulti_KeysAreString_HappyPath()
         {
             string cacheKey1 = "key1";
             string cacheValue1 = "value1";
@@ -481,39 +481,39 @@ namespace MomentoIntegrationTest
             client.Set(cacheName, cacheKey2, cacheValue2);
 
             List<string> keys = new() { cacheKey1, cacheKey2, "key123123" };
-            CacheMultiGetResponse result = client.MultiGet(cacheName, keys);
+            CacheGetMultiResponse result = client.GetMulti(cacheName, keys);
 
             Assert.Equal(result.Strings(), new string[] { cacheValue1, cacheValue2, null });
             Assert.Equal(result.Status(), new CacheGetStatus[] { CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS });
         }
 
         [Fact]
-        public void MultiGet_Failure()
+        public void GetMulti_Failure()
         {
             // Set very small timeout for dataClientOperationTimeoutMilliseconds
             SimpleCacheClient simpleCacheClient = new SimpleCacheClient(authKey, defaultTtlSeconds, 1);
             List<string> keys = new() { "key1", "key2", "key3", "key4" };
-            Assert.Throws<MomentoSdk.Exceptions.TimeoutException>(() => simpleCacheClient.MultiGet(cacheName, keys));
+            Assert.Throws<MomentoSdk.Exceptions.TimeoutException>(() => simpleCacheClient.GetMulti(cacheName, keys));
         }
 
         [Fact]
-        public void MultiSet_NullCheckBytes_ThrowsException()
+        public void SetMulti_NullCheckBytes_ThrowsException()
         {
-            Assert.Throws<ArgumentNullException>(() => client.MultiSet(null, new Dictionary<byte[], byte[]>()));
-            Assert.Throws<ArgumentNullException>(() => client.MultiSet("cache", (Dictionary<byte[], byte[]>)null));
+            Assert.Throws<ArgumentNullException>(() => client.SetMulti(null, new Dictionary<byte[], byte[]>()));
+            Assert.Throws<ArgumentNullException>(() => client.SetMulti("cache", (Dictionary<byte[], byte[]>)null));
 
             var badDictionary = new Dictionary<byte[], byte[]>() { { Utf8ToBytes("asdf"), null } };
-            Assert.Throws<ArgumentNullException>(() => client.MultiSet("cache", badDictionary));
+            Assert.Throws<ArgumentNullException>(() => client.SetMulti("cache", badDictionary));
         }
 
         [Fact]
-        public void MultiSet_ItemsAreBytes_HappyPath()
+        public void SetMulti_ItemsAreBytes_HappyPath()
         {
             var dictionary = new Dictionary<byte[], byte[]>() {
                     { Utf8ToBytes("key1"), Utf8ToBytes("value1") },
                     { Utf8ToBytes("key2"), Utf8ToBytes("value2") }
                 };
-            CacheMultiSetResponse response = client.MultiSet(cacheName, dictionary);
+            CacheSetMultiResponse response = client.SetMulti(cacheName, dictionary);
             Assert.Equal(dictionary, response.Bytes());
 
             var getResponse = client.Get(cacheName, Utf8ToBytes("key1"));
@@ -525,23 +525,23 @@ namespace MomentoIntegrationTest
 
 
         [Fact]
-        public void MultiSet_NullCheckString_ThrowsException()
+        public void SetMulti_NullCheckString_ThrowsException()
         {
-            Assert.Throws<ArgumentNullException>(() => client.MultiSet(null, new Dictionary<string, string>()));
-            Assert.Throws<ArgumentNullException>(() => client.MultiSet("cache", (Dictionary<string, string>)null));
+            Assert.Throws<ArgumentNullException>(() => client.SetMulti(null, new Dictionary<string, string>()));
+            Assert.Throws<ArgumentNullException>(() => client.SetMulti("cache", (Dictionary<string, string>)null));
 
             var badDictionary = new Dictionary<string, string>() { { "asdf", null } };
-            Assert.Throws<ArgumentNullException>(() => client.MultiSet("cache", badDictionary));
+            Assert.Throws<ArgumentNullException>(() => client.SetMulti("cache", badDictionary));
         }
 
         [Fact]
-        public void MultiSet_KeysAreString_HappyPath()
+        public void SetMulti_KeysAreString_HappyPath()
         {
             var dictionary = new Dictionary<string, string>() {
                     { "key1", "value1" },
                     { "key2", "value2" }
                 };
-            CacheMultiSetResponse response = client.MultiSet(cacheName, dictionary);
+            CacheSetMultiResponse response = client.SetMulti(cacheName, dictionary);
             Assert.Equal(dictionary, response.Strings());
 
             var getResponse = client.Get(cacheName, "key1");


### PR DESCRIPTION
The previous naming convention preferred modifiers before commands, as
in `MultiGet`, `DictionaryMultiGet`. This ordering makes it
difficult to group commands under the IDE and in documentation. The
new ordering `GetMulti`, `DictionaryGetMulti` eases this.

With this way, now the following will be completions of
`DictionaryGet`:

`DictionaryGet`, `DictionaryGetMulti`, `DictionaryGetAll`