### PR TITLE
chore: enable nullable reference types in projects

### DIFF
--- a/Momento/Incubating/Responses/CacheDictionaryGetAllResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictionaryGetAllResponse.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using MomentoSdk.Responses;

--- a/Momento/Incubating/Responses/CacheDictionaryGetMultiResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictionaryGetMultiResponse.cs
@@ -1,6 +1,4 @@
-﻿#nullable enable
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using MomentoSdk.Responses;

--- a/Momento/Incubating/Responses/CacheDictionaryGetResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictionaryGetResponse.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Text;
 using MomentoSdk.Responses;
 

--- a/Momento/Incubating/Responses/CacheDictionarySetMultiResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictionarySetMultiResponse.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/Momento/Incubating/Responses/CacheDictionarySetResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictionarySetResponse.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System;
+﻿using System;
 using System.Text;
 
 namespace MomentoSdk.Incubating.Responses

--- a/Momento/MomentoSdk.csproj
+++ b/Momento/MomentoSdk.csproj
@@ -3,6 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
 	</PropertyGroup>
 	<ItemGroup>
 		<None Remove="Momento" />

--- a/Momento/Responses/CacheGetMultiResponse.cs
+++ b/Momento/Responses/CacheGetMultiResponse.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace MomentoSdk.Responses

--- a/Momento/Responses/CacheGetResponse.cs
+++ b/Momento/Responses/CacheGetResponse.cs
@@ -1,5 +1,4 @@
-﻿#nullable enable
-using System.Text;
+﻿using System.Text;
 using CacheClient;
 using Google.Protobuf;
 using MomentoSdk.Exceptions;

--- a/Momento/Responses/CacheInfo.cs
+++ b/Momento/Responses/CacheInfo.cs
@@ -16,7 +16,7 @@ namespace MomentoSdk.Responses
         }
 
         // override object.Equals
-        public bool Equals(CacheInfo other)
+        public bool Equals(CacheInfo? other)
         {
             if (other == null)
             {
@@ -26,10 +26,12 @@ namespace MomentoSdk.Responses
             return this.name == other.name;
         }
 
-        public override bool Equals(Object obj)
+        public override bool Equals(Object? obj)
         {
             if (obj == null)
+            {
                 return false;
+            }
 
             return Equals(obj as CacheInfo);
         }

--- a/Momento/Responses/ListCachesResponse.cs
+++ b/Momento/Responses/ListCachesResponse.cs
@@ -4,7 +4,7 @@ namespace MomentoSdk.Responses
     public class ListCachesResponse
     {
         private readonly List<CacheInfo> caches;
-        private readonly string nextPageToken;
+        private readonly string? nextPageToken;
 
         public ListCachesResponse(ControlClient._ListCachesResponse result)
         {
@@ -21,7 +21,7 @@ namespace MomentoSdk.Responses
             return caches;
         }
 
-        public string NextPageToken()
+        public string? NextPageToken()
         {
             return nextPageToken;
         }

--- a/Momento/ScsControlClient.cs
+++ b/Momento/ScsControlClient.cs
@@ -49,7 +49,7 @@ namespace MomentoSdk
             }
         }
 
-        public ListCachesResponse ListCaches(string nextPageToken = null)
+        public ListCachesResponse ListCaches(string? nextPageToken = null)
         {
             _ListCachesRequest request = new _ListCachesRequest() { NextToken = nextPageToken == null ? "" : nextPageToken };
             try

--- a/Momento/SimpleCacheClient.cs
+++ b/Momento/SimpleCacheClient.cs
@@ -63,7 +63,7 @@ namespace MomentoSdk
         /// </summary>
         /// <param name="nextPageToken">A token to specify where to start paginating. This is the NextToken from a previous response.</param>
         /// <returns>The result of the list cache operation.</returns>
-        public ListCachesResponse ListCaches(string nextPageToken = null)
+        public ListCachesResponse ListCaches(string? nextPageToken = null)
         {
             return this.controlClient.ListCaches(nextPageToken);
         }

--- a/MomentoIntegrationTest/MomentoIntegrationTest.csproj
+++ b/MomentoIntegrationTest/MomentoIntegrationTest.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MomentoIntegrationTest/SimpleCacheControlTest.cs
+++ b/MomentoIntegrationTest/SimpleCacheControlTest.cs
@@ -10,7 +10,8 @@ namespace MomentoIntegrationTest
 {
     public class SimpleCacheControlTest
     {
-        private string authKey = Environment.GetEnvironmentVariable("TEST_AUTH_TOKEN");
+        private string authKey = Environment.GetEnvironmentVariable("TEST_AUTH_TOKEN") ??
+            throw new NullReferenceException("TEST_AUTH_TOKEN environment variable must be set.");
 
         [Fact]
         public void SimpleCacheClientConstructor_BadRequestTimeout_ThrowsException()
@@ -27,14 +28,14 @@ namespace MomentoIntegrationTest
         [Fact]
         public void SimpleCacheClientConstructor_NullJWT_InvalidJwtException()
         {
-            Assert.Throws<InvalidArgumentException>(() => new SimpleCacheClient(null, defaultTtlSeconds: 10));
+            Assert.Throws<InvalidArgumentException>(() => new SimpleCacheClient(null!, defaultTtlSeconds: 10));
         }
 
         [Fact]
         public void DeleteCache_NullCache_ArgumentNullException()
         {
             SimpleCacheClient client = new SimpleCacheClient(authKey, defaultTtlSeconds: 10);
-            Assert.Throws<ArgumentNullException>(() => client.DeleteCache(null));
+            Assert.Throws<ArgumentNullException>(() => client.DeleteCache(null!));
         }
 
         [Fact]
@@ -48,7 +49,7 @@ namespace MomentoIntegrationTest
         public void CreateCache_NullCache_ArgumentNullException()
         {
             SimpleCacheClient client = new SimpleCacheClient(authKey, defaultTtlSeconds: 10);
-            Assert.Throws<ArgumentNullException>(() => client.CreateCache(null));
+            Assert.Throws<ArgumentNullException>(() => client.CreateCache(null!));
         }
 
         // Tests: creating a cache, listing a cache, and deleting a cache.

--- a/MomentoIntegrationTest/SimpleCacheDataTest.cs
+++ b/MomentoIntegrationTest/SimpleCacheDataTest.cs
@@ -11,7 +11,8 @@ namespace MomentoIntegrationTest
 {
     public class SimpleCacheDataTest : IDisposable
     {
-        private string authKey = Environment.GetEnvironmentVariable("TEST_AUTH_TOKEN");
+        private string authKey = Environment.GetEnvironmentVariable("TEST_AUTH_TOKEN") ??
+            throw new NullReferenceException("TEST_AUTH_TOKEN environment variable must be set.");
         private string cacheName = "client-sdk-csharp";
         private uint defaultTtlSeconds = 10;
         private SimpleCacheClient client;
@@ -58,7 +59,7 @@ namespace MomentoIntegrationTest
             byte[] key = Utf8ToBytes("key1");
             byte[] value = Utf8ToBytes("value1");
             await client.SetAsync(cacheName, key, value);
-            byte[] setValue = (await client.GetAsync(cacheName, key)).Bytes();
+            byte[]? setValue = (await client.GetAsync(cacheName, key)).Bytes();
             Assert.Equal(value, setValue);
 
             key = Utf8ToBytes("key2");
@@ -93,7 +94,7 @@ namespace MomentoIntegrationTest
             string key = "key3";
             string value = "value3";
             await client.SetAsync(cacheName, key, value);
-            string setValue = (await client.GetAsync(cacheName, key)).String();
+            string? setValue = (await client.GetAsync(cacheName, key)).String();
             Assert.Equal(value, setValue);
 
             key = "key4";
@@ -128,7 +129,7 @@ namespace MomentoIntegrationTest
             string key = "key5";
             byte[] value = Utf8ToBytes("value5");
             await client.SetAsync(cacheName, key, value);
-            byte[] setValue = (await client.GetAsync(cacheName, key)).Bytes();
+            byte[]? setValue = (await client.GetAsync(cacheName, key)).Bytes();
             Assert.Equal(value, setValue);
 
             key = "key6";
@@ -141,13 +142,13 @@ namespace MomentoIntegrationTest
         [Fact]
         public async void GetMultiAsync_NullCheckBytes_ThrowsException()
         {
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync(null, new List<byte[]>()));
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", (List<byte[]>)null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync(null!, new List<byte[]>()));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", (List<byte[]>)null!));
 
-            var badList = new List<byte[]>(new byte[][] { Utf8ToBytes("asdf"), null });
+            var badList = new List<byte[]>(new byte[][] { Utf8ToBytes("asdf"), null! });
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", badList));
 
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", Utf8ToBytes("key1"), null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", Utf8ToBytes("key1"), null!));
         }
 
         [Fact]
@@ -163,8 +164,8 @@ namespace MomentoIntegrationTest
             List<byte[]> keys = new() { Utf8ToBytes(cacheKey1), Utf8ToBytes(cacheKey2) };
 
             CacheGetMultiResponse result = await client.GetMultiAsync(cacheName, keys);
-            string stringResult1 = result.Strings()[0];
-            string stringResult2 = result.Strings()[1];
+            string? stringResult1 = result.Strings()[0];
+            string? stringResult2 = result.Strings()[1];
             Assert.Equal(cacheValue1, stringResult1);
             Assert.Equal(cacheValue2, stringResult2);
         }
@@ -180,8 +181,8 @@ namespace MomentoIntegrationTest
             client.Set(cacheName, cacheKey2, cacheValue2);
 
             CacheGetMultiResponse result = await client.GetMultiAsync(cacheName, cacheKey1, cacheKey2);
-            string stringResult1 = result.Strings()[0];
-            string stringResult2 = result.Strings()[1];
+            string? stringResult1 = result.Strings()[0];
+            string? stringResult2 = result.Strings()[1];
             Assert.Equal(cacheValue1, stringResult1);
             Assert.Equal(cacheValue2, stringResult2);
         }
@@ -189,13 +190,13 @@ namespace MomentoIntegrationTest
         [Fact]
         public async void GetMultiAsync_NullCheckString_ThrowsException()
         {
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync(null, new List<string>()));
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", (List<string>)null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync(null!, new List<string>()));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", (List<string>)null!));
 
-            List<string> strings = new(new string[] { "key1", "key2", null });
+            List<string> strings = new(new string[] { "key1", "key2", null! });
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", strings));
 
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", "key1", "key2", null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", "key1", "key2", null!));
         }
 
         [Fact]
@@ -211,7 +212,7 @@ namespace MomentoIntegrationTest
             List<string> keys = new() { cacheKey1, cacheKey2, "key123123" };
             CacheGetMultiResponse result = await client.GetMultiAsync(cacheName, keys);
 
-            Assert.Equal(result.Strings(), new string[] { cacheValue1, cacheValue2, null });
+            Assert.Equal(result.Strings(), new string[] { cacheValue1, cacheValue2, null! });
             Assert.Equal(result.Status(), new CacheGetStatus[] { CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS });
         }
 
@@ -227,10 +228,10 @@ namespace MomentoIntegrationTest
         [Fact]
         public async void SetMultiAsync_NullCheckBytes_ThrowsException()
         {
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync(null, new Dictionary<byte[], byte[]>()));
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync("cache", (Dictionary<byte[], byte[]>)null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync(null!, new Dictionary<byte[], byte[]>()));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync("cache", (Dictionary<byte[], byte[]>)null!));
 
-            var badDictionary = new Dictionary<byte[], byte[]>() { { Utf8ToBytes("asdf"), null } };
+            var badDictionary = new Dictionary<byte[], byte[]>() { { Utf8ToBytes("asdf"), null! } };
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync("cache", badDictionary));
         }
 
@@ -254,10 +255,10 @@ namespace MomentoIntegrationTest
         [Fact]
         public async void SetMultiAsync_NullCheckStrings_ThrowsException()
         {
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync(null, new Dictionary<string, string>()));
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync("cache", (Dictionary<string, string>)null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync(null!, new Dictionary<string, string>()));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync("cache", (Dictionary<string, string>)null!));
 
-            var badDictionary = new Dictionary<string, string>() { { "asdf", null } };
+            var badDictionary = new Dictionary<string, string>() { { "asdf", null! } };
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync("cache", badDictionary));
         }
 
@@ -295,7 +296,7 @@ namespace MomentoIntegrationTest
             byte[] key = Utf8ToBytes("key10");
             byte[] value = Utf8ToBytes("value10");
             client.Set(cacheName, key, value);
-            byte[] setValue = client.Get(cacheName, key).Bytes();
+            byte[]? setValue = client.Get(cacheName, key).Bytes();
             Assert.Equal(value, setValue);
 
             key = Utf8ToBytes("key11");
@@ -308,8 +309,8 @@ namespace MomentoIntegrationTest
         [Fact]
         public void Get_NullChecksBytes_ThrowsException()
         {
-            Assert.Throws<ArgumentNullException>(() => client.Get("cache", (byte[])null));
-            Assert.Throws<ArgumentNullException>(() => client.Get(null, new byte[] { 0x00 }));
+            Assert.Throws<ArgumentNullException>(() => client.Get("cache", (byte[])null!));
+            Assert.Throws<ArgumentNullException>(() => client.Get(null!, new byte[] { 0x00 }));
         }
 
         [Fact]
@@ -365,7 +366,7 @@ namespace MomentoIntegrationTest
             string key = "key12";
             string value = "value12";
             client.Set(cacheName, key, value);
-            string setValue = client.Get(cacheName, key).String();
+            string? setValue = client.Get(cacheName, key).String();
             Assert.Equal(value, setValue);
 
             key = "key13";
@@ -400,7 +401,7 @@ namespace MomentoIntegrationTest
             string key = "key14";
             byte[] value = Utf8ToBytes("value14");
             client.Set(cacheName, key, value);
-            byte[] setValue = client.Get(cacheName, key).Bytes();
+            byte[]? setValue = client.Get(cacheName, key).Bytes();
             Assert.Equal(value, setValue);
 
             key = "key15";
@@ -413,13 +414,13 @@ namespace MomentoIntegrationTest
         [Fact]
         public void GetMulti_NullCheckBytes_ThrowsException()
         {
-            Assert.Throws<ArgumentNullException>(() => client.GetMulti(null, new List<byte[]>()));
-            Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", (List<byte[]>)null));
+            Assert.Throws<ArgumentNullException>(() => client.GetMulti(null!, new List<byte[]>()));
+            Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", (List<byte[]>)null!));
 
-            var badList = new List<byte[]>(new byte[][] { Utf8ToBytes("asdf"), null });
+            var badList = new List<byte[]>(new byte[][] { Utf8ToBytes("asdf"), null! });
             Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", badList));
 
-            Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", Utf8ToBytes("key1"), null));
+            Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", Utf8ToBytes("key1"), null!));
         }
 
         [Fact]
@@ -435,8 +436,8 @@ namespace MomentoIntegrationTest
             List<byte[]> keys = new() { Utf8ToBytes(cacheKey1), Utf8ToBytes(cacheKey2) };
 
             CacheGetMultiResponse result = client.GetMulti(cacheName, keys);
-            string stringResult1 = result.Strings()[0];
-            string stringResult2 = result.Strings()[1];
+            string? stringResult1 = result.Strings()[0];
+            string? stringResult2 = result.Strings()[1];
             Assert.Equal(cacheValue1, stringResult1);
             Assert.Equal(cacheValue2, stringResult2);
         }
@@ -452,8 +453,8 @@ namespace MomentoIntegrationTest
             client.Set(cacheName, cacheKey2, cacheValue2);
 
             CacheGetMultiResponse result = client.GetMulti(cacheName, cacheKey1, cacheKey2);
-            string stringResult1 = result.Strings()[0];
-            string stringResult2 = result.Strings()[1];
+            string? stringResult1 = result.Strings()[0];
+            string? stringResult2 = result.Strings()[1];
             Assert.Equal(cacheValue1, stringResult1);
             Assert.Equal(cacheValue2, stringResult2);
         }
@@ -461,13 +462,13 @@ namespace MomentoIntegrationTest
         [Fact]
         public void GetMulti_NullCheckString_ThrowsException()
         {
-            Assert.Throws<ArgumentNullException>(() => client.GetMulti(null, new List<string>()));
-            Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", (List<string>)null));
+            Assert.Throws<ArgumentNullException>(() => client.GetMulti(null!, new List<string>()));
+            Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", (List<string>)null!));
 
-            List<string> strings = new(new string[] { "key1", "key2", null });
+            List<string> strings = new(new string[] { "key1", "key2", null! });
             Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", strings));
 
-            Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", "key1", "key2", null));
+            Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", "key1", "key2", null!));
         }
 
         [Fact]
@@ -483,7 +484,7 @@ namespace MomentoIntegrationTest
             List<string> keys = new() { cacheKey1, cacheKey2, "key123123" };
             CacheGetMultiResponse result = client.GetMulti(cacheName, keys);
 
-            Assert.Equal(result.Strings(), new string[] { cacheValue1, cacheValue2, null });
+            Assert.Equal(result.Strings(), new string[] { cacheValue1, cacheValue2, null! });
             Assert.Equal(result.Status(), new CacheGetStatus[] { CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS });
         }
 
@@ -499,10 +500,10 @@ namespace MomentoIntegrationTest
         [Fact]
         public void SetMulti_NullCheckBytes_ThrowsException()
         {
-            Assert.Throws<ArgumentNullException>(() => client.SetMulti(null, new Dictionary<byte[], byte[]>()));
-            Assert.Throws<ArgumentNullException>(() => client.SetMulti("cache", (Dictionary<byte[], byte[]>)null));
+            Assert.Throws<ArgumentNullException>(() => client.SetMulti(null!, new Dictionary<byte[], byte[]>()));
+            Assert.Throws<ArgumentNullException>(() => client.SetMulti("cache", (Dictionary<byte[], byte[]>)null!));
 
-            var badDictionary = new Dictionary<byte[], byte[]>() { { Utf8ToBytes("asdf"), null } };
+            var badDictionary = new Dictionary<byte[], byte[]>() { { Utf8ToBytes("asdf"), null! } };
             Assert.Throws<ArgumentNullException>(() => client.SetMulti("cache", badDictionary));
         }
 
@@ -527,10 +528,10 @@ namespace MomentoIntegrationTest
         [Fact]
         public void SetMulti_NullCheckString_ThrowsException()
         {
-            Assert.Throws<ArgumentNullException>(() => client.SetMulti(null, new Dictionary<string, string>()));
-            Assert.Throws<ArgumentNullException>(() => client.SetMulti("cache", (Dictionary<string, string>)null));
+            Assert.Throws<ArgumentNullException>(() => client.SetMulti(null!, new Dictionary<string, string>()));
+            Assert.Throws<ArgumentNullException>(() => client.SetMulti("cache", (Dictionary<string, string>)null!));
 
-            var badDictionary = new Dictionary<string, string>() { { "asdf", null } };
+            var badDictionary = new Dictionary<string, string>() { { "asdf", null! } };
             Assert.Throws<ArgumentNullException>(() => client.SetMulti("cache", badDictionary));
         }
 

--- a/MomentoTest/MomentoSignerTest.cs
+++ b/MomentoTest/MomentoSignerTest.cs
@@ -24,7 +24,7 @@ namespace MomentoTest
             uint expiryEpochSeconds = uint.MaxValue;
             var url = signer.CreatePresignedUrl("foobar.com", new SigningRequest("testCacheName", "testCacheKey", CacheOperation.GET, expiryEpochSeconds)); ;
 
-            string jwt = HttpUtility.ParseQueryString(new Uri(url).Query).Get("token");
+            string? jwt = HttpUtility.ParseQueryString(new Uri(url).Query).Get("token");
 
             var securityKey = new JsonWebKey(jwk);
             TokenValidationParameters validationParameters = new TokenValidationParameters()
@@ -46,10 +46,10 @@ namespace MomentoTest
             uint expiryEpochSeconds = uint.MaxValue;
             var url = signer.CreatePresignedUrl("foobar.com", new SigningRequest("testCacheName", "testCacheKey", CacheOperation.GET, expiryEpochSeconds));
 
-            Uri uriResult;
+            Uri? uriResult;
             bool result = Uri.TryCreate(url, UriKind.Absolute, out uriResult);
             Assert.True(result);
-            Assert.Equal(Uri.UriSchemeHttps, uriResult.Scheme);
+            Assert.Equal(Uri.UriSchemeHttps, uriResult?.Scheme);
             Assert.StartsWith("https://rest.foobar.com/cache/get/testCacheName/testCacheKey?token=", url);
         }
 
@@ -64,10 +64,10 @@ namespace MomentoTest
             };
             var url = signer.CreatePresignedUrl("foobar.com", req);
 
-            Uri uriResult;
+            Uri? uriResult;
             bool result = Uri.TryCreate(url, UriKind.Absolute, out uriResult);
             Assert.True(result);
-            Assert.Equal(Uri.UriSchemeHttps, uriResult.Scheme);
+            Assert.Equal(Uri.UriSchemeHttps, uriResult?.Scheme);
             Assert.StartsWith("https://rest.foobar.com/cache/set/testCacheName/testCacheKey?ttl_milliseconds=4294967295000&token=", url);
         }
 
@@ -79,10 +79,10 @@ namespace MomentoTest
             var testCacheKey = "#$&\\'+,/:;=?@[]";
             var url = signer.CreatePresignedUrl("foobar.com", new SigningRequest("testCacheName", testCacheKey, CacheOperation.GET, expiryEpochSeconds));
 
-            Uri uriResult;
+            Uri? uriResult;
             bool result = Uri.TryCreate(url, UriKind.Absolute, out uriResult);
             Assert.True(result);
-            Assert.Equal(Uri.UriSchemeHttps, uriResult.Scheme);
+            Assert.Equal(Uri.UriSchemeHttps, uriResult?.Scheme);
             Assert.StartsWith("https://rest.foobar.com/cache/get/testCacheName/%23%24%26%5c%27%2b%2c%2f%3a%3b%3d%3f%40%5b%5d?token=", url);
         }
 

--- a/MomentoTest/MomentoTest.csproj
+++ b/MomentoTest/MomentoTest.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #80 

Enable nullable reference types (NRT) and null static analysis in the
projects. With this setting the compiler issues warnings when
variables/arguments are in the wrong null context. This PR enables the setting,
resolves remaining NRT warnings, and removes previously per-file
nullable-enabled directives.

NRT enabled is best practice in new projects and documented here:

https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/nullable-warnings
https://docs.microsoft.com/en-us/ef/core/miscellaneous/nullable-reference-types
https://docs.microsoft.com/en-us/dotnet/csharp/nullable-migration-strategies