### PR TITLE
chore: use client test fixture to speedup tests

### DIFF
--- a/MomentoIntegrationTest/Fixtures.cs
+++ b/MomentoIntegrationTest/Fixtures.cs
@@ -1,0 +1,46 @@
+namespace MomentoIntegrationTest
+{
+    /// <summary>
+    /// A cache client fixture.
+    /// Use this when not testing client-building edge cases:
+    /// re-using the client drops overall integration test time down ~5X.
+    /// </summary>
+    public class SimpleCacheClientFixture : IDisposable
+    {
+        public SimpleCacheClient Client { get; private set; }
+        public string AuthToken { get; private set; }
+
+        public const string CacheName = "client-sdk-csharp";
+        public const uint DefaultTtlSeconds = 10;
+
+        public SimpleCacheClientFixture()
+        {
+            AuthToken = Environment.GetEnvironmentVariable("TEST_AUTH_TOKEN") ??
+                throw new NullReferenceException("TEST_AUTH_TOKEN environment variable must be set.");
+            Client = new(AuthToken, defaultTtlSeconds: DefaultTtlSeconds);
+
+            try
+            {
+                Client.CreateCache(CacheName);
+            }
+            catch (AlreadyExistsException)
+            {
+            }
+        }
+
+        public void Dispose()
+        {
+            Client.DeleteCache(CacheName);
+            Client.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Register the fixture in xUnit.
+    /// </summary>
+    [CollectionDefinition("SimpleCacheClient")]
+    public class SimpleCacheClientCollection : ICollectionFixture<SimpleCacheClientFixture>
+    {
+
+    }
+}

--- a/MomentoIntegrationTest/SimpleCacheControlTest.cs
+++ b/MomentoIntegrationTest/SimpleCacheControlTest.cs
@@ -1,22 +1,24 @@
-﻿using System;
-using System.Linq;
-using Xunit;
-using MomentoSdk;
-using MomentoSdk.Exceptions;
-using MomentoSdk.Responses;
+﻿using System.Linq;
 using System.Collections.Generic;
 
 namespace MomentoIntegrationTest
 {
+    [Collection("SimpleCacheClient")]
     public class SimpleCacheControlTest
     {
-        private string authKey = Environment.GetEnvironmentVariable("TEST_AUTH_TOKEN") ??
-            throw new NullReferenceException("TEST_AUTH_TOKEN environment variable must be set.");
+        private SimpleCacheClient client;
+        private string authToken;
+
+        public SimpleCacheControlTest(SimpleCacheClientFixture fixture)
+        {
+            client = fixture.Client;
+            authToken = fixture.AuthToken;
+        }
 
         [Fact]
         public void SimpleCacheClientConstructor_BadRequestTimeout_ThrowsException()
         {
-            Assert.Throws<InvalidArgumentException>(() => new SimpleCacheClient(authKey, defaultTtlSeconds: 10, dataClientOperationTimeoutMilliseconds: 0));
+            Assert.Throws<InvalidArgumentException>(() => new SimpleCacheClient(authToken, defaultTtlSeconds: 10, dataClientOperationTimeoutMilliseconds: 0));
         }
 
         [Fact]
@@ -34,21 +36,18 @@ namespace MomentoIntegrationTest
         [Fact]
         public void DeleteCache_NullCache_ArgumentNullException()
         {
-            SimpleCacheClient client = new SimpleCacheClient(authKey, defaultTtlSeconds: 10);
             Assert.Throws<ArgumentNullException>(() => client.DeleteCache(null!));
         }
 
         [Fact]
         public void DeleteCache_CacheDoesntExist_NotFoundException()
         {
-            SimpleCacheClient client = new SimpleCacheClient(authKey, defaultTtlSeconds: 10);
-            Assert.Throws<NotFoundException>(() => client.DeleteCache("non existant cache"));
+            Assert.Throws<NotFoundException>(() => client.DeleteCache("non-existent cache"));
         }
 
         [Fact]
         public void CreateCache_NullCache_ArgumentNullException()
         {
-            SimpleCacheClient client = new SimpleCacheClient(authKey, defaultTtlSeconds: 10);
             Assert.Throws<ArgumentNullException>(() => client.CreateCache(null!));
         }
 
@@ -57,7 +56,6 @@ namespace MomentoIntegrationTest
         public void ListCaches_OneCache_HappyPath()
         {
             // Create cache
-            SimpleCacheClient client = new SimpleCacheClient(authKey, defaultTtlSeconds: 10);
             string cacheName = Guid.NewGuid().ToString();
             client.CreateCache(cacheName);
 
@@ -77,7 +75,6 @@ namespace MomentoIntegrationTest
         public void ListCaches_Iteration_HappyPath()
         {
             // Create caches
-            SimpleCacheClient client = new SimpleCacheClient(authKey, defaultTtlSeconds: 10);
             List<String> cacheNames = new List<String>();
 
             // TODO: increase limit after pagination is enabled
@@ -119,7 +116,6 @@ namespace MomentoIntegrationTest
         public void ListCaches_BadNextToken_NoException()
         {
             // A bad next token does not throw an exception
-            SimpleCacheClient client = new SimpleCacheClient(authKey, defaultTtlSeconds: 10);
             client.ListCaches(nextPageToken: "hello world");
         }
     }

--- a/MomentoIntegrationTest/SimpleCacheDataTest.cs
+++ b/MomentoIntegrationTest/SimpleCacheDataTest.cs
@@ -1,40 +1,22 @@
-﻿using System;
-using System.Threading.Tasks;
-using Xunit;
-using MomentoSdk;
-using MomentoSdk.Responses;
-using MomentoSdk.Exceptions;
+﻿using System.Threading.Tasks;
 using System.Text;
 using System.Collections.Generic;
 
 namespace MomentoIntegrationTest
 {
-    public class SimpleCacheDataTest : IDisposable
+    [Collection("SimpleCacheClient")]
+    public class SimpleCacheDataTest
     {
-        private string authKey = Environment.GetEnvironmentVariable("TEST_AUTH_TOKEN") ??
-            throw new NullReferenceException("TEST_AUTH_TOKEN environment variable must be set.");
-        private string cacheName = "client-sdk-csharp";
-        private uint defaultTtlSeconds = 10;
+        private readonly string authToken;
+        private const string CacheName = SimpleCacheClientFixture.CacheName;
+        private const uint DefaultTtlSeconds = SimpleCacheClientFixture.DefaultTtlSeconds;
         private SimpleCacheClient client;
 
         // Test initialization
-        public SimpleCacheDataTest()
+        public SimpleCacheDataTest(SimpleCacheClientFixture fixture)
         {
-            client = new SimpleCacheClient(authKey, defaultTtlSeconds);
-            try
-            {
-                client.CreateCache(cacheName);
-            }
-            catch (AlreadyExistsException)
-            {
-            }
-        }
-
-        // Test cleanup
-        public void Dispose()
-        {
-            client.DeleteCache(cacheName);
-            client.Dispose();
+            client = fixture.Client;
+            authToken = fixture.AuthToken;
         }
 
         private byte[] Utf8ToBytes(string s)
@@ -49,7 +31,7 @@ namespace MomentoIntegrationTest
         public async void SetAsync_NullChecksBytesBytes_ThrowsException(string cacheName, byte[] key, byte[] value)
         {
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAsync(cacheName, key, value));
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAsync(cacheName, key, value, defaultTtlSeconds));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAsync(cacheName, key, value, DefaultTtlSeconds));
         }
 
         // Tests SetAsyc(cacheName, byte[], byte[]) as well as GetAsync(cacheName, byte[])
@@ -58,14 +40,14 @@ namespace MomentoIntegrationTest
         {
             byte[] key = Utf8ToBytes("key1");
             byte[] value = Utf8ToBytes("value1");
-            await client.SetAsync(cacheName, key, value);
-            byte[]? setValue = (await client.GetAsync(cacheName, key)).Bytes();
+            await client.SetAsync(CacheName, key, value);
+            byte[]? setValue = (await client.GetAsync(CacheName, key)).Bytes();
             Assert.Equal(value, setValue);
 
             key = Utf8ToBytes("key2");
             value = Utf8ToBytes("value2");
-            await client.SetAsync(cacheName, key, value, ttlSeconds: 15);
-            setValue = (await client.GetAsync(cacheName, key)).Bytes();
+            await client.SetAsync(CacheName, key, value, ttlSeconds: 15);
+            setValue = (await client.GetAsync(CacheName, key)).Bytes();
             Assert.Equal(value, setValue);
         }
 
@@ -84,7 +66,7 @@ namespace MomentoIntegrationTest
         public async void SetAsync_NullChecksStringString_ThrowsException(string cacheName, string key, string value)
         {
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAsync(cacheName, key, value));
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAsync(cacheName, key, value, defaultTtlSeconds));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAsync(cacheName, key, value, DefaultTtlSeconds));
         }
 
         // Also tests GetAsync(cacheName, string)
@@ -93,14 +75,14 @@ namespace MomentoIntegrationTest
         {
             string key = "key3";
             string value = "value3";
-            await client.SetAsync(cacheName, key, value);
-            string? setValue = (await client.GetAsync(cacheName, key)).String();
+            await client.SetAsync(CacheName, key, value);
+            string? setValue = (await client.GetAsync(CacheName, key)).String();
             Assert.Equal(value, setValue);
 
             key = "key4";
             value = "value4";
-            await client.SetAsync(cacheName, key, value, ttlSeconds: 15);
-            setValue = (await client.GetAsync(cacheName, key)).String();
+            await client.SetAsync(CacheName, key, value, ttlSeconds: 15);
+            setValue = (await client.GetAsync(CacheName, key)).String();
             Assert.Equal(value, setValue);
         }
 
@@ -119,7 +101,7 @@ namespace MomentoIntegrationTest
         public async void SetAsync_NullChecksStringBytes_ThrowsException(string cacheName, string key, byte[] value)
         {
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAsync(cacheName, key, value));
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAsync(cacheName, key, value, defaultTtlSeconds));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAsync(cacheName, key, value, DefaultTtlSeconds));
         }
 
         // Also tests GetAsync(cacheName, string)
@@ -128,14 +110,14 @@ namespace MomentoIntegrationTest
         {
             string key = "key5";
             byte[] value = Utf8ToBytes("value5");
-            await client.SetAsync(cacheName, key, value);
-            byte[]? setValue = (await client.GetAsync(cacheName, key)).Bytes();
+            await client.SetAsync(CacheName, key, value);
+            byte[]? setValue = (await client.GetAsync(CacheName, key)).Bytes();
             Assert.Equal(value, setValue);
 
             key = "key6";
             value = Utf8ToBytes("value6");
-            await client.SetAsync(cacheName, key, value, ttlSeconds: 15);
-            setValue = (await client.GetAsync(cacheName, key)).Bytes();
+            await client.SetAsync(CacheName, key, value, ttlSeconds: 15);
+            setValue = (await client.GetAsync(CacheName, key)).Bytes();
             Assert.Equal(value, setValue);
         }
 
@@ -158,12 +140,12 @@ namespace MomentoIntegrationTest
             string cacheValue1 = "value1";
             string cacheKey2 = "key2";
             string cacheValue2 = "value2";
-            client.Set(cacheName, cacheKey1, cacheValue1);
-            client.Set(cacheName, cacheKey2, cacheValue2);
+            client.Set(CacheName, cacheKey1, cacheValue1);
+            client.Set(CacheName, cacheKey2, cacheValue2);
 
             List<byte[]> keys = new() { Utf8ToBytes(cacheKey1), Utf8ToBytes(cacheKey2) };
 
-            CacheGetMultiResponse result = await client.GetMultiAsync(cacheName, keys);
+            CacheGetMultiResponse result = await client.GetMultiAsync(CacheName, keys);
             string? stringResult1 = result.Strings()[0];
             string? stringResult2 = result.Strings()[1];
             Assert.Equal(cacheValue1, stringResult1);
@@ -177,10 +159,10 @@ namespace MomentoIntegrationTest
             string cacheValue1 = "value1";
             string cacheKey2 = "key2";
             string cacheValue2 = "value2";
-            client.Set(cacheName, cacheKey1, cacheValue1);
-            client.Set(cacheName, cacheKey2, cacheValue2);
+            client.Set(CacheName, cacheKey1, cacheValue1);
+            client.Set(CacheName, cacheKey2, cacheValue2);
 
-            CacheGetMultiResponse result = await client.GetMultiAsync(cacheName, cacheKey1, cacheKey2);
+            CacheGetMultiResponse result = await client.GetMultiAsync(CacheName, cacheKey1, cacheKey2);
             string? stringResult1 = result.Strings()[0];
             string? stringResult2 = result.Strings()[1];
             Assert.Equal(cacheValue1, stringResult1);
@@ -206,11 +188,11 @@ namespace MomentoIntegrationTest
             string cacheValue1 = "value1";
             string cacheKey2 = "key2";
             string cacheValue2 = "value2";
-            client.Set(cacheName, cacheKey1, cacheValue1);
-            client.Set(cacheName, cacheKey2, cacheValue2);
+            client.Set(CacheName, cacheKey1, cacheValue1);
+            client.Set(CacheName, cacheKey2, cacheValue2);
 
             List<string> keys = new() { cacheKey1, cacheKey2, "key123123" };
-            CacheGetMultiResponse result = await client.GetMultiAsync(cacheName, keys);
+            CacheGetMultiResponse result = await client.GetMultiAsync(CacheName, keys);
 
             Assert.Equal(result.Strings(), new string[] { cacheValue1, cacheValue2, null! });
             Assert.Equal(result.Status(), new CacheGetStatus[] { CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS });
@@ -220,9 +202,9 @@ namespace MomentoIntegrationTest
         public void GetMultiAsync_Failure()
         {
             // Set very small timeout for dataClientOperationTimeoutMilliseconds
-            SimpleCacheClient simpleCacheClient = new SimpleCacheClient(authKey, defaultTtlSeconds, 1);
+            SimpleCacheClient simpleCacheClient = new SimpleCacheClient(authToken, DefaultTtlSeconds, 1);
             List<string> keys = new() { "key1", "key2", "key3", "key4" };
-            Assert.ThrowsAsync<MomentoSdk.Exceptions.TimeoutException>(() => simpleCacheClient.GetMultiAsync(cacheName, keys));
+            Assert.ThrowsAsync<MomentoSdk.Exceptions.TimeoutException>(() => simpleCacheClient.GetMultiAsync(CacheName, keys));
         }
 
         [Fact]
@@ -242,13 +224,13 @@ namespace MomentoIntegrationTest
                 { Utf8ToBytes("key1"), Utf8ToBytes("value1") },
                 { Utf8ToBytes("key2"), Utf8ToBytes("value2") }
             };
-            CacheSetMultiResponse response = await client.SetMultiAsync(cacheName, dictionary);
+            CacheSetMultiResponse response = await client.SetMultiAsync(CacheName, dictionary);
             Assert.Equal(dictionary, response.Bytes());
 
-            var getResponse = await client.GetAsync(cacheName, Utf8ToBytes("key1"));
+            var getResponse = await client.GetAsync(CacheName, Utf8ToBytes("key1"));
             Assert.Equal("value1", getResponse.String());
 
-            getResponse = await client.GetAsync(cacheName, Utf8ToBytes("key2"));
+            getResponse = await client.GetAsync(CacheName, Utf8ToBytes("key2"));
             Assert.Equal("value2", getResponse.String());
         }
 
@@ -269,13 +251,13 @@ namespace MomentoIntegrationTest
                 { "key1", "value1" },
                 { "key2", "value2" }
             };
-            CacheSetMultiResponse response = await client.SetMultiAsync(cacheName, dictionary);
+            CacheSetMultiResponse response = await client.SetMultiAsync(CacheName, dictionary);
             Assert.Equal(dictionary, response.Strings());
 
-            var getResponse = await client.GetAsync(cacheName, "key1");
+            var getResponse = await client.GetAsync(CacheName, "key1");
             Assert.Equal("value1", getResponse.String());
 
-            getResponse = await client.GetAsync(cacheName, "key2");
+            getResponse = await client.GetAsync(CacheName, "key2");
             Assert.Equal("value2", getResponse.String());
         }
 
@@ -286,7 +268,7 @@ namespace MomentoIntegrationTest
         public void Set_NullChecksBytesBytes_ThrowsException(string cacheName, byte[] key, byte[] value)
         {
             Assert.Throws<ArgumentNullException>(() => client.Set(cacheName, key, value));
-            Assert.Throws<ArgumentNullException>(() => client.Set(cacheName, key, value, defaultTtlSeconds));
+            Assert.Throws<ArgumentNullException>(() => client.Set(cacheName, key, value, DefaultTtlSeconds));
         }
 
         // Tests Set(cacheName, byte[], byte[]) as well as Get(cacheName, byte[])
@@ -295,14 +277,14 @@ namespace MomentoIntegrationTest
         {
             byte[] key = Utf8ToBytes("key10");
             byte[] value = Utf8ToBytes("value10");
-            client.Set(cacheName, key, value);
-            byte[]? setValue = client.Get(cacheName, key).Bytes();
+            client.Set(CacheName, key, value);
+            byte[]? setValue = client.Get(CacheName, key).Bytes();
             Assert.Equal(value, setValue);
 
             key = Utf8ToBytes("key11");
             value = Utf8ToBytes("value11");
-            client.Set(cacheName, key, value, ttlSeconds: 15);
-            setValue = client.Get(cacheName, key).Bytes();
+            client.Set(CacheName, key, value, ttlSeconds: 15);
+            setValue = client.Get(CacheName, key).Bytes();
             Assert.Equal(value, setValue);
         }
 
@@ -318,16 +300,16 @@ namespace MomentoIntegrationTest
         {
             string cacheKey = "some cache key";
             string cacheValue = "some cache value";
-            client.Set(cacheName, cacheKey, cacheValue, 1);
+            client.Set(CacheName, cacheKey, cacheValue, 1);
             await Task.Delay(3000);
-            CacheGetResponse result = client.Get(cacheName, cacheKey);
+            CacheGetResponse result = client.Get(CacheName, cacheKey);
             Assert.Equal(CacheGetStatus.MISS, result.Status);
         }
 
         [Fact]
         public void Get_Miss_HappyPath()
         {
-            CacheGetResponse result = client.Get(cacheName, Guid.NewGuid().ToString());
+            CacheGetResponse result = client.Get(CacheName, Guid.NewGuid().ToString());
             Assert.Equal(CacheGetStatus.MISS, result.Status);
             Assert.Null(result.String());
             Assert.Null(result.Bytes());
@@ -336,17 +318,15 @@ namespace MomentoIntegrationTest
         [Fact]
         public void Get_CacheDoesntExist_ThrowsException()
         {
-            uint defaultTtlSeconds = 10;
-            SimpleCacheClient client = new SimpleCacheClient(authKey, defaultTtlSeconds);
-            Assert.Throws<NotFoundException>(() => client.Get("non-existent-cache", Guid.NewGuid().ToString()));
+            SimpleCacheClient simpleCacheClient = new SimpleCacheClient(authToken, DefaultTtlSeconds);
+            Assert.Throws<NotFoundException>(() => simpleCacheClient.Get("non-existent-cache", Guid.NewGuid().ToString()));
         }
 
         [Fact]
         public void Set_CacheDoesntExist_ThrowsException()
         {
-            uint defaultTtlSeconds = 10;
-            SimpleCacheClient client = new SimpleCacheClient(authKey, defaultTtlSeconds);
-            Assert.Throws<NotFoundException>(() => client.Set("non-existent-cache", Guid.NewGuid().ToString(), Guid.NewGuid().ToString()));
+            SimpleCacheClient simpleCacheClient = new SimpleCacheClient(authToken, DefaultTtlSeconds);
+            Assert.Throws<NotFoundException>(() => simpleCacheClient.Set("non-existent-cache", Guid.NewGuid().ToString(), Guid.NewGuid().ToString()));
         }
 
         [Theory]
@@ -356,7 +336,7 @@ namespace MomentoIntegrationTest
         public void Set_NullChecksStringString_ThrowsException(string cacheName, string key, string value)
         {
             Assert.Throws<ArgumentNullException>(() => client.Set(cacheName, key, value));
-            Assert.Throws<ArgumentNullException>(() => client.Set(cacheName, key, value, defaultTtlSeconds));
+            Assert.Throws<ArgumentNullException>(() => client.Set(cacheName, key, value, DefaultTtlSeconds));
         }
 
         // Tests Set(cacheName, string, string) as well as Get(cacheName, string)
@@ -365,14 +345,14 @@ namespace MomentoIntegrationTest
         {
             string key = "key12";
             string value = "value12";
-            client.Set(cacheName, key, value);
-            string? setValue = client.Get(cacheName, key).String();
+            client.Set(CacheName, key, value);
+            string? setValue = client.Get(CacheName, key).String();
             Assert.Equal(value, setValue);
 
             key = "key13";
             value = "value13";
-            client.Set(cacheName, key, value, ttlSeconds: 15);
-            setValue = client.Get(cacheName, key).String();
+            client.Set(CacheName, key, value, ttlSeconds: 15);
+            setValue = client.Get(CacheName, key).String();
             Assert.Equal(value, setValue);
         }
 
@@ -391,7 +371,7 @@ namespace MomentoIntegrationTest
         public void Set_NullChecksStringBytes_ThrowsException(string cacheName, string key, byte[] value)
         {
             Assert.Throws<ArgumentNullException>(() => client.Set(cacheName, key, value));
-            Assert.Throws<ArgumentNullException>(() => client.Set(cacheName, key, value, defaultTtlSeconds));
+            Assert.Throws<ArgumentNullException>(() => client.Set(cacheName, key, value, DefaultTtlSeconds));
         }
 
         // Tests Set(cacheName, string, byte[]) as well as Get(cacheName, string)
@@ -400,14 +380,14 @@ namespace MomentoIntegrationTest
         {
             string key = "key14";
             byte[] value = Utf8ToBytes("value14");
-            client.Set(cacheName, key, value);
-            byte[]? setValue = client.Get(cacheName, key).Bytes();
+            client.Set(CacheName, key, value);
+            byte[]? setValue = client.Get(CacheName, key).Bytes();
             Assert.Equal(value, setValue);
 
             key = "key15";
             value = Utf8ToBytes("value15");
-            client.Set(cacheName, key, value, ttlSeconds: 15);
-            setValue = client.Get(cacheName, key).Bytes();
+            client.Set(CacheName, key, value, ttlSeconds: 15);
+            setValue = client.Get(CacheName, key).Bytes();
             Assert.Equal(value, setValue);
         }
 
@@ -430,12 +410,12 @@ namespace MomentoIntegrationTest
             string cacheValue1 = "value1";
             string cacheKey2 = "key2";
             string cacheValue2 = "value2";
-            client.Set(cacheName, cacheKey1, cacheValue1);
-            client.Set(cacheName, cacheKey2, cacheValue2);
+            client.Set(CacheName, cacheKey1, cacheValue1);
+            client.Set(CacheName, cacheKey2, cacheValue2);
 
             List<byte[]> keys = new() { Utf8ToBytes(cacheKey1), Utf8ToBytes(cacheKey2) };
 
-            CacheGetMultiResponse result = client.GetMulti(cacheName, keys);
+            CacheGetMultiResponse result = client.GetMulti(CacheName, keys);
             string? stringResult1 = result.Strings()[0];
             string? stringResult2 = result.Strings()[1];
             Assert.Equal(cacheValue1, stringResult1);
@@ -449,10 +429,10 @@ namespace MomentoIntegrationTest
             string cacheValue1 = "value1";
             string cacheKey2 = "key2";
             string cacheValue2 = "value2";
-            client.Set(cacheName, cacheKey1, cacheValue1);
-            client.Set(cacheName, cacheKey2, cacheValue2);
+            client.Set(CacheName, cacheKey1, cacheValue1);
+            client.Set(CacheName, cacheKey2, cacheValue2);
 
-            CacheGetMultiResponse result = client.GetMulti(cacheName, cacheKey1, cacheKey2);
+            CacheGetMultiResponse result = client.GetMulti(CacheName, cacheKey1, cacheKey2);
             string? stringResult1 = result.Strings()[0];
             string? stringResult2 = result.Strings()[1];
             Assert.Equal(cacheValue1, stringResult1);
@@ -478,11 +458,11 @@ namespace MomentoIntegrationTest
             string cacheValue1 = "value1";
             string cacheKey2 = "key2";
             string cacheValue2 = "value2";
-            client.Set(cacheName, cacheKey1, cacheValue1);
-            client.Set(cacheName, cacheKey2, cacheValue2);
+            client.Set(CacheName, cacheKey1, cacheValue1);
+            client.Set(CacheName, cacheKey2, cacheValue2);
 
             List<string> keys = new() { cacheKey1, cacheKey2, "key123123" };
-            CacheGetMultiResponse result = client.GetMulti(cacheName, keys);
+            CacheGetMultiResponse result = client.GetMulti(CacheName, keys);
 
             Assert.Equal(result.Strings(), new string[] { cacheValue1, cacheValue2, null! });
             Assert.Equal(result.Status(), new CacheGetStatus[] { CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS });
@@ -492,9 +472,9 @@ namespace MomentoIntegrationTest
         public void GetMulti_Failure()
         {
             // Set very small timeout for dataClientOperationTimeoutMilliseconds
-            SimpleCacheClient simpleCacheClient = new SimpleCacheClient(authKey, defaultTtlSeconds, 1);
+            SimpleCacheClient simpleCacheClient = new SimpleCacheClient(authToken, DefaultTtlSeconds, 1);
             List<string> keys = new() { "key1", "key2", "key3", "key4" };
-            Assert.Throws<MomentoSdk.Exceptions.TimeoutException>(() => simpleCacheClient.GetMulti(cacheName, keys));
+            Assert.Throws<MomentoSdk.Exceptions.TimeoutException>(() => simpleCacheClient.GetMulti(CacheName, keys));
         }
 
         [Fact]
@@ -514,13 +494,13 @@ namespace MomentoIntegrationTest
                     { Utf8ToBytes("key1"), Utf8ToBytes("value1") },
                     { Utf8ToBytes("key2"), Utf8ToBytes("value2") }
                 };
-            CacheSetMultiResponse response = client.SetMulti(cacheName, dictionary);
+            CacheSetMultiResponse response = client.SetMulti(CacheName, dictionary);
             Assert.Equal(dictionary, response.Bytes());
 
-            var getResponse = client.Get(cacheName, Utf8ToBytes("key1"));
+            var getResponse = client.Get(CacheName, Utf8ToBytes("key1"));
             Assert.Equal("value1", getResponse.String());
 
-            getResponse = client.Get(cacheName, Utf8ToBytes("key2"));
+            getResponse = client.Get(CacheName, Utf8ToBytes("key2"));
             Assert.Equal("value2", getResponse.String());
         }
 
@@ -542,13 +522,13 @@ namespace MomentoIntegrationTest
                     { "key1", "value1" },
                     { "key2", "value2" }
                 };
-            CacheSetMultiResponse response = client.SetMulti(cacheName, dictionary);
+            CacheSetMultiResponse response = client.SetMulti(CacheName, dictionary);
             Assert.Equal(dictionary, response.Strings());
 
-            var getResponse = client.Get(cacheName, "key1");
+            var getResponse = client.Get(CacheName, "key1");
             Assert.Equal("value1", getResponse.String());
 
-            getResponse = client.Get(cacheName, "key2");
+            getResponse = client.Get(CacheName, "key2");
             Assert.Equal("value2", getResponse.String());
         }
 
@@ -566,15 +546,15 @@ namespace MomentoIntegrationTest
             // Set a key to then delete
             byte[] key = new byte[] { 0x01, 0x02, 0x03, 0x04 };
             byte[] value = new byte[] { 0x05, 0x06, 0x07, 0x08 };
-            client.Set(cacheName, key, value, ttlSeconds: 60);
-            CacheGetResponse getResponse = client.Get(cacheName, key);
+            client.Set(CacheName, key, value, ttlSeconds: 60);
+            CacheGetResponse getResponse = client.Get(CacheName, key);
             Assert.Equal(CacheGetStatus.HIT, getResponse.Status);
 
             // Delete
-            client.Delete(cacheName, key);
+            client.Delete(CacheName, key);
 
             // Check deleted
-            getResponse = client.Get(cacheName, key);
+            getResponse = client.Get(CacheName, key);
             Assert.Equal(CacheGetStatus.MISS, getResponse.Status);
         }
 
@@ -592,15 +572,15 @@ namespace MomentoIntegrationTest
             // Set a key to then delete
             byte[] key = new byte[] { 0x01, 0x02, 0x03, 0x04 };
             byte[] value = new byte[] { 0x05, 0x06, 0x07, 0x08 };
-            await client.SetAsync(cacheName, key, value, ttlSeconds: 60);
-            CacheGetResponse getResponse = await client.GetAsync(cacheName, key);
+            await client.SetAsync(CacheName, key, value, ttlSeconds: 60);
+            CacheGetResponse getResponse = await client.GetAsync(CacheName, key);
             Assert.Equal(CacheGetStatus.HIT, getResponse.Status);
 
             // Delete
-            await client.DeleteAsync(cacheName, key);
+            await client.DeleteAsync(CacheName, key);
 
             // Check deleted
-            getResponse = await client.GetAsync(cacheName, key);
+            getResponse = await client.GetAsync(CacheName, key);
             Assert.Equal(CacheGetStatus.MISS, getResponse.Status);
         }
 
@@ -618,15 +598,15 @@ namespace MomentoIntegrationTest
             // Set a key to then delete
             string key = "key";
             string value = "value";
-            client.Set(cacheName, key, value, ttlSeconds: 60);
-            CacheGetResponse getResponse = client.Get(cacheName, key);
+            client.Set(CacheName, key, value, ttlSeconds: 60);
+            CacheGetResponse getResponse = client.Get(CacheName, key);
             Assert.Equal(CacheGetStatus.HIT, getResponse.Status);
 
             // Delete
-            client.Delete(cacheName, key);
+            client.Delete(CacheName, key);
 
             // Check deleted
-            getResponse = client.Get(cacheName, key);
+            getResponse = client.Get(CacheName, key);
             Assert.Equal(CacheGetStatus.MISS, getResponse.Status);
         }
 
@@ -644,15 +624,15 @@ namespace MomentoIntegrationTest
             // Set a key to then delete
             string key = "key";
             string value = "value";
-            await client.SetAsync(cacheName, key, value, ttlSeconds: 60);
-            CacheGetResponse getResponse = await client.GetAsync(cacheName, key);
+            await client.SetAsync(CacheName, key, value, ttlSeconds: 60);
+            CacheGetResponse getResponse = await client.GetAsync(CacheName, key);
             Assert.Equal(CacheGetStatus.HIT, getResponse.Status);
 
             // Delete
-            await client.DeleteAsync(cacheName, key);
+            await client.DeleteAsync(CacheName, key);
 
             // Check deleted
-            getResponse = await client.GetAsync(cacheName, key);
+            getResponse = await client.GetAsync(CacheName, key);
             Assert.Equal(CacheGetStatus.MISS, getResponse.Status);
         }
     }

--- a/MomentoIntegrationTest/Usings.cs
+++ b/MomentoIntegrationTest/Usings.cs
@@ -1,0 +1,5 @@
+global using Xunit;
+global using MomentoSdk;
+global using MomentoSdk.Exceptions;
+global using MomentoSdk.Responses;
+global using System;


### PR DESCRIPTION
This PR introduces a client test fixture. The previous tests
instantiated the client in test class constructors. That is, we used
this pattern:

```csharp
public class MyTests
{
	public MyTests()
	{
		// Instantiate the client
	}

	public void Test_Something()
	{
		// tests using the client
	}

	public void Test_Otherthing()
	{
		// tests using the client
	}
}
```

Data instantiated in the constructor will be setup and torn down
for *each* test method, not just for the class as a whole. Because
an isolated client is not necessary for most of the tests and incurs
high overhead, we should avoid this.

In `Fixtures.cs` we create a client fixture and register it to be
available across all test classes. We updated the test cases accordingly.

See [the official documentation](https://xunit.net/docs/shared-context) for reference