### PR TITLE
chore: prefer namespace statements to namespace blocks

### DIFF
--- a/Momento/Exceptions/AlreadyExistsException.cs
+++ b/Momento/Exceptions/AlreadyExistsException.cs
@@ -1,12 +1,11 @@
-﻿namespace MomentoSdk.Exceptions
+﻿namespace MomentoSdk.Exceptions;
+
+/// <summary>
+/// Resource already exists
+/// </summary>
+public class AlreadyExistsException : MomentoServiceException
 {
-    /// <summary>
-    /// Resource already exists
-    /// </summary>
-    public class AlreadyExistsException : MomentoServiceException
+    public AlreadyExistsException(string message) : base(message)
     {
-        public AlreadyExistsException(string message) : base(message)
-        {
-        }
     }
 }

--- a/Momento/Exceptions/AuthenticationException.cs
+++ b/Momento/Exceptions/AuthenticationException.cs
@@ -1,12 +1,11 @@
-﻿namespace MomentoSdk.Exceptions
+﻿namespace MomentoSdk.Exceptions;
+
+/// <summary>
+/// Authentication token is not provided or is invalid.
+/// </summary>
+public class AuthenticationException : MomentoServiceException
 {
-    /// <summary>
-    /// Authentication token is not provided or is invalid.
-    /// </summary>
-    public class AuthenticationException : MomentoServiceException
+    public AuthenticationException(string message) : base(message)
     {
-        public AuthenticationException(string message) : base(message)
-        {
-        }
     }
 }

--- a/Momento/Exceptions/BadRequestException.cs
+++ b/Momento/Exceptions/BadRequestException.cs
@@ -1,12 +1,11 @@
-﻿namespace MomentoSdk.Exceptions
+﻿namespace MomentoSdk.Exceptions;
+
+/// <summary>
+/// Invalid parameters sent to Momento Services.
+/// </summary>
+public class BadRequestException : MomentoServiceException
 {
-    /// <summary>
-    /// Invalid parameters sent to Momento Services.
-    /// </summary>
-    public class BadRequestException : MomentoServiceException
+    public BadRequestException(string message) : base(message)
     {
-        public BadRequestException(string message) : base(message)
-        {
-        }
     }
 }

--- a/Momento/Exceptions/CacheExceptionMapper.cs
+++ b/Momento/Exceptions/CacheExceptionMapper.cs
@@ -1,57 +1,57 @@
 ﻿using System;
 using Grpc.Core;
-namespace MomentoSdk.Exceptions
+
+namespace MomentoSdk.Exceptions;
+
+class CacheExceptionMapper
 {
-    class CacheExceptionMapper
+    private const string INTERNAL_SERVER_ERROR_MESSAGE = "Unexpected exception occurred while trying to fulfill the request.";
+    private const string SDK_ERROR_MESSAGE = "SDK Failed to process the request.";
+
+    public static Exception Convert(Exception e)
     {
-        private const string INTERNAL_SERVER_ERROR_MESSAGE = "Unexpected exception occurred while trying to fulfill the request.";
-        private const string SDK_ERROR_MESSAGE = "SDK Failed to process the request.";
-
-        public static Exception Convert(Exception e)
+        if (e is SdkException exception)
         {
-            if (e is SdkException exception)
-            {
-                return exception;
-            }
-            if (e is RpcException ex)
-            {
-                switch (ex.StatusCode)
-                {
-                    case StatusCode.InvalidArgument:
-                    case StatusCode.OutOfRange:
-                    case StatusCode.FailedPrecondition:
-                    case StatusCode.Unimplemented:
-                        return new BadRequestException(ex.Message);
-
-                    case StatusCode.PermissionDenied:
-                        return new PermissionDeniedException(ex.Message);
-
-                    case StatusCode.Unauthenticated:
-                        return new AuthenticationException(ex.Message);
-
-                    case StatusCode.ResourceExhausted:
-                        return new LimitExceededException(ex.Message);
-
-                    case StatusCode.NotFound:
-                        return new NotFoundException(ex.Message);
-
-                    case StatusCode.AlreadyExists:
-                        return new AlreadyExistsException(ex.Message);
-
-                    case StatusCode.DeadlineExceeded:
-                        return new TimeoutException(ex.Message);
-
-                    case StatusCode.Cancelled:
-                        return new CancelledException(ex.Message);
-
-                    case StatusCode.Unknown:
-                    case StatusCode.Unavailable:
-                    case StatusCode.Aborted:
-                    case StatusCode.DataLoss:
-                    default: return new InternalServerException(INTERNAL_SERVER_ERROR_MESSAGE, e);
-                }
-            }
-            return new ClientSdkException(SDK_ERROR_MESSAGE, e);
+            return exception;
         }
+        if (e is RpcException ex)
+        {
+            switch (ex.StatusCode)
+            {
+                case StatusCode.InvalidArgument:
+                case StatusCode.OutOfRange:
+                case StatusCode.FailedPrecondition:
+                case StatusCode.Unimplemented:
+                    return new BadRequestException(ex.Message);
+
+                case StatusCode.PermissionDenied:
+                    return new PermissionDeniedException(ex.Message);
+
+                case StatusCode.Unauthenticated:
+                    return new AuthenticationException(ex.Message);
+
+                case StatusCode.ResourceExhausted:
+                    return new LimitExceededException(ex.Message);
+
+                case StatusCode.NotFound:
+                    return new NotFoundException(ex.Message);
+
+                case StatusCode.AlreadyExists:
+                    return new AlreadyExistsException(ex.Message);
+
+                case StatusCode.DeadlineExceeded:
+                    return new TimeoutException(ex.Message);
+
+                case StatusCode.Cancelled:
+                    return new CancelledException(ex.Message);
+
+                case StatusCode.Unknown:
+                case StatusCode.Unavailable:
+                case StatusCode.Aborted:
+                case StatusCode.DataLoss:
+                default: return new InternalServerException(INTERNAL_SERVER_ERROR_MESSAGE, e);
+            }
+        }
+        return new ClientSdkException(SDK_ERROR_MESSAGE, e);
     }
 }

--- a/Momento/Exceptions/CancelledException.cs
+++ b/Momento/Exceptions/CancelledException.cs
@@ -1,12 +1,11 @@
-﻿namespace MomentoSdk.Exceptions
+﻿namespace MomentoSdk.Exceptions;
+
+public class CancelledException : MomentoServiceException
 {
-    public class CancelledException : MomentoServiceException
+    /// <summary>
+    /// Operation was cancelled.
+    /// </summary>
+    public CancelledException(string message) : base(message)
     {
-        /// <summary>
-        /// Operation was cancelled.
-        /// </summary>
-        public CancelledException(string message) : base(message)
-        {
-        }
     }
 }

--- a/Momento/Exceptions/ClientSdkException.cs
+++ b/Momento/Exceptions/ClientSdkException.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 
-namespace MomentoSdk.Exceptions
+namespace MomentoSdk.Exceptions;
+
+public class ClientSdkException : SdkException
 {
-    public class ClientSdkException : SdkException
+    public ClientSdkException(string message) : base(message)
     {
-        public ClientSdkException(string message) : base(message)
-        {
-        }
-        public ClientSdkException(string message, Exception e) : base(message, e)
-        {
-        }
+    }
+    public ClientSdkException(string message, Exception e) : base(message, e)
+    {
     }
 }

--- a/Momento/Exceptions/InternalServerException.cs
+++ b/Momento/Exceptions/InternalServerException.cs
@@ -1,16 +1,15 @@
 ﻿using System;
-namespace MomentoSdk.Exceptions
+namespace MomentoSdk.Exceptions;
+
+/// <summary>
+/// Momento Service encountered an unexpected exception while trying to fulfill the request.
+/// </summary>
+public class InternalServerException : MomentoServiceException
 {
-    /// <summary>
-    /// Momento Service encountered an unexpected exception while trying to fulfill the request.
-    /// </summary>
-    public class InternalServerException : MomentoServiceException
+    public InternalServerException(string message, Exception e) : base(message, e)
     {
-        public InternalServerException(string message, Exception e) : base(message, e)
-        {
-        }
-        public InternalServerException(string message) : base(message)
-        {
-        }
+    }
+    public InternalServerException(string message) : base(message)
+    {
     }
 }

--- a/Momento/Exceptions/InvalidArgumentException.cs
+++ b/Momento/Exceptions/InvalidArgumentException.cs
@@ -1,17 +1,16 @@
 ﻿using System;
-namespace MomentoSdk.Exceptions
-{
-    /// <summary>
-    /// SDK client side validation failed.
-    /// </summary>
-    public class InvalidArgumentException : ClientSdkException
-    {
-        public InvalidArgumentException(string message) : base(message)
-        {
-        }
+namespace MomentoSdk.Exceptions;
 
-        public InvalidArgumentException(string message, Exception e) : base(message, e)
-        {
-        }
+/// <summary>
+/// SDK client side validation failed.
+/// </summary>
+public class InvalidArgumentException : ClientSdkException
+{
+    public InvalidArgumentException(string message) : base(message)
+    {
+    }
+
+    public InvalidArgumentException(string message, Exception e) : base(message, e)
+    {
     }
 }

--- a/Momento/Exceptions/LimitExceededException.cs
+++ b/Momento/Exceptions/LimitExceededException.cs
@@ -1,12 +1,11 @@
-﻿namespace MomentoSdk.Exceptions
+﻿namespace MomentoSdk.Exceptions;
+
+/// <summary>
+/// Requested operation couldn't be completed because system limits were hit.
+/// </summary>
+public class LimitExceededException : MomentoServiceException
 {
-    /// <summary>
-    /// Requested operation couldn't be completed because system limits were hit.
-    /// </summary>
-    public class LimitExceededException : MomentoServiceException
+    public LimitExceededException(string message) : base(message)
     {
-        public LimitExceededException(string message) : base(message)
-        {
-        }
     }
 }

--- a/Momento/Exceptions/MomentoServiceException.cs
+++ b/Momento/Exceptions/MomentoServiceException.cs
@@ -1,16 +1,15 @@
 ﻿using System;
-namespace MomentoSdk.Exceptions
+namespace MomentoSdk.Exceptions;
+
+/// <summary>
+/// Base type for all the exceptions resulting from invalid interactions with Momento Services.
+/// </summary>
+public abstract class MomentoServiceException : SdkException
 {
-    /// <summary>
-    /// Base type for all the exceptions resulting from invalid interactions with Momento Services.
-    /// </summary>
-    public abstract class MomentoServiceException : SdkException
+    protected MomentoServiceException(string message) : base(message)
     {
-        protected MomentoServiceException(string message) : base(message)
-        {
-        }
-        protected MomentoServiceException(string message, Exception e) : base(message, e)
-        {
-        }
+    }
+    protected MomentoServiceException(string message, Exception e) : base(message, e)
+    {
     }
 }

--- a/Momento/Exceptions/NotFoundException.cs
+++ b/Momento/Exceptions/NotFoundException.cs
@@ -1,12 +1,11 @@
-﻿namespace MomentoSdk.Exceptions
+﻿namespace MomentoSdk.Exceptions;
+
+/// <summary>
+/// Requested resource or the resource on which an operation was requested doesn't exist.
+/// </summary>
+public class NotFoundException : MomentoServiceException
 {
-    /// <summary>
-    /// Requested resource or the resource on which an operation was requested doesn't exist.
-    /// </summary>
-    public class NotFoundException : MomentoServiceException
+    public NotFoundException(string message) : base(message)
     {
-        public NotFoundException(string message) : base(message)
-        {
-        }
     }
 }

--- a/Momento/Exceptions/PermissionDeniedException.cs
+++ b/Momento/Exceptions/PermissionDeniedException.cs
@@ -1,12 +1,11 @@
-﻿namespace MomentoSdk.Exceptions
+﻿namespace MomentoSdk.Exceptions;
+
+/// <summary>
+/// Insufficient permissions to execute an operation.
+/// </summary>
+public class PermissionDeniedException : MomentoServiceException
 {
-    /// <summary>
-    /// Insufficient permissions to execute an operation.
-    /// </summary>
-    public class PermissionDeniedException : MomentoServiceException
+    public PermissionDeniedException(string message) : base(message)
     {
-        public PermissionDeniedException(string message) : base(message)
-        {
-        }
     }
 }

--- a/Momento/Exceptions/SdkException.cs
+++ b/Momento/Exceptions/SdkException.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 
-namespace MomentoSdk.Exceptions
+namespace MomentoSdk.Exceptions;
+
+public abstract class SdkException : Exception
 {
-    public abstract class SdkException : Exception
+    protected SdkException(string message) : base(message)
     {
-        protected SdkException(string message) : base(message)
-        {
-        }
-        protected SdkException(string message, Exception e) : base(message, e)
-        {
-        }
+    }
+    protected SdkException(string message, Exception e) : base(message, e)
+    {
     }
 }

--- a/Momento/Exceptions/TimeoutException.cs
+++ b/Momento/Exceptions/TimeoutException.cs
@@ -1,12 +1,11 @@
-﻿namespace MomentoSdk.Exceptions
+﻿namespace MomentoSdk.Exceptions;
+
+/// <summary>
+/// Requested operation did not complete in allotted time.
+/// </summary>
+public class TimeoutException : MomentoServiceException
 {
-    /// <summary>
-    /// Requested operation did not complete in allotted time.
-    /// </summary>
-    public class TimeoutException : MomentoServiceException
+    public TimeoutException(string message) : base(message)
     {
-        public TimeoutException(string message) : base(message)
-        {
-        }
     }
 }

--- a/Momento/HeaderInterceptor.cs
+++ b/Momento/HeaderInterceptor.cs
@@ -4,85 +4,84 @@ using Grpc.Core.Interceptors;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace MomentoSdk
+namespace MomentoSdk;
+
+class Header
 {
-    class Header
+    public const string AuthorizationKey = "Authorization";
+    public const string AgentKey = "Agent";
+    public readonly List<string> onceOnlyHeaders = new List<string> { Header.AgentKey };
+    public string Name;
+    public string Value;
+    public Header(String name, String value)
     {
-        public const string AuthorizationKey = "Authorization";
-        public const string AgentKey = "Agent";
-        public readonly List<string> onceOnlyHeaders = new List<string> { Header.AgentKey };
-        public string Name;
-        public string Value;
-        public Header(String name, String value)
-        {
-            this.Name = name;
-            this.Value = value;
-        }
-
+        this.Name = name;
+        this.Value = value;
     }
-    class HeaderInterceptor : Grpc.Core.Interceptors.Interceptor
+
+}
+class HeaderInterceptor : Grpc.Core.Interceptors.Interceptor
+{
+    private readonly List<Header> headersToAddEveryTime = new List<Header> { };
+    private readonly List<Header> headersToAddOnce = new List<Header> { };
+    private volatile Boolean areOnlyOnceHeadersSent = false;
+    public HeaderInterceptor(List<Header> headers)
     {
-        private readonly List<Header> headersToAddEveryTime = new List<Header> { };
-        private readonly List<Header> headersToAddOnce = new List<Header> { };
-        private volatile Boolean areOnlyOnceHeadersSent = false;
-        public HeaderInterceptor(List<Header> headers)
-        {
-            this.headersToAddOnce = headers.Where(header => header.onceOnlyHeaders.Contains(header.Name)).ToList();
-            this.headersToAddEveryTime = headers.Where(header => !header.onceOnlyHeaders.Contains(header.Name)).ToList();
-        }
+        this.headersToAddOnce = headers.Where(header => header.onceOnlyHeaders.Contains(header.Name)).ToList();
+        this.headersToAddEveryTime = headers.Where(header => !header.onceOnlyHeaders.Contains(header.Name)).ToList();
+    }
 
-        public override TResponse BlockingUnaryCall<TRequest, TResponse>(TRequest request, ClientInterceptorContext<TRequest, TResponse> context, BlockingUnaryCallContinuation<TRequest, TResponse> continuation)
-        {
-            AddCallerMetadata(ref context);
-            return continuation(request, context);
-        }
-        public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(TRequest request, ClientInterceptorContext<TRequest, TResponse> context, AsyncUnaryCallContinuation<TRequest, TResponse> continuation)
-        {
-            AddCallerMetadata(ref context);
-            return continuation(request, context);
-        }
-        public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(TRequest request, ClientInterceptorContext<TRequest, TResponse> context, AsyncServerStreamingCallContinuation<TRequest, TResponse> continuation)
-        {
-            AddCallerMetadata(ref context);
-            return continuation(request, context);
-        }
-        public override AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(ClientInterceptorContext<TRequest, TResponse> context, AsyncClientStreamingCallContinuation<TRequest, TResponse> continuation)
-        {
-            AddCallerMetadata(ref context);
-            return continuation(context);
-        }
-        public override AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(ClientInterceptorContext<TRequest, TResponse> context, AsyncDuplexStreamingCallContinuation<TRequest, TResponse> continuation)
-        {
-            AddCallerMetadata(ref context);
-            return continuation(context);
-        }
+    public override TResponse BlockingUnaryCall<TRequest, TResponse>(TRequest request, ClientInterceptorContext<TRequest, TResponse> context, BlockingUnaryCallContinuation<TRequest, TResponse> continuation)
+    {
+        AddCallerMetadata(ref context);
+        return continuation(request, context);
+    }
+    public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(TRequest request, ClientInterceptorContext<TRequest, TResponse> context, AsyncUnaryCallContinuation<TRequest, TResponse> continuation)
+    {
+        AddCallerMetadata(ref context);
+        return continuation(request, context);
+    }
+    public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(TRequest request, ClientInterceptorContext<TRequest, TResponse> context, AsyncServerStreamingCallContinuation<TRequest, TResponse> continuation)
+    {
+        AddCallerMetadata(ref context);
+        return continuation(request, context);
+    }
+    public override AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(ClientInterceptorContext<TRequest, TResponse> context, AsyncClientStreamingCallContinuation<TRequest, TResponse> continuation)
+    {
+        AddCallerMetadata(ref context);
+        return continuation(context);
+    }
+    public override AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(ClientInterceptorContext<TRequest, TResponse> context, AsyncDuplexStreamingCallContinuation<TRequest, TResponse> continuation)
+    {
+        AddCallerMetadata(ref context);
+        return continuation(context);
+    }
 
-        private void AddCallerMetadata<TRequest, TResponse>(ref ClientInterceptorContext<TRequest, TResponse> context)
-            where TRequest : class
-            where TResponse : class
-        {
-            var headers = context.Options.Headers;
+    private void AddCallerMetadata<TRequest, TResponse>(ref ClientInterceptorContext<TRequest, TResponse> context)
+        where TRequest : class
+        where TResponse : class
+    {
+        var headers = context.Options.Headers;
 
-            // Call doesn't have a headers collection to add to.
-            // Need to create a new context with headers for the call.
-            if (headers == null)
-            {
-                headers = new Metadata();
-                var options = context.Options.WithHeaders(headers);
-                context = new ClientInterceptorContext<TRequest, TResponse>(context.Method, context.Host, options);
-            }
-            foreach (Header header in this.headersToAddEveryTime)
+        // Call doesn't have a headers collection to add to.
+        // Need to create a new context with headers for the call.
+        if (headers == null)
+        {
+            headers = new Metadata();
+            var options = context.Options.WithHeaders(headers);
+            context = new ClientInterceptorContext<TRequest, TResponse>(context.Method, context.Host, options);
+        }
+        foreach (Header header in this.headersToAddEveryTime)
+        {
+            headers.Add(header.Name, header.Value);
+        }
+        if (!areOnlyOnceHeadersSent)
+        {
+            foreach (Header header in this.headersToAddOnce)
             {
                 headers.Add(header.Name, header.Value);
             }
-            if (!areOnlyOnceHeadersSent)
-            {
-                foreach (Header header in this.headersToAddOnce)
-                {
-                    headers.Add(header.Name, header.Value);
-                }
-                areOnlyOnceHeadersSent = true;
-            }
+            areOnlyOnceHeadersSent = true;
         }
     }
 }

--- a/Momento/Incubating/Responses/CacheDictionaryGetAllResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictionaryGetAllResponse.cs
@@ -3,27 +3,26 @@ using System.Collections.Generic;
 using System.Text;
 using MomentoSdk.Responses;
 
-namespace MomentoSdk.Incubating.Responses
+namespace MomentoSdk.Incubating.Responses;
+
+public class CacheDictionaryGetAllResponse
 {
-    public class CacheDictionaryGetAllResponse
+    public CacheDictionaryGetAllResponse()
     {
-        public CacheDictionaryGetAllResponse()
-        {
-        }
+    }
 
-        public CacheGetStatus Status()
-        {
-            throw new NotImplementedException();
-        }
+    public CacheGetStatus Status()
+    {
+        throw new NotImplementedException();
+    }
 
-        public Dictionary<byte[], byte[]>? DictionaryAsBytes()
-        {
-            throw new NotImplementedException();
-        }
+    public Dictionary<byte[], byte[]>? DictionaryAsBytes()
+    {
+        throw new NotImplementedException();
+    }
 
-        public Dictionary<string, string>? Dictionary(Encoding? encoding = null)
-        {
-            throw new NotImplementedException();
-        }
+    public Dictionary<string, string>? Dictionary(Encoding? encoding = null)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/Momento/Incubating/Responses/CacheDictionaryGetMultiResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictionaryGetMultiResponse.cs
@@ -4,32 +4,31 @@ using System.Text;
 using MomentoSdk.Responses;
 
 
-namespace MomentoSdk.Incubating.Responses
+namespace MomentoSdk.Incubating.Responses;
+
+public class CacheDictionaryGetMultiResponse
 {
-    public class CacheDictionaryGetMultiResponse
+    public CacheDictionaryGetMultiResponse()
     {
-        public CacheDictionaryGetMultiResponse()
-        {
-        }
+    }
 
-        public List<CacheGetStatus> Status()
-        {
-            throw new NotImplementedException();
-        }
+    public List<CacheGetStatus> Status()
+    {
+        throw new NotImplementedException();
+    }
 
-        public List<string?> Values(Encoding? encoding = null)
-        {
-            throw new NotImplementedException();
-        }
+    public List<string?> Values(Encoding? encoding = null)
+    {
+        throw new NotImplementedException();
+    }
 
-        public List<byte[]?> ValuesAsBytes()
-        {
-            throw new NotImplementedException();
-        }
+    public List<byte[]?> ValuesAsBytes()
+    {
+        throw new NotImplementedException();
+    }
 
-        public List<CacheGetResponse> ToList()
-        {
-            throw new NotImplementedException();
-        }
+    public List<CacheGetResponse> ToList()
+    {
+        throw new NotImplementedException();
     }
 }

--- a/Momento/Incubating/Responses/CacheDictionaryGetResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictionaryGetResponse.cs
@@ -3,27 +3,26 @@ using System.Text;
 using MomentoSdk.Responses;
 
 
-namespace MomentoSdk.Incubating.Responses
+namespace MomentoSdk.Incubating.Responses;
+
+public class CacheDictionaryGetResponse
 {
-    public class CacheDictionaryGetResponse
+    public CacheDictionaryGetResponse()
     {
-        public CacheDictionaryGetResponse()
-        {
-        }
+    }
 
-        public CacheGetStatus Status()
-        {
-            throw new NotImplementedException();
-        }
+    public CacheGetStatus Status()
+    {
+        throw new NotImplementedException();
+    }
 
-        public string? String(Encoding? encoding = null)
-        {
-            throw new NotImplementedException();
-        }
+    public string? String(Encoding? encoding = null)
+    {
+        throw new NotImplementedException();
+    }
 
-        public byte[]? Bytes()
-        {
-            throw new NotImplementedException();
-        }
+    public byte[]? Bytes()
+    {
+        throw new NotImplementedException();
     }
 }

--- a/Momento/Incubating/Responses/CacheDictionarySetMultiResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictionarySetMultiResponse.cs
@@ -2,25 +2,24 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace MomentoSdk.Incubating.Responses
-{
-    public class CacheDictionarySetMultiResponse
-    {
-        public CacheDictionarySetMultiResponse()
-        {
-        }
+namespace MomentoSdk.Incubating.Responses;
 
-        public string DictionaryName()
-        {
-            throw new NotImplementedException();
-        }
-        public Dictionary<byte[], byte>? DictionaryAsBytes()
-        {
-            throw new NotImplementedException();
-        }
-        public Dictionary<string, string>? Dictionary(Encoding? encoding = null)
-        {
-            throw new NotImplementedException();
-        }
+public class CacheDictionarySetMultiResponse
+{
+    public CacheDictionarySetMultiResponse()
+    {
+    }
+
+    public string DictionaryName()
+    {
+        throw new NotImplementedException();
+    }
+    public Dictionary<byte[], byte>? DictionaryAsBytes()
+    {
+        throw new NotImplementedException();
+    }
+    public Dictionary<string, string>? Dictionary(Encoding? encoding = null)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/Momento/Incubating/Responses/CacheDictionarySetResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictionarySetResponse.cs
@@ -1,37 +1,36 @@
 ﻿using System;
 using System.Text;
 
-namespace MomentoSdk.Incubating.Responses
+namespace MomentoSdk.Incubating.Responses;
+
+public class CacheDictionarySetResponse
 {
-    public class CacheDictionarySetResponse
+    public CacheDictionarySetResponse()
     {
-        public CacheDictionarySetResponse()
-        {
-        }
+    }
 
-        public string DictionaryName()
-        {
-            throw new NotImplementedException();
-        }
+    public string DictionaryName()
+    {
+        throw new NotImplementedException();
+    }
 
-        public byte[] KeyAsBytes()
-        {
-            throw new NotImplementedException();
-        }
+    public byte[] KeyAsBytes()
+    {
+        throw new NotImplementedException();
+    }
 
-        public string Key(Encoding? encoding = null)
-        {
-            throw new NotImplementedException();
-        }
+    public string Key(Encoding? encoding = null)
+    {
+        throw new NotImplementedException();
+    }
 
-        public byte[] ValueAsBytes()
-        {
-            throw new NotImplementedException();
-        }
+    public byte[] ValueAsBytes()
+    {
+        throw new NotImplementedException();
+    }
 
-        public string Value(Encoding? encoding = null)
-        {
-            throw new NotImplementedException();
-        }
+    public string Value(Encoding? encoding = null)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/Momento/Incubating/SimpleCacheClient.cs
+++ b/Momento/Incubating/SimpleCacheClient.cs
@@ -3,103 +3,101 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using MomentoSdk.Incubating.Responses;
 
-namespace MomentoSdk.Incubating
+namespace MomentoSdk.Incubating;
+
+public class SimpleCacheClient : MomentoSdk.SimpleCacheClient
 {
-    public class SimpleCacheClient : MomentoSdk.SimpleCacheClient
+    public SimpleCacheClient(string authToken, uint defaultTtlSeconds) : base(authToken, defaultTtlSeconds)
     {
-        public SimpleCacheClient(string authToken, uint defaultTtlSeconds) : base(authToken, defaultTtlSeconds)
-        {
-        }
+    }
 
-        public CacheDictionarySetResponse DictionarySet(string cacheName, string dictionaryName, byte[] key, byte[] value, bool refreshTtl, uint? ttlSeconds = null)
-        {
-            throw new NotImplementedException();
-        }
+    public CacheDictionarySetResponse DictionarySet(string cacheName, string dictionaryName, byte[] key, byte[] value, bool refreshTtl, uint? ttlSeconds = null)
+    {
+        throw new NotImplementedException();
+    }
 
-        public CacheDictionarySetResponse DictionarySet(string cacheName, string dictionaryName, string key, string value, bool refreshTtl, uint? ttlSeconds = null)
-        {
-            throw new NotImplementedException();
-        }
+    public CacheDictionarySetResponse DictionarySet(string cacheName, string dictionaryName, string key, string value, bool refreshTtl, uint? ttlSeconds = null)
+    {
+        throw new NotImplementedException();
+    }
 
-        public async Task<CacheDictionarySetResponse> DictionarySetAsync(string cacheName, string dictionaryName, byte[] key, byte[] value, bool refreshTtl, uint? ttlSeconds = null)
-        {
-            return await Task.FromException<CacheDictionarySetResponse>(new NotImplementedException());
-        }
+    public async Task<CacheDictionarySetResponse> DictionarySetAsync(string cacheName, string dictionaryName, byte[] key, byte[] value, bool refreshTtl, uint? ttlSeconds = null)
+    {
+        return await Task.FromException<CacheDictionarySetResponse>(new NotImplementedException());
+    }
 
-        public async Task<CacheDictionarySetResponse> DictionarySetAsync(string cacheName, string dictionaryName, string key, string value, bool refreshTtl, uint? ttlSeconds = null)
-        {
-            return await Task.FromException<CacheDictionarySetResponse>(new NotImplementedException());
-        }
+    public async Task<CacheDictionarySetResponse> DictionarySetAsync(string cacheName, string dictionaryName, string key, string value, bool refreshTtl, uint? ttlSeconds = null)
+    {
+        return await Task.FromException<CacheDictionarySetResponse>(new NotImplementedException());
+    }
 
-        public CacheDictionaryGetResponse DictionaryGet(string cacheName, string dictionaryName, byte[] key)
-        {
-            throw new NotImplementedException();
-        }
+    public CacheDictionaryGetResponse DictionaryGet(string cacheName, string dictionaryName, byte[] key)
+    {
+        throw new NotImplementedException();
+    }
 
-        public CacheDictionaryGetResponse DictionaryGet(string cacheName, string dictionaryName, string key)
-        {
-            throw new NotImplementedException();
-        }
+    public CacheDictionaryGetResponse DictionaryGet(string cacheName, string dictionaryName, string key)
+    {
+        throw new NotImplementedException();
+    }
 
-        public async Task<CacheDictionaryGetResponse> DictionaryGetAsync(string cacheName, string dictionaryName, byte[] key)
-        {
-            return await Task.FromException<CacheDictionaryGetResponse>(new NotImplementedException());
-        }
+    public async Task<CacheDictionaryGetResponse> DictionaryGetAsync(string cacheName, string dictionaryName, byte[] key)
+    {
+        return await Task.FromException<CacheDictionaryGetResponse>(new NotImplementedException());
+    }
 
-        public async Task<CacheDictionaryGetResponse> DictionaryGetAsync(string cacheName, string dictionaryName, string key)
-        {
-            return await Task.FromException<CacheDictionaryGetResponse>(new NotImplementedException());
-        }
+    public async Task<CacheDictionaryGetResponse> DictionaryGetAsync(string cacheName, string dictionaryName, string key)
+    {
+        return await Task.FromException<CacheDictionaryGetResponse>(new NotImplementedException());
+    }
 
-        public CacheDictionarySetMultiResponse DictionarySetMulti(string cacheName, string dictionaryName, IDictionary<byte[], byte[]> dictionary, bool refreshTtl, uint? ttlSeconds = null)
-        {
-            throw new NotImplementedException();
-        }
+    public CacheDictionarySetMultiResponse DictionarySetMulti(string cacheName, string dictionaryName, IDictionary<byte[], byte[]> dictionary, bool refreshTtl, uint? ttlSeconds = null)
+    {
+        throw new NotImplementedException();
+    }
 
-        public CacheDictionarySetMultiResponse DictionarySetMulti(string cacheName, string dictionaryName, IDictionary<string, string> dictionary, bool refreshTtl, uint? ttlSeconds = null)
-        {
-            throw new NotImplementedException();
-        }
+    public CacheDictionarySetMultiResponse DictionarySetMulti(string cacheName, string dictionaryName, IDictionary<string, string> dictionary, bool refreshTtl, uint? ttlSeconds = null)
+    {
+        throw new NotImplementedException();
+    }
 
-        public async Task<CacheDictionarySetMultiResponse> DictionarySetMultiAsync(string cacheName, string dictionaryName, IDictionary<string, string> dictionary, bool refreshTtl, uint? ttlSeconds = null)
-        {
-            return await Task.FromException<CacheDictionarySetMultiResponse>(new NotImplementedException());
-        }
+    public async Task<CacheDictionarySetMultiResponse> DictionarySetMultiAsync(string cacheName, string dictionaryName, IDictionary<string, string> dictionary, bool refreshTtl, uint? ttlSeconds = null)
+    {
+        return await Task.FromException<CacheDictionarySetMultiResponse>(new NotImplementedException());
+    }
 
-        public async Task<CacheDictionarySetMultiResponse> DictionarySetMultiAsync(string cacheName, string dictionaryName, IDictionary<byte[], byte[]> dictionary, bool refreshTtl, uint? ttlSeconds = null)
-        {
-            return await Task.FromException<CacheDictionarySetMultiResponse>(new NotImplementedException());
-        }
+    public async Task<CacheDictionarySetMultiResponse> DictionarySetMultiAsync(string cacheName, string dictionaryName, IDictionary<byte[], byte[]> dictionary, bool refreshTtl, uint? ttlSeconds = null)
+    {
+        return await Task.FromException<CacheDictionarySetMultiResponse>(new NotImplementedException());
+    }
 
-        public CacheDictionaryGetMultiResponse DictionaryGetMulti(string cacheName, string dictionaryName, params byte[][] keys)
-        {
-            throw new NotImplementedException();
-        }
+    public CacheDictionaryGetMultiResponse DictionaryGetMulti(string cacheName, string dictionaryName, params byte[][] keys)
+    {
+        throw new NotImplementedException();
+    }
 
-        public CacheDictionaryGetMultiResponse DictionaryGetMulti(string cacheName, string dictionaryName, params string[] keys)
-        {
-            throw new NotImplementedException();
-        }
+    public CacheDictionaryGetMultiResponse DictionaryGetMulti(string cacheName, string dictionaryName, params string[] keys)
+    {
+        throw new NotImplementedException();
+    }
 
-        public async Task<CacheDictionaryGetMultiResponse> DictionaryGetMultiAsync(string cacheName, string dictionaryName, params byte[][] keys)
-        {
-            return await Task.FromException<CacheDictionaryGetMultiResponse>(new NotImplementedException());
-        }
+    public async Task<CacheDictionaryGetMultiResponse> DictionaryGetMultiAsync(string cacheName, string dictionaryName, params byte[][] keys)
+    {
+        return await Task.FromException<CacheDictionaryGetMultiResponse>(new NotImplementedException());
+    }
 
-        public async Task<CacheDictionaryGetMultiResponse> DictionaryGetMultiAsync(string cacheName, string dictionaryName, params string[] keys)
-        {
-            return await Task.FromException<CacheDictionaryGetMultiResponse>(new NotImplementedException());
-        }
+    public async Task<CacheDictionaryGetMultiResponse> DictionaryGetMultiAsync(string cacheName, string dictionaryName, params string[] keys)
+    {
+        return await Task.FromException<CacheDictionaryGetMultiResponse>(new NotImplementedException());
+    }
 
-        public CacheDictionaryGetAllResponse DictionaryGetAll(string cacheName, string dictionaryName)
-        {
-            throw new NotImplementedException();
-        }
+    public CacheDictionaryGetAllResponse DictionaryGetAll(string cacheName, string dictionaryName)
+    {
+        throw new NotImplementedException();
+    }
 
-        public async Task<CacheDictionaryGetAllResponse> DictionaryGetAllAsync(string cacheName, string dictionaryName)
-        {
-            return await Task.FromException<CacheDictionaryGetAllResponse>(new NotImplementedException());
-        }
+    public async Task<CacheDictionaryGetAllResponse> DictionaryGetAllAsync(string cacheName, string dictionaryName)
+    {
+        return await Task.FromException<CacheDictionaryGetAllResponse>(new NotImplementedException());
     }
 }
-

--- a/Momento/JwtUtils.cs
+++ b/Momento/JwtUtils.cs
@@ -4,45 +4,44 @@ using JWT.Serializers;
 using MomentoSdk.Exceptions;
 using Newtonsoft.Json;
 
-namespace MomentoSdk
-{
-    class JwtUtils
-    {
-        /// <summary>
-        /// extracts the controlEndpoint and cacheEndpoint
-        /// from the jwt
-        /// </summary>
-        /// <param name="jwt"></param>
-        /// <returns></returns>
-        public static Claims DecodeJwt(string jwt)
-        {
-            IJsonSerializer serializer = new JsonNetSerializer();
+namespace MomentoSdk;
 
-            IBase64UrlEncoder urlEncoder = new JwtBase64UrlEncoder();
-            JwtDecoder decoder = new JwtDecoder(serializer, urlEncoder);
-            try
-            {
-                var decodedJwt = decoder.Decode(jwt);
-                return JsonConvert.DeserializeObject<Claims>(decodedJwt);
-            }
-            catch (Exception)
-            {
-                throw new InvalidArgumentException("invalid jwt passed");
-            }
+class JwtUtils
+{
+    /// <summary>
+    /// extracts the controlEndpoint and cacheEndpoint
+    /// from the jwt
+    /// </summary>
+    /// <param name="jwt"></param>
+    /// <returns></returns>
+    public static Claims DecodeJwt(string jwt)
+    {
+        IJsonSerializer serializer = new JsonNetSerializer();
+
+        IBase64UrlEncoder urlEncoder = new JwtBase64UrlEncoder();
+        JwtDecoder decoder = new JwtDecoder(serializer, urlEncoder);
+        try
+        {
+            var decodedJwt = decoder.Decode(jwt);
+            return JsonConvert.DeserializeObject<Claims>(decodedJwt);
+        }
+        catch (Exception)
+        {
+            throw new InvalidArgumentException("invalid jwt passed");
         }
     }
+}
 
-    class Claims
+class Claims
+{
+    [JsonProperty(PropertyName = "cp", Required = Required.Always)]
+    public string ControlEndpoint { get; private set; }
+    [JsonProperty(PropertyName = "c", Required = Required.Always)]
+    public string CacheEndpoint { get; private set; }
+
+    public Claims(string cacheEndpoint, string controlEndpoint)
     {
-        [JsonProperty(PropertyName = "cp", Required = Required.Always)]
-        public string ControlEndpoint { get; private set; }
-        [JsonProperty(PropertyName = "c", Required = Required.Always)]
-        public string CacheEndpoint { get; private set; }
-
-        public Claims(string cacheEndpoint, string controlEndpoint)
-        {
-            this.CacheEndpoint = cacheEndpoint;
-            this.ControlEndpoint = controlEndpoint;
-        }
+        this.CacheEndpoint = cacheEndpoint;
+        this.ControlEndpoint = controlEndpoint;
     }
 }

--- a/Momento/MomentoSigner.cs
+++ b/Momento/MomentoSigner.cs
@@ -4,99 +4,98 @@ using System.Web;
 using Microsoft.IdentityModel.Tokens;
 using MomentoSdk.Exceptions;
 
-namespace MomentoSdk
+namespace MomentoSdk;
+
+public class MomentoSigner
 {
-    public class MomentoSigner
+    private readonly JwtHeader jwtHeader;
+
+    public MomentoSigner(string jwkJsonString)
     {
-        private readonly JwtHeader jwtHeader;
-
-        public MomentoSigner(string jwkJsonString)
+        try
         {
-            try
-            {
-                var securityKey = new JsonWebKey(jwkJsonString);
-                var credentials = new SigningCredentials(securityKey, securityKey.Alg);
-                this.jwtHeader = new JwtHeader(credentials);
-            }
-            catch (Exception e)
-            {
-                throw new InvalidArgumentException($"Invalid JWK: {jwkJsonString}", e);
-            }
+            var securityKey = new JsonWebKey(jwkJsonString);
+            var credentials = new SigningCredentials(securityKey, securityKey.Alg);
+            this.jwtHeader = new JwtHeader(credentials);
+        }
+        catch (Exception e)
+        {
+            throw new InvalidArgumentException($"Invalid JWK: {jwkJsonString}", e);
+        }
+    }
+
+    /// <summary>
+    /// Create a pre-signed HTTPS URL.
+    /// </summary>
+    /// <param name="hostname">Hostname of the SimpleCacheService. Use the value returned from CreateSigningKey's response. A rest keyword is prepended to the hostname</param>
+    /// <param name="signingRequest">The parameters used for generating a pre-signed URL</param>
+    /// <returns></returns>
+    public string CreatePresignedUrl(string hostname, SigningRequest signingRequest)
+    {
+        var jwtToken = SignAccessToken(signingRequest);
+        var cacheName = HttpUtility.UrlEncode(signingRequest.CacheName);
+        var cacheKey = HttpUtility.UrlEncode(signingRequest.CacheKey);
+
+        return signingRequest.CacheOperation switch
+        {
+            CacheOperation.GET => $"https://rest.{hostname}/cache/get/{cacheName}/{cacheKey}?token={jwtToken}",
+            CacheOperation.SET => $"https://rest.{hostname}/cache/set/{cacheName}/{cacheKey}?ttl_milliseconds={signingRequest.TtlSeconds * (ulong)1000}&token={jwtToken}",
+            _ => throw new NotImplementedException($"Unhandled {signingRequest.CacheOperation}")
+        };
+    }
+
+    /// <summary>
+    /// Create the signature for auth to be used in JWT.
+    /// </summary>
+    /// <param name="hostname">Hostname of the SimpleCacheService. Use the value returned from CreateSigningKey's response.</param>
+    /// <param name="signingRequest">The parameters used for generating a pre-signed URL</param>
+    /// <returns></returns>
+    public string SignAccessToken(SigningRequest signingRequest)
+    {
+        var payload = CommonJwtBody(signingRequest.CacheName, signingRequest.CacheKey, signingRequest.ExpiryEpochSeconds);
+        switch (signingRequest.CacheOperation)
+        {
+            case CacheOperation.GET:
+                {
+                    payload.Add("method", new string[] { "get" });
+                    break;
+                }
+            case CacheOperation.SET:
+                {
+                    payload.Add("method", new string[] { "set" });
+                    payload.Add("ttl", signingRequest.TtlSeconds);
+                    break;
+                }
+            default:
+                {
+                    throw new NotImplementedException($"Unhandled {signingRequest.CacheOperation}");
+                }
         }
 
-        /// <summary>
-        /// Create a pre-signed HTTPS URL.
-        /// </summary>
-        /// <param name="hostname">Hostname of the SimpleCacheService. Use the value returned from CreateSigningKey's response. A rest keyword is prepended to the hostname</param>
-        /// <param name="signingRequest">The parameters used for generating a pre-signed URL</param>
-        /// <returns></returns>
-        public string CreatePresignedUrl(string hostname, SigningRequest signingRequest)
-        {
-            var jwtToken = SignAccessToken(signingRequest);
-            var cacheName = HttpUtility.UrlEncode(signingRequest.CacheName);
-            var cacheKey = HttpUtility.UrlEncode(signingRequest.CacheKey);
+        return CreateJwtToken(payload);
+    }
 
-            return signingRequest.CacheOperation switch
-            {
-                CacheOperation.GET => $"https://rest.{hostname}/cache/get/{cacheName}/{cacheKey}?token={jwtToken}",
-                CacheOperation.SET => $"https://rest.{hostname}/cache/set/{cacheName}/{cacheKey}?ttl_milliseconds={signingRequest.TtlSeconds * (ulong)1000}&token={jwtToken}",
-                _ => throw new NotImplementedException($"Unhandled {signingRequest.CacheOperation}")
-            };
+    private string CreateJwtToken(JwtPayload jwtPayload)
+    {
+        try
+        {
+            var jwtToken = new JwtSecurityToken(this.jwtHeader, jwtPayload);
+            return new JwtSecurityTokenHandler().WriteToken(jwtToken);
         }
-
-        /// <summary>
-        /// Create the signature for auth to be used in JWT.
-        /// </summary>
-        /// <param name="hostname">Hostname of the SimpleCacheService. Use the value returned from CreateSigningKey's response.</param>
-        /// <param name="signingRequest">The parameters used for generating a pre-signed URL</param>
-        /// <returns></returns>
-        public string SignAccessToken(SigningRequest signingRequest)
+        catch (Exception e)
         {
-            var payload = CommonJwtBody(signingRequest.CacheName, signingRequest.CacheKey, signingRequest.ExpiryEpochSeconds);
-            switch (signingRequest.CacheOperation)
-            {
-                case CacheOperation.GET:
-                    {
-                        payload.Add("method", new string[] { "get" });
-                        break;
-                    }
-                case CacheOperation.SET:
-                    {
-                        payload.Add("method", new string[] { "set" });
-                        payload.Add("ttl", signingRequest.TtlSeconds);
-                        break;
-                    }
-                default:
-                    {
-                        throw new NotImplementedException($"Unhandled {signingRequest.CacheOperation}");
-                    }
-            }
-
-            return CreateJwtToken(payload);
+            throw new InvalidArgumentException($"Invalid JWK alg: {jwtHeader.Alg}", e);
         }
-
-        private string CreateJwtToken(JwtPayload jwtPayload)
-        {
-            try
-            {
-                var jwtToken = new JwtSecurityToken(this.jwtHeader, jwtPayload);
-                return new JwtSecurityTokenHandler().WriteToken(jwtToken);
-            }
-            catch (Exception e)
-            {
-                throw new InvalidArgumentException($"Invalid JWK alg: {jwtHeader.Alg}", e);
-            }
-        }
+    }
 
 
-        private JwtPayload CommonJwtBody(string cacheName, string cacheKey, uint expiryEpochSeconds)
-        {
-            return new JwtPayload()
+    private JwtPayload CommonJwtBody(string cacheName, string cacheKey, uint expiryEpochSeconds)
+    {
+        return new JwtPayload()
             {
                 { "exp", expiryEpochSeconds },
                 { "cache", cacheName },
                 { "key", cacheKey }
             };
-        }
     }
 }

--- a/Momento/Requests/SigningRequest.cs
+++ b/Momento/Requests/SigningRequest.cs
@@ -1,59 +1,56 @@
-﻿using System;
-namespace MomentoSdk
+﻿namespace MomentoSdk;
+
+public enum CacheOperation
 {
-    public enum CacheOperation
+    SET,
+    GET
+};
+
+public class SigningRequest
+{
+    /// <summary>
+    /// The name of the cache.
+    /// </summary>
+    public string CacheName
     {
-        SET,
-        GET
-    };
-
-    public class SigningRequest
+        get;
+    }
+    /// <summary>
+    /// The key of the object.
+    /// </summary>
+    public string CacheKey
     {
-        /// <summary>
-        /// The name of the cache.
-        /// </summary>
-        public string CacheName
-        {
-            get;
-        }
-        /// <summary>
-        /// The key of the object.
-        /// </summary>
-        public string CacheKey
-        {
-            get;
-        }
-        /// <summary>
-        /// The operation performed on the item in the cache.
-        /// </summary>
-        public CacheOperation CacheOperation
-        {
-            get;
-        }
-        /// <summary>
-        /// The timestamp that the pre-signed URL is valid until.
-        /// </summary>
-        public uint ExpiryEpochSeconds
-        {
-            get;
-        }
-        /// <summary>
-        /// Time to Live for the item in Cache.
-        /// This is an optional property that will only be used for CacheOperation.SET
-        /// </summary>
-        public uint TtlSeconds
-        {
-            get;
-            set;
-        }
+        get;
+    }
+    /// <summary>
+    /// The operation performed on the item in the cache.
+    /// </summary>
+    public CacheOperation CacheOperation
+    {
+        get;
+    }
+    /// <summary>
+    /// The timestamp that the pre-signed URL is valid until.
+    /// </summary>
+    public uint ExpiryEpochSeconds
+    {
+        get;
+    }
+    /// <summary>
+    /// Time to Live for the item in Cache.
+    /// This is an optional property that will only be used for CacheOperation.SET
+    /// </summary>
+    public uint TtlSeconds
+    {
+        get;
+        set;
+    }
 
-        public SigningRequest(string cacheName, string cacheKey, CacheOperation cacheOperation, uint expiryEpochSeconds)
-        {
-            CacheName = cacheName;
-            CacheKey = cacheKey;
-            CacheOperation = cacheOperation;
-            ExpiryEpochSeconds = expiryEpochSeconds;
-        }
-
+    public SigningRequest(string cacheName, string cacheKey, CacheOperation cacheOperation, uint expiryEpochSeconds)
+    {
+        CacheName = cacheName;
+        CacheKey = cacheKey;
+        CacheOperation = cacheOperation;
+        ExpiryEpochSeconds = expiryEpochSeconds;
     }
 }

--- a/Momento/Responses/CacheDeleteResponse.cs
+++ b/Momento/Responses/CacheDeleteResponse.cs
@@ -1,10 +1,8 @@
-﻿using System;
-namespace MomentoSdk.Responses
+﻿namespace MomentoSdk.Responses;
+
+public class CacheDeleteResponse
 {
-    public class CacheDeleteResponse
+    public CacheDeleteResponse()
     {
-        public CacheDeleteResponse()
-        {
-        }
     }
 }

--- a/Momento/Responses/CacheGetMultiResponse.cs
+++ b/Momento/Responses/CacheGetMultiResponse.cs
@@ -1,35 +1,34 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace MomentoSdk.Responses
+namespace MomentoSdk.Responses;
+
+public class CacheGetMultiResponse
 {
-    public class CacheGetMultiResponse
+    private readonly List<CacheGetResponse> responses;
+
+    public CacheGetMultiResponse(IEnumerable<CacheGetResponse> responses)
     {
-        private readonly List<CacheGetResponse> responses;
+        this.responses = new(responses);
+    }
 
-        public CacheGetMultiResponse(IEnumerable<CacheGetResponse> responses)
-        {
-            this.responses = new(responses);
-        }
+    public List<CacheGetResponse> ToList()
+    {
+        return responses;
+    }
 
-        public List<CacheGetResponse> ToList()
-        {
-            return responses;
-        }
+    public List<CacheGetStatus> Status()
+    {
+        return responses.Select(response => response.Status).ToList();
+    }
 
-        public List<CacheGetStatus> Status()
-        {
-            return responses.Select(response => response.Status).ToList();
-        }
+    public List<string?> Strings()
+    {
+        return responses.Select(response => response.String()).ToList();
+    }
 
-        public List<string?> Strings()
-        {
-            return responses.Select(response => response.String()).ToList();
-        }
-
-        public List<byte[]?> Bytes()
-        {
-            return responses.Select(response => response.Bytes()).ToList();
-        }
+    public List<byte[]?> Bytes()
+    {
+        return responses.Select(response => response.Bytes()).ToList();
     }
 }

--- a/Momento/Responses/CacheGetResponse.cs
+++ b/Momento/Responses/CacheGetResponse.cs
@@ -3,49 +3,48 @@ using CacheClient;
 using Google.Protobuf;
 using MomentoSdk.Exceptions;
 
-namespace MomentoSdk.Responses
+namespace MomentoSdk.Responses;
+
+public class CacheGetResponse
 {
-    public class CacheGetResponse
+    public CacheGetStatus Status { get; private set; }
+    private readonly ByteString body;
+
+    public CacheGetResponse(_GetResponse response)
     {
-        public CacheGetStatus Status { get; private set; }
-        private readonly ByteString body;
-
-        public CacheGetResponse(_GetResponse response)
-        {
-            body = response.CacheBody;
-            Status = From(response.Result);
-        }
-
-        public string? String(Encoding? encoding = null)
-        {
-            encoding ??= Encoding.UTF8;
-
-            if (Status == CacheGetStatus.HIT)
-            {
-                return body.ToString(encoding);
-            }
-            return null;
-        }
-
-        public byte[]? Bytes()
-        {
-            if (Status == CacheGetStatus.HIT)
-            {
-                return body.ToByteArray();
-            }
-            return null;
-        }
-
-
-        private static CacheGetStatus From(ECacheResult result)
-        {
-            switch (result)
-            {
-                case ECacheResult.Hit: return CacheGetStatus.HIT;
-                case ECacheResult.Miss: return CacheGetStatus.MISS;
-                default: throw new InternalServerException("Invalid Cache Status.");
-            }
-        }
-
+        body = response.CacheBody;
+        Status = From(response.Result);
     }
+
+    public string? String(Encoding? encoding = null)
+    {
+        encoding ??= Encoding.UTF8;
+
+        if (Status == CacheGetStatus.HIT)
+        {
+            return body.ToString(encoding);
+        }
+        return null;
+    }
+
+    public byte[]? Bytes()
+    {
+        if (Status == CacheGetStatus.HIT)
+        {
+            return body.ToByteArray();
+        }
+        return null;
+    }
+
+
+    private static CacheGetStatus From(ECacheResult result)
+    {
+        switch (result)
+        {
+            case ECacheResult.Hit: return CacheGetStatus.HIT;
+            case ECacheResult.Miss: return CacheGetStatus.MISS;
+            default: throw new InternalServerException("Invalid Cache Status.");
+        }
+    }
+
 }

--- a/Momento/Responses/CacheGetStatus.cs
+++ b/Momento/Responses/CacheGetStatus.cs
@@ -1,8 +1,7 @@
-﻿namespace MomentoSdk.Responses
+﻿namespace MomentoSdk.Responses;
+
+public enum CacheGetStatus
 {
-    public enum CacheGetStatus
-    {
-        HIT,
-        MISS,
-    }
+    HIT,
+    MISS,
 }

--- a/Momento/Responses/CacheInfo.cs
+++ b/Momento/Responses/CacheInfo.cs
@@ -1,44 +1,43 @@
 ﻿using System;
 
-namespace MomentoSdk.Responses
+namespace MomentoSdk.Responses;
+
+public class CacheInfo : IEquatable<CacheInfo>
 {
-    public class CacheInfo : IEquatable<CacheInfo>
+    private readonly string name;
+    public CacheInfo(string cachename)
     {
-        private readonly string name;
-        public CacheInfo(string cachename)
+        name = cachename;
+    }
+
+    public string Name()
+    {
+        return name;
+    }
+
+    // override object.Equals
+    public bool Equals(CacheInfo? other)
+    {
+        if (other == null)
         {
-            name = cachename;
+            return false;
         }
 
-        public string Name()
+        return this.name == other.name;
+    }
+
+    public override bool Equals(Object? obj)
+    {
+        if (obj == null)
         {
-            return name;
+            return false;
         }
 
-        // override object.Equals
-        public bool Equals(CacheInfo? other)
-        {
-            if (other == null)
-            {
-                return false;
-            }
+        return Equals(obj as CacheInfo);
+    }
 
-            return this.name == other.name;
-        }
-
-        public override bool Equals(Object? obj)
-        {
-            if (obj == null)
-            {
-                return false;
-            }
-
-            return Equals(obj as CacheInfo);
-        }
-
-        public override int GetHashCode()
-        {
-            return name.GetHashCode();
-        }
+    public override int GetHashCode()
+    {
+        return name.GetHashCode();
     }
 }

--- a/Momento/Responses/CacheSetMultiResponse.cs
+++ b/Momento/Responses/CacheSetMultiResponse.cs
@@ -1,29 +1,28 @@
 using System.Collections.Generic;
 
-namespace MomentoSdk.Responses
+namespace MomentoSdk.Responses;
+
+public class CacheSetMultiResponse
 {
-    public class CacheSetMultiResponse
+    private readonly object items;
+
+    public CacheSetMultiResponse(IDictionary<byte[], byte[]> items)
     {
-        private readonly object items;
+        this.items = (object)items;
+    }
 
-        public CacheSetMultiResponse(IDictionary<byte[], byte[]> items)
-        {
-            this.items = (object)items;
-        }
+    public CacheSetMultiResponse(IDictionary<string, string> items)
+    {
+        this.items = (object)items;
+    }
 
-        public CacheSetMultiResponse(IDictionary<string, string> items)
-        {
-            this.items = (object)items;
-        }
+    public IDictionary<string, string> Strings()
+    {
+        return (IDictionary<string, string>)items;
+    }
 
-        public IDictionary<string, string> Strings()
-        {
-            return (IDictionary<string, string>)items;
-        }
-
-        public IDictionary<byte[], byte[]> Bytes()
-        {
-            return (IDictionary<byte[], byte[]>)items;
-        }
+    public IDictionary<byte[], byte[]> Bytes()
+    {
+        return (IDictionary<byte[], byte[]>)items;
     }
 }

--- a/Momento/Responses/CacheSetResponse.cs
+++ b/Momento/Responses/CacheSetResponse.cs
@@ -1,13 +1,12 @@
-﻿using System;
-using CacheClient;
-namespace MomentoSdk.Responses
-{
-    public class CacheSetResponse
-    {
-        public CacheSetResponse(_SetResponse response)
-        {
-        }
+﻿using CacheClient;
 
-        // TODO: Add values that were set.
+namespace MomentoSdk.Responses;
+
+public class CacheSetResponse
+{
+    public CacheSetResponse(_SetResponse response)
+    {
     }
+
+    // TODO: Add values that were set.
 }

--- a/Momento/Responses/CreateCacheResponse.cs
+++ b/Momento/Responses/CreateCacheResponse.cs
@@ -1,10 +1,8 @@
-﻿using System;
-namespace MomentoSdk.Responses
+﻿namespace MomentoSdk.Responses;
+
+public class CreateCacheResponse
 {
-    public class CreateCacheResponse
+    public CreateCacheResponse()
     {
-        public CreateCacheResponse()
-        {
-        }
     }
 }

--- a/Momento/Responses/DeleteCacheResponse.cs
+++ b/Momento/Responses/DeleteCacheResponse.cs
@@ -1,10 +1,8 @@
-﻿using System;
-namespace MomentoSdk.Responses
+﻿namespace MomentoSdk.Responses;
+
+public class DeleteCacheResponse
 {
-    public class DeleteCacheResponse
+    public DeleteCacheResponse()
     {
-        public DeleteCacheResponse()
-        {
-        }
     }
 }

--- a/Momento/Responses/ListCachesResponse.cs
+++ b/Momento/Responses/ListCachesResponse.cs
@@ -1,29 +1,29 @@
 ﻿using System.Collections.Generic;
-namespace MomentoSdk.Responses
+
+namespace MomentoSdk.Responses;
+
+public class ListCachesResponse
 {
-    public class ListCachesResponse
+    private readonly List<CacheInfo> caches;
+    private readonly string? nextPageToken;
+
+    public ListCachesResponse(ControlClient._ListCachesResponse result)
     {
-        private readonly List<CacheInfo> caches;
-        private readonly string? nextPageToken;
-
-        public ListCachesResponse(ControlClient._ListCachesResponse result)
+        nextPageToken = result.NextToken == "" ? null : result.NextToken;
+        caches = new List<CacheInfo>();
+        foreach (ControlClient._Cache c in result.Cache)
         {
-            nextPageToken = result.NextToken == "" ? null : result.NextToken;
-            caches = new List<CacheInfo>();
-            foreach (ControlClient._Cache c in result.Cache)
-            {
-                caches.Add(new CacheInfo(c.CacheName));
-            }
+            caches.Add(new CacheInfo(c.CacheName));
         }
+    }
 
-        public List<CacheInfo> Caches()
-        {
-            return caches;
-        }
+    public List<CacheInfo> Caches()
+    {
+        return caches;
+    }
 
-        public string? NextPageToken()
-        {
-            return nextPageToken;
-        }
+    public string? NextPageToken()
+    {
+        return nextPageToken;
     }
 }

--- a/Momento/ScsControlClient.cs
+++ b/Momento/ScsControlClient.cs
@@ -4,82 +4,81 @@ using MomentoSdk.Exceptions;
 using ControlClient;
 using System.Threading.Tasks;
 
-namespace MomentoSdk
+namespace MomentoSdk;
+
+internal sealed class ScsControlClient : IDisposable
 {
-    internal sealed class ScsControlClient : IDisposable
+    private readonly ControlGrpcManager grpcManager;
+    private readonly string authToken;
+    private readonly string endpoint;
+    private const uint DEADLINE_SECONDS = 60;
+
+    public ScsControlClient(string authToken, string endpoint)
     {
-        private readonly ControlGrpcManager grpcManager;
-        private readonly string authToken;
-        private readonly string endpoint;
-        private const uint DEADLINE_SECONDS = 60;
+        this.grpcManager = new ControlGrpcManager(authToken, endpoint);
+        this.authToken = authToken;
+        this.endpoint = endpoint;
+    }
 
-        public ScsControlClient(string authToken, string endpoint)
+    public CreateCacheResponse CreateCache(string cacheName)
+    {
+        CheckValidCacheName(cacheName);
+        try
         {
-            this.grpcManager = new ControlGrpcManager(authToken, endpoint);
-            this.authToken = authToken;
-            this.endpoint = endpoint;
+            _CreateCacheRequest request = new _CreateCacheRequest() { CacheName = cacheName };
+            this.grpcManager.Client().CreateCache(request, deadline: CalculateDeadline());
+            return new CreateCacheResponse();
         }
+        catch (Exception e)
+        {
+            throw CacheExceptionMapper.Convert(e);
+        }
+    }
 
-        public CreateCacheResponse CreateCache(string cacheName)
+    public DeleteCacheResponse DeleteCache(string cacheName)
+    {
+        _DeleteCacheRequest request = new _DeleteCacheRequest() { CacheName = cacheName };
+        try
         {
-            CheckValidCacheName(cacheName);
-            try
-            {
-                _CreateCacheRequest request = new _CreateCacheRequest() { CacheName = cacheName };
-                this.grpcManager.Client().CreateCache(request, deadline: CalculateDeadline());
-                return new CreateCacheResponse();
-            }
-            catch (Exception e)
-            {
-                throw CacheExceptionMapper.Convert(e);
-            }
+            this.grpcManager.Client().DeleteCache(request, deadline: CalculateDeadline());
+            return new DeleteCacheResponse();
         }
+        catch (Exception e)
+        {
+            throw CacheExceptionMapper.Convert(e);
+        }
+    }
 
-        public DeleteCacheResponse DeleteCache(string cacheName)
+    public ListCachesResponse ListCaches(string? nextPageToken = null)
+    {
+        _ListCachesRequest request = new _ListCachesRequest() { NextToken = nextPageToken == null ? "" : nextPageToken };
+        try
         {
-            _DeleteCacheRequest request = new _DeleteCacheRequest() { CacheName = cacheName };
-            try
-            {
-                this.grpcManager.Client().DeleteCache(request, deadline: CalculateDeadline());
-                return new DeleteCacheResponse();
-            }
-            catch (Exception e)
-            {
-                throw CacheExceptionMapper.Convert(e);
-            }
+            ControlClient._ListCachesResponse result = this.grpcManager.Client().ListCaches(request, deadline: CalculateDeadline());
+            return new ListCachesResponse(result);
         }
+        catch (Exception e)
+        {
+            throw CacheExceptionMapper.Convert(e);
+        }
+    }
 
-        public ListCachesResponse ListCaches(string? nextPageToken = null)
+    private bool CheckValidCacheName(string cacheName)
+    {
+        if (string.IsNullOrWhiteSpace(cacheName))
         {
-            _ListCachesRequest request = new _ListCachesRequest() { NextToken = nextPageToken == null ? "" : nextPageToken };
-            try
-            {
-                ControlClient._ListCachesResponse result = this.grpcManager.Client().ListCaches(request, deadline: CalculateDeadline());
-                return new ListCachesResponse(result);
-            }
-            catch (Exception e)
-            {
-                throw CacheExceptionMapper.Convert(e);
-            }
+            throw new InvalidArgumentException("Cache name must be nonempty");
         }
+        return true;
+    }
 
-        private bool CheckValidCacheName(string cacheName)
-        {
-            if (string.IsNullOrWhiteSpace(cacheName))
-            {
-                throw new InvalidArgumentException("Cache name must be nonempty");
-            }
-            return true;
-        }
+    private DateTime CalculateDeadline()
+    {
+        return DateTime.UtcNow.AddSeconds(DEADLINE_SECONDS);
+    }
 
-        private DateTime CalculateDeadline()
-        {
-            return DateTime.UtcNow.AddSeconds(DEADLINE_SECONDS);
-        }
-
-        public void Dispose()
-        {
-            this.grpcManager.Dispose();
-        }
+    public void Dispose()
+    {
+        this.grpcManager.Dispose();
     }
 }

--- a/Momento/SimpleCacheClient.cs
+++ b/Momento/SimpleCacheClient.cs
@@ -5,656 +5,655 @@ using MomentoSdk.Responses;
 using MomentoSdk.Exceptions;
 using System.Collections.Generic;
 
-namespace MomentoSdk
+namespace MomentoSdk;
+
+public class SimpleCacheClient : IDisposable
 {
-    public class SimpleCacheClient : IDisposable
+    private readonly ScsControlClient controlClient;
+    private readonly ScsDataClient dataClient;
+
+    /// <summary>
+    /// Client to perform operations against the Simple Cache Service.
+    /// </summary>
+    /// <param name="authToken">Momento JWT.</param>
+    /// <param name="defaultTtlSeconds">Default time to live for the item in cache.</param>
+    /// <param name="dataClientOperationTimeoutMilliseconds">Deadline (timeout) for communicating to the server. Defaults to 5 seconds.</param>
+    public SimpleCacheClient(string authToken, uint defaultTtlSeconds, uint? dataClientOperationTimeoutMilliseconds = null)
     {
-        private readonly ScsControlClient controlClient;
-        private readonly ScsDataClient dataClient;
+        ValidateRequestTimeout(dataClientOperationTimeoutMilliseconds);
+        Claims claims = JwtUtils.DecodeJwt(authToken);
+        string controlEndpoint = "https://" + claims.ControlEndpoint + ":443";
+        string cacheEndpoint = "https://" + claims.CacheEndpoint + ":443";
+        ScsControlClient controlClient = new ScsControlClient(authToken, controlEndpoint);
+        ScsDataClient dataClient = new ScsDataClient(authToken, cacheEndpoint, defaultTtlSeconds, dataClientOperationTimeoutMilliseconds);
+        this.controlClient = controlClient;
+        this.dataClient = dataClient;
+    }
 
-        /// <summary>
-        /// Client to perform operations against the Simple Cache Service.
-        /// </summary>
-        /// <param name="authToken">Momento JWT.</param>
-        /// <param name="defaultTtlSeconds">Default time to live for the item in cache.</param>
-        /// <param name="dataClientOperationTimeoutMilliseconds">Deadline (timeout) for communicating to the server. Defaults to 5 seconds.</param>
-        public SimpleCacheClient(string authToken, uint defaultTtlSeconds, uint? dataClientOperationTimeoutMilliseconds = null)
+    /// <summary>
+    /// Creates a cache if it doesn't exist.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to be created.</param>
+    /// <returns>The result of the create cache operation</returns>
+    public CreateCacheResponse CreateCache(string cacheName)
+    {
+        if (cacheName == null)
         {
-            ValidateRequestTimeout(dataClientOperationTimeoutMilliseconds);
-            Claims claims = JwtUtils.DecodeJwt(authToken);
-            string controlEndpoint = "https://" + claims.ControlEndpoint + ":443";
-            string cacheEndpoint = "https://" + claims.CacheEndpoint + ":443";
-            ScsControlClient controlClient = new ScsControlClient(authToken, controlEndpoint);
-            ScsDataClient dataClient = new ScsDataClient(authToken, cacheEndpoint, defaultTtlSeconds, dataClientOperationTimeoutMilliseconds);
-            this.controlClient = controlClient;
-            this.dataClient = dataClient;
+            throw new ArgumentNullException(nameof(cacheName));
+        }
+        return this.controlClient.CreateCache(cacheName);
+    }
+
+    /// <summary>
+    /// Deletes a cache and all of the items within it.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to be deleted.</param>
+    /// <returns>The result of the delete cache operation.</returns>
+    public DeleteCacheResponse DeleteCache(string cacheName)
+    {
+        if (cacheName == null)
+        {
+            throw new ArgumentNullException(nameof(cacheName));
+        }
+        return this.controlClient.DeleteCache(cacheName);
+    }
+
+    /// <summary>
+    /// List all caches.
+    /// </summary>
+    /// <param name="nextPageToken">A token to specify where to start paginating. This is the NextToken from a previous response.</param>
+    /// <returns>The result of the list cache operation.</returns>
+    public ListCachesResponse ListCaches(string? nextPageToken = null)
+    {
+        return this.controlClient.ListCaches(nextPageToken);
+    }
+
+    /// <summary>
+    /// Sets the value in cache with a given time to live (TTL) seconds.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to store the item in.</param>
+    /// <param name="key">The key to set.</param>
+    /// <param name="value">The value to be stored.</param>
+    /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
+    /// <returns>Future containing the result of the set operation.</returns>
+    public async Task<CacheSetResponse> SetAsync(string cacheName, byte[] key, byte[] value, uint? ttlSeconds = null)
+    {
+        if (cacheName == null)
+        {
+            throw new ArgumentNullException(nameof(cacheName));
+        }
+        if (key == null)
+        {
+            throw new ArgumentNullException(nameof(key));
+        }
+        if (value == null)
+        {
+            throw new ArgumentNullException(nameof(value));
         }
 
-        /// <summary>
-        /// Creates a cache if it doesn't exist.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to be created.</param>
-        /// <returns>The result of the create cache operation</returns>
-        public CreateCacheResponse CreateCache(string cacheName)
+        return await this.dataClient.SetAsync(cacheName, key, value, ttlSeconds);
+    }
+
+    /// <summary>
+    /// Get the cache value stored for the given key.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+    /// <param name="key">The key to lookup.</param>
+    /// <returns>Future with CacheGetResponse containing the status of the get operation and the associated value data.</returns>
+    public async Task<CacheGetResponse> GetAsync(string cacheName, byte[] key)
+    {
+        if (cacheName == null)
         {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            return this.controlClient.CreateCache(cacheName);
+            throw new ArgumentNullException(nameof(cacheName));
+        }
+        if (key == null)
+        {
+            throw new ArgumentNullException(nameof(key));
         }
 
-        /// <summary>
-        /// Deletes a cache and all of the items within it.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to be deleted.</param>
-        /// <returns>The result of the delete cache operation.</returns>
-        public DeleteCacheResponse DeleteCache(string cacheName)
+        return await this.dataClient.GetAsync(cacheName, key);
+    }
+
+    /// <summary>
+    /// Remove the key from the cache.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to delete the key from.</param>
+    /// <param name="key">The key to delete.</param>
+    /// <returns>Future containing the result of the delete operation.</returns>
+    public async Task<CacheDeleteResponse> DeleteAsync(string cacheName, byte[] key)
+    {
+        if (cacheName == null)
         {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            return this.controlClient.DeleteCache(cacheName);
+            throw new ArgumentNullException(nameof(cacheName));
+        }
+        if (key == null)
+        {
+            throw new ArgumentNullException(nameof(key));
         }
 
-        /// <summary>
-        /// List all caches.
-        /// </summary>
-        /// <param name="nextPageToken">A token to specify where to start paginating. This is the NextToken from a previous response.</param>
-        /// <returns>The result of the list cache operation.</returns>
-        public ListCachesResponse ListCaches(string? nextPageToken = null)
+        return await this.dataClient.DeleteAsync(cacheName, key);
+    }
+
+    /// <summary>
+    /// Sets the value in cache with a given time to live (TTL) seconds.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to store the item in.</param>
+    /// <param name="key">The key to set.</param>
+    /// <param name="value">The value to be stored.</param>
+    /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
+    /// <returns>Future containing the result of the set operation</returns>
+    public async Task<CacheSetResponse> SetAsync(string cacheName, string key, string value, uint? ttlSeconds = null)
+    {
+        if (cacheName == null)
         {
-            return this.controlClient.ListCaches(nextPageToken);
+            throw new ArgumentNullException(nameof(cacheName));
+        }
+        if (key == null)
+        {
+            throw new ArgumentNullException(nameof(key));
+        }
+        if (value == null)
+        {
+            throw new ArgumentNullException(nameof(value));
         }
 
-        /// <summary>
-        /// Sets the value in cache with a given time to live (TTL) seconds.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to store the item in.</param>
-        /// <param name="key">The key to set.</param>
-        /// <param name="value">The value to be stored.</param>
-        /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-        /// <returns>Future containing the result of the set operation.</returns>
-        public async Task<CacheSetResponse> SetAsync(string cacheName, byte[] key, byte[] value, uint? ttlSeconds = null)
-        {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
+        return await this.dataClient.SetAsync(cacheName, key, value, ttlSeconds);
+    }
 
-            return await this.dataClient.SetAsync(cacheName, key, value, ttlSeconds);
+    /// <summary>
+    /// Get the cache value stored for the given key.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+    /// <param name="key">The key to lookup.</param>
+    /// <returns>Future with CacheGetResponse containing the status of the get operation and the associated value data</returns>
+    public async Task<CacheGetResponse> GetAsync(string cacheName, string key)
+    {
+        if (cacheName == null)
+        {
+            throw new ArgumentNullException(nameof(cacheName));
+        }
+        if (key == null)
+        {
+            throw new ArgumentNullException(nameof(key));
         }
 
-        /// <summary>
-        /// Get the cache value stored for the given key.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-        /// <param name="key">The key to lookup.</param>
-        /// <returns>Future with CacheGetResponse containing the status of the get operation and the associated value data.</returns>
-        public async Task<CacheGetResponse> GetAsync(string cacheName, byte[] key)
-        {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
+        return await this.dataClient.GetAsync(cacheName, key);
+    }
 
-            return await this.dataClient.GetAsync(cacheName, key);
+    /// <summary>
+    /// Remove the key from the cache.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to delete the key from.</param>
+    /// <param name="key">The key to delete.</param>
+    /// <returns>Future containing the result of the delete operation.</returns>
+    public async Task<CacheDeleteResponse> DeleteAsync(string cacheName, string key)
+    {
+        if (cacheName == null)
+        {
+            throw new ArgumentNullException(nameof(cacheName));
+        }
+        if (key == null)
+        {
+            throw new ArgumentNullException(nameof(key));
         }
 
-        /// <summary>
-        /// Remove the key from the cache.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to delete the key from.</param>
-        /// <param name="key">The key to delete.</param>
-        /// <returns>Future containing the result of the delete operation.</returns>
-        public async Task<CacheDeleteResponse> DeleteAsync(string cacheName, byte[] key)
-        {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
+        return await this.dataClient.DeleteAsync(cacheName, key);
+    }
 
-            return await this.dataClient.DeleteAsync(cacheName, key);
+    /// <summary>
+    /// Sets the value in cache with a given time to live (TTL) seconds.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to store the item in.</param>
+    /// <param name="key">The key to set.</param>
+    /// <param name="value">The value to be stored.</param>
+    /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
+    /// <returns>Future containing the result of the set operation</returns>
+    public async Task<CacheSetResponse> SetAsync(string cacheName, string key, byte[] value, uint? ttlSeconds = null)
+    {
+        if (cacheName == null)
+        {
+            throw new ArgumentNullException(nameof(cacheName));
+        }
+        if (key == null)
+        {
+            throw new ArgumentNullException(nameof(key));
+        }
+        if (value == null)
+        {
+            throw new ArgumentNullException(nameof(value));
         }
 
-        /// <summary>
-        /// Sets the value in cache with a given time to live (TTL) seconds.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to store the item in.</param>
-        /// <param name="key">The key to set.</param>
-        /// <param name="value">The value to be stored.</param>
-        /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-        /// <returns>Future containing the result of the set operation</returns>
-        public async Task<CacheSetResponse> SetAsync(string cacheName, string key, string value, uint? ttlSeconds = null)
-        {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
+        return await this.dataClient.SetAsync(cacheName, key, value, ttlSeconds);
+    }
 
-            return await this.dataClient.SetAsync(cacheName, key, value, ttlSeconds);
+    /// <summary>
+    /// Gets multiple values from the cache.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+    /// <param name="keys">The keys to get.</param>
+    /// <returns>Future with CacheGetMultiResponse containing the status of the get operation and the associated value data.</returns>
+    public async Task<CacheGetMultiResponse> GetMultiAsync(string cacheName, IEnumerable<byte[]> keys)
+    {
+        if (cacheName == null)
+        {
+            throw new ArgumentNullException(nameof(cacheName));
+        }
+        if (keys == null)
+        {
+            throw new ArgumentNullException(nameof(keys));
+        }
+        if (keys.Any(key => key == null))
+        {
+            throw new ArgumentNullException(nameof(keys), "Each key must be non-null");
         }
 
-        /// <summary>
-        /// Get the cache value stored for the given key.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-        /// <param name="key">The key to lookup.</param>
-        /// <returns>Future with CacheGetResponse containing the status of the get operation and the associated value data</returns>
-        public async Task<CacheGetResponse> GetAsync(string cacheName, string key)
-        {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
+        return await this.dataClient.GetMultiAsync(cacheName, keys);
+    }
 
-            return await this.dataClient.GetAsync(cacheName, key);
+    /// <summary>
+    /// Gets multiple values from the cache.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+    /// <param name="keys">The keys to get.</param>
+    /// <returns>Future with CacheGetMultiResponse containing the status of the get operation and the associated value data.</returns>
+    public async Task<CacheGetMultiResponse> GetMultiAsync(string cacheName, IEnumerable<string> keys)
+    {
+        if (cacheName == null)
+        {
+            throw new ArgumentNullException(nameof(cacheName));
+        }
+        if (keys == null)
+        {
+            throw new ArgumentNullException(nameof(keys));
+        }
+        if (keys.Any(key => key == null))
+        {
+            throw new ArgumentNullException(nameof(keys), "Each key must be non-null");
         }
 
-        /// <summary>
-        /// Remove the key from the cache.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to delete the key from.</param>
-        /// <param name="key">The key to delete.</param>
-        /// <returns>Future containing the result of the delete operation.</returns>
-        public async Task<CacheDeleteResponse> DeleteAsync(string cacheName, string key)
-        {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
 
-            return await this.dataClient.DeleteAsync(cacheName, key);
+        return await this.dataClient.GetMultiAsync(cacheName, keys);
+    }
+
+    /// <summary>
+    /// Gets multiple values from the cache.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+    /// <param name="keys">The keys to get.</param>
+    /// <returns>Future with CacheGetMultiResponse containing the status of the get operation and the associated value data.</returns>
+    public async Task<CacheGetMultiResponse> GetMultiAsync(string cacheName, params byte[][] keys)
+    {
+        if (cacheName == null)
+        {
+            throw new ArgumentNullException(nameof(cacheName));
+        }
+        if (keys == null)
+        {
+            throw new ArgumentNullException(nameof(keys));
+        }
+        if (keys.Any(key => key == null))
+        {
+            throw new ArgumentNullException(nameof(keys), "Each key must be non-null");
         }
 
-        /// <summary>
-        /// Sets the value in cache with a given time to live (TTL) seconds.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to store the item in.</param>
-        /// <param name="key">The key to set.</param>
-        /// <param name="value">The value to be stored.</param>
-        /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-        /// <returns>Future containing the result of the set operation</returns>
-        public async Task<CacheSetResponse> SetAsync(string cacheName, string key, byte[] value, uint? ttlSeconds = null)
-        {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
+        return await this.dataClient.GetMultiAsync(cacheName, keys);
+    }
 
-            return await this.dataClient.SetAsync(cacheName, key, value, ttlSeconds);
+    /// <summary>
+    /// Gets multiple values from the cache.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+    /// <param name="keys">The keys to get.</param>
+    /// <returns>Future with CacheGetMultiResponse containing the status of the get operation and the associated value data.</returns>
+    public async Task<CacheGetMultiResponse> GetMultiAsync(string cacheName, params string[] keys)
+    {
+        if (cacheName == null)
+        {
+            throw new ArgumentNullException(nameof(cacheName));
+        }
+        if (keys == null || keys.Any(key => key == null))
+        {
+            throw new ArgumentNullException(nameof(keys));
+        }
+        if (keys.Any(key => key == null))
+        {
+            throw new ArgumentNullException(nameof(keys), "Each key must be non-null");
         }
 
-        /// <summary>
-        /// Gets multiple values from the cache.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-        /// <param name="keys">The keys to get.</param>
-        /// <returns>Future with CacheGetMultiResponse containing the status of the get operation and the associated value data.</returns>
-        public async Task<CacheGetMultiResponse> GetMultiAsync(string cacheName, IEnumerable<byte[]> keys)
-        {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (keys == null)
-            {
-                throw new ArgumentNullException(nameof(keys));
-            }
-            if (keys.Any(key => key == null))
-            {
-                throw new ArgumentNullException(nameof(keys), "Each key must be non-null");
-            }
+        return await this.dataClient.GetMultiAsync(cacheName, keys);
+    }
 
-            return await this.dataClient.GetMultiAsync(cacheName, keys);
+    /// <summary>
+    /// Stores multiple items in the cache. Overwrites existing items.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to store the items in.</param>
+    /// <param name="items">The items to set.</param>
+    /// <returns>Future with CacheSetMultiResponse containing the data set.</returns>
+    public async Task<CacheSetMultiResponse> SetMultiAsync(string cacheName, IDictionary<byte[], byte[]> items, uint? ttlSeconds = null)
+    {
+        if (cacheName == null)
+        {
+            throw new ArgumentNullException(nameof(cacheName));
+        }
+        if (items == null)
+        {
+            throw new ArgumentNullException(nameof(items));
+        }
+        if (items.Values.Any(value => value == null))
+        {
+            throw new ArgumentNullException(nameof(items), "Each value must be non-null");
         }
 
-        /// <summary>
-        /// Gets multiple values from the cache.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-        /// <param name="keys">The keys to get.</param>
-        /// <returns>Future with CacheGetMultiResponse containing the status of the get operation and the associated value data.</returns>
-        public async Task<CacheGetMultiResponse> GetMultiAsync(string cacheName, IEnumerable<string> keys)
+        await this.dataClient.SetMultiAsync(cacheName, items, ttlSeconds);
+        return new CacheSetMultiResponse(items);
+    }
+
+    /// <summary>
+    /// Stores multiple items in the cache. Overwrites existing items.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to store the items in.</param>
+    /// <param name="items">The items to set.</param>
+    /// <returns>Future with CacheSetMultiResponse containing the data set.</returns>
+    public async Task<CacheSetMultiResponse> SetMultiAsync(string cacheName, IDictionary<string, string> items, uint? ttlSeconds = null)
+    {
+        if (cacheName == null)
         {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (keys == null)
-            {
-                throw new ArgumentNullException(nameof(keys));
-            }
-            if (keys.Any(key => key == null))
-            {
-                throw new ArgumentNullException(nameof(keys), "Each key must be non-null");
-            }
-
-
-            return await this.dataClient.GetMultiAsync(cacheName, keys);
+            throw new ArgumentNullException(nameof(cacheName));
+        }
+        if (items == null)
+        {
+            throw new ArgumentNullException(nameof(items));
+        }
+        if (items.Values.Any(value => value == null))
+        {
+            throw new ArgumentNullException(nameof(items), "Each value must be non-null");
         }
 
-        /// <summary>
-        /// Gets multiple values from the cache.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-        /// <param name="keys">The keys to get.</param>
-        /// <returns>Future with CacheGetMultiResponse containing the status of the get operation and the associated value data.</returns>
-        public async Task<CacheGetMultiResponse> GetMultiAsync(string cacheName, params byte[][] keys)
-        {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (keys == null)
-            {
-                throw new ArgumentNullException(nameof(keys));
-            }
-            if (keys.Any(key => key == null))
-            {
-                throw new ArgumentNullException(nameof(keys), "Each key must be non-null");
-            }
+        await this.dataClient.SetMultiAsync(cacheName, items, ttlSeconds);
+        return new CacheSetMultiResponse(items);
+    }
 
-            return await this.dataClient.GetMultiAsync(cacheName, keys);
+    /// <summary>
+    ///  Sets the value in the cache. If a value for this key is already present it will be replaced by the new value.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to store the item in.</param>
+    /// <param name="key">The key to set.</param>
+    /// <param name="value">The value to be stored.</param>
+    /// <param name="ttlSeconds">Time to live (TTL) for the item in Cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
+    /// <returns>Result of the set operation</returns>
+    public CacheSetResponse Set(string cacheName, byte[] key, byte[] value, uint? ttlSeconds = null)
+    {
+        if (cacheName == null)
+        {
+            throw new ArgumentNullException(nameof(cacheName));
+        }
+        if (key == null)
+        {
+            throw new ArgumentNullException(nameof(key));
+        }
+        if (value == null)
+        {
+            throw new ArgumentNullException(nameof(value));
         }
 
-        /// <summary>
-        /// Gets multiple values from the cache.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-        /// <param name="keys">The keys to get.</param>
-        /// <returns>Future with CacheGetMultiResponse containing the status of the get operation and the associated value data.</returns>
-        public async Task<CacheGetMultiResponse> GetMultiAsync(string cacheName, params string[] keys)
-        {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (keys == null || keys.Any(key => key == null))
-            {
-                throw new ArgumentNullException(nameof(keys));
-            }
-            if (keys.Any(key => key == null))
-            {
-                throw new ArgumentNullException(nameof(keys), "Each key must be non-null");
-            }
+        return this.dataClient.Set(cacheName, key, value, ttlSeconds);
+    }
 
-            return await this.dataClient.GetMultiAsync(cacheName, keys);
+    /// <summary>
+    /// Get the cache value stored for the given key.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+    /// <param name="key">The key to lookup.</param>
+    /// <returns>CacheGetResponse containing the status of the get operation and the associated value data.</returns>
+    public CacheGetResponse Get(string cacheName, byte[] key)
+    {
+        if (cacheName == null)
+        {
+            throw new ArgumentNullException(nameof(cacheName));
+        }
+        if (key == null)
+        {
+            throw new ArgumentNullException(nameof(key));
         }
 
-        /// <summary>
-        /// Stores multiple items in the cache. Overwrites existing items.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to store the items in.</param>
-        /// <param name="items">The items to set.</param>
-        /// <returns>Future with CacheSetMultiResponse containing the data set.</returns>
-        public async Task<CacheSetMultiResponse> SetMultiAsync(string cacheName, IDictionary<byte[], byte[]> items, uint? ttlSeconds = null)
-        {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (items == null)
-            {
-                throw new ArgumentNullException(nameof(items));
-            }
-            if (items.Values.Any(value => value == null))
-            {
-                throw new ArgumentNullException(nameof(items), "Each value must be non-null");
-            }
+        return this.dataClient.Get(cacheName, key);
+    }
 
-            await this.dataClient.SetMultiAsync(cacheName, items, ttlSeconds);
-            return new CacheSetMultiResponse(items);
+    /// <summary>
+    /// Remove the key from the cache.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to delete the key from.</param>
+    /// <param name="key">The key to delete.</param>
+    /// <returns>Future containing the result of the delete operation.</returns>
+    public CacheDeleteResponse Delete(string cacheName, byte[] key)
+    {
+        if (cacheName == null)
+        {
+            throw new ArgumentNullException(nameof(cacheName));
+        }
+        if (key == null)
+        {
+            throw new ArgumentNullException(nameof(key));
         }
 
-        /// <summary>
-        /// Stores multiple items in the cache. Overwrites existing items.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to store the items in.</param>
-        /// <param name="items">The items to set.</param>
-        /// <returns>Future with CacheSetMultiResponse containing the data set.</returns>
-        public async Task<CacheSetMultiResponse> SetMultiAsync(string cacheName, IDictionary<string, string> items, uint? ttlSeconds = null)
-        {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (items == null)
-            {
-                throw new ArgumentNullException(nameof(items));
-            }
-            if (items.Values.Any(value => value == null))
-            {
-                throw new ArgumentNullException(nameof(items), "Each value must be non-null");
-            }
+        return this.dataClient.Delete(cacheName, key);
+    }
 
-            await this.dataClient.SetMultiAsync(cacheName, items, ttlSeconds);
-            return new CacheSetMultiResponse(items);
+    /// <summary>
+    /// Sets the value in cache with a given time to live (TTL) seconds. If a value for this key is already present it will be replaced by the new value.
+    /// </summary>
+    /// <param name="key">The key to set.</param>
+    /// <param name="value">The value to be stored.</param>
+    /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
+    /// <returns>Result of the set operation.</returns>
+    public CacheSetResponse Set(string cacheName, string key, string value, uint? ttlSeconds = null)
+    {
+        if (cacheName == null)
+        {
+            throw new ArgumentNullException(nameof(cacheName));
+        }
+        if (key == null)
+        {
+            throw new ArgumentNullException(nameof(key));
+        }
+        if (value == null)
+        {
+            throw new ArgumentNullException(nameof(value));
         }
 
-        /// <summary>
-        ///  Sets the value in the cache. If a value for this key is already present it will be replaced by the new value.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to store the item in.</param>
-        /// <param name="key">The key to set.</param>
-        /// <param name="value">The value to be stored.</param>
-        /// <param name="ttlSeconds">Time to live (TTL) for the item in Cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-        /// <returns>Result of the set operation</returns>
-        public CacheSetResponse Set(string cacheName, byte[] key, byte[] value, uint? ttlSeconds = null)
-        {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
+        return this.dataClient.Set(cacheName, key, value, ttlSeconds);
+    }
 
-            return this.dataClient.Set(cacheName, key, value, ttlSeconds);
+    /// <summary>
+    /// Get the cache value stored for the given key.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+    /// <param name="key">The key to lookup.</param>
+    /// <returns>CacheGetResponse containing the status of the get operation and the associated value data.</returns>
+    public CacheGetResponse Get(string cacheName, string key)
+    {
+        if (cacheName == null)
+        {
+            throw new ArgumentNullException(nameof(cacheName));
+        }
+        if (key == null)
+        {
+            throw new ArgumentNullException(nameof(key));
         }
 
-        /// <summary>
-        /// Get the cache value stored for the given key.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-        /// <param name="key">The key to lookup.</param>
-        /// <returns>CacheGetResponse containing the status of the get operation and the associated value data.</returns>
-        public CacheGetResponse Get(string cacheName, byte[] key)
-        {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
+        return this.dataClient.Get(cacheName, key);
+    }
 
-            return this.dataClient.Get(cacheName, key);
+    /// <summary>
+    /// Gets multiple values from the cache.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+    /// <param name="keys">The keys to get.</param>
+    /// <returns>Response object with the status of the get operation and the associated value data.</returns>
+    public CacheGetMultiResponse GetMulti(string cacheName, IEnumerable<byte[]> keys)
+    {
+        try
+        {
+            return GetMultiAsync(cacheName, keys).Result;
+        }
+        catch (AggregateException e)
+        {
+            throw e.GetBaseException();
+        }
+    }
+
+    /// <summary>
+    /// Gets multiple values from the cache.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+    /// <param name="keys">The keys to get.</param>
+    /// <returns>Response object with the status of the get operation and the associated value data.</returns>
+    public CacheGetMultiResponse GetMulti(string cacheName, IEnumerable<string> keys)
+    {
+        try
+        {
+            return GetMultiAsync(cacheName, keys).Result;
+        }
+        catch (AggregateException e)
+        {
+            throw e.GetBaseException();
+        }
+    }
+
+    /// <summary>
+    /// Gets multiple values from the cache.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+    /// <param name="keys">The keys to get.</param>
+    /// <returns>Future with CacheGetMultiResponse containing the status of the get operation and the associated value data.</returns>
+    public CacheGetMultiResponse GetMulti(string cacheName, params byte[][] keys)
+    {
+        try
+        {
+            return GetMultiAsync(cacheName, keys).Result;
+        }
+        catch (AggregateException e)
+        {
+            throw e.GetBaseException();
+        }
+    }
+
+    /// <summary>
+    /// Gets multiple values from the cache.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+    /// <param name="keys">The keys to get.</param>
+    /// <returns>Future with CacheGetMultiResponse containing the status of the get operation and the associated value data.</returns>
+    public CacheGetMultiResponse GetMulti(string cacheName, params string[] keys)
+    {
+        try
+        {
+            return GetMultiAsync(cacheName, keys).Result;
+        }
+        catch (AggregateException e)
+        {
+            throw e.GetBaseException();
+        }
+    }
+
+    /// <summary>
+    /// Stores multiple items in the cache. Overwrites existing items.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to store the items in.</param>
+    /// <param name="items">The items to set.</param>
+    /// <returns>Future with CacheSetMultiResponse containing the data set.</returns>
+    public CacheSetMultiResponse SetMulti(string cacheName, IDictionary<byte[], byte[]> items, uint? ttlSeconds = null)
+    {
+        try
+        {
+            return SetMultiAsync(cacheName, items, ttlSeconds).Result;
+        }
+        catch (AggregateException e)
+        {
+            throw e.GetBaseException();
+        }
+    }
+
+    /// <summary>
+    /// Stores multiple items in the cache. Overwrites existing items.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to store the items in.</param>
+    /// <param name="items">The items to set.</param>
+    /// <returns>Future with CacheSetMultiResponse containing the data set.</returns>
+    public CacheSetMultiResponse SetMulti(string cacheName, IDictionary<string, string> items, uint? ttlSeconds = null)
+    {
+        try
+        {
+            return SetMultiAsync(cacheName, items, ttlSeconds).Result;
+        }
+        catch (AggregateException e)
+        {
+            throw e.GetBaseException();
+        }
+    }
+
+    /// <summary>
+    /// Remove the key from the cache.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to delete the key from.</param>
+    /// <param name="key">The key to delete.</param>
+    /// <returns>Future containing the result of the delete operation.</returns>
+    public CacheDeleteResponse Delete(string cacheName, string key)
+    {
+        if (cacheName == null)
+        {
+            throw new ArgumentNullException(nameof(cacheName));
+        }
+        if (key == null)
+        {
+            throw new ArgumentNullException(nameof(key));
         }
 
-        /// <summary>
-        /// Remove the key from the cache.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to delete the key from.</param>
-        /// <param name="key">The key to delete.</param>
-        /// <returns>Future containing the result of the delete operation.</returns>
-        public CacheDeleteResponse Delete(string cacheName, byte[] key)
-        {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
+        return this.dataClient.Delete(cacheName, key);
+    }
 
-            return this.dataClient.Delete(cacheName, key);
+    /// <summary>
+    /// Sets the value in cache with a given time to live (TTL) seconds. If a value for this key is already present it will be replaced by the new value.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to store the item in.</param>
+    /// <param name="key">The key to set.</param>
+    /// <param name="value">The value to be stored.</param>
+    /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
+    /// <returns>Result of the set operation</returns>
+    public CacheSetResponse Set(string cacheName, string key, byte[] value, uint? ttlSeconds = null)
+    {
+        if (cacheName == null)
+        {
+            throw new ArgumentNullException(nameof(cacheName));
+        }
+        if (key == null)
+        {
+            throw new ArgumentNullException(nameof(key));
+        }
+        if (value == null)
+        {
+            throw new ArgumentNullException(nameof(key));
         }
 
-        /// <summary>
-        /// Sets the value in cache with a given time to live (TTL) seconds. If a value for this key is already present it will be replaced by the new value.
-        /// </summary>
-        /// <param name="key">The key to set.</param>
-        /// <param name="value">The value to be stored.</param>
-        /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-        /// <returns>Result of the set operation.</returns>
-        public CacheSetResponse Set(string cacheName, string key, string value, uint? ttlSeconds = null)
-        {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
+        return this.dataClient.Set(cacheName, key, value, ttlSeconds);
+    }
 
-            return this.dataClient.Set(cacheName, key, value, ttlSeconds);
+    public void Dispose()
+    {
+        this.controlClient.Dispose();
+        this.dataClient.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private void ValidateRequestTimeout(uint? requestTimeoutMilliseconds = null)
+    {
+        if (requestTimeoutMilliseconds == null)
+        {
+            return;
         }
-
-        /// <summary>
-        /// Get the cache value stored for the given key.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-        /// <param name="key">The key to lookup.</param>
-        /// <returns>CacheGetResponse containing the status of the get operation and the associated value data.</returns>
-        public CacheGetResponse Get(string cacheName, string key)
+        if (requestTimeoutMilliseconds == 0)
         {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-
-            return this.dataClient.Get(cacheName, key);
-        }
-
-        /// <summary>
-        /// Gets multiple values from the cache.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-        /// <param name="keys">The keys to get.</param>
-        /// <returns>Response object with the status of the get operation and the associated value data.</returns>
-        public CacheGetMultiResponse GetMulti(string cacheName, IEnumerable<byte[]> keys)
-        {
-            try
-            {
-                return GetMultiAsync(cacheName, keys).Result;
-            }
-            catch (AggregateException e)
-            {
-                throw e.GetBaseException();
-            }
-        }
-
-        /// <summary>
-        /// Gets multiple values from the cache.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-        /// <param name="keys">The keys to get.</param>
-        /// <returns>Response object with the status of the get operation and the associated value data.</returns>
-        public CacheGetMultiResponse GetMulti(string cacheName, IEnumerable<string> keys)
-        {
-            try
-            {
-                return GetMultiAsync(cacheName, keys).Result;
-            }
-            catch (AggregateException e)
-            {
-                throw e.GetBaseException();
-            }
-        }
-
-        /// <summary>
-        /// Gets multiple values from the cache.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-        /// <param name="keys">The keys to get.</param>
-        /// <returns>Future with CacheGetMultiResponse containing the status of the get operation and the associated value data.</returns>
-        public CacheGetMultiResponse GetMulti(string cacheName, params byte[][] keys)
-        {
-            try
-            {
-                return GetMultiAsync(cacheName, keys).Result;
-            }
-            catch (AggregateException e)
-            {
-                throw e.GetBaseException();
-            }
-        }
-
-        /// <summary>
-        /// Gets multiple values from the cache.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-        /// <param name="keys">The keys to get.</param>
-        /// <returns>Future with CacheGetMultiResponse containing the status of the get operation and the associated value data.</returns>
-        public CacheGetMultiResponse GetMulti(string cacheName, params string[] keys)
-        {
-            try
-            {
-                return GetMultiAsync(cacheName, keys).Result;
-            }
-            catch (AggregateException e)
-            {
-                throw e.GetBaseException();
-            }
-        }
-
-        /// <summary>
-        /// Stores multiple items in the cache. Overwrites existing items.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to store the items in.</param>
-        /// <param name="items">The items to set.</param>
-        /// <returns>Future with CacheSetMultiResponse containing the data set.</returns>
-        public CacheSetMultiResponse SetMulti(string cacheName, IDictionary<byte[], byte[]> items, uint? ttlSeconds = null)
-        {
-            try
-            {
-                return SetMultiAsync(cacheName, items, ttlSeconds).Result;
-            }
-            catch (AggregateException e)
-            {
-                throw e.GetBaseException();
-            }
-        }
-
-        /// <summary>
-        /// Stores multiple items in the cache. Overwrites existing items.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to store the items in.</param>
-        /// <param name="items">The items to set.</param>
-        /// <returns>Future with CacheSetMultiResponse containing the data set.</returns>
-        public CacheSetMultiResponse SetMulti(string cacheName, IDictionary<string, string> items, uint? ttlSeconds = null)
-        {
-            try
-            {
-                return SetMultiAsync(cacheName, items, ttlSeconds).Result;
-            }
-            catch (AggregateException e)
-            {
-                throw e.GetBaseException();
-            }
-        }
-
-        /// <summary>
-        /// Remove the key from the cache.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to delete the key from.</param>
-        /// <param name="key">The key to delete.</param>
-        /// <returns>Future containing the result of the delete operation.</returns>
-        public CacheDeleteResponse Delete(string cacheName, string key)
-        {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-
-            return this.dataClient.Delete(cacheName, key);
-        }
-
-        /// <summary>
-        /// Sets the value in cache with a given time to live (TTL) seconds. If a value for this key is already present it will be replaced by the new value.
-        /// </summary>
-        /// <param name="cacheName">Name of the cache to store the item in.</param>
-        /// <param name="key">The key to set.</param>
-        /// <param name="value">The value to be stored.</param>
-        /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-        /// <returns>Result of the set operation</returns>
-        public CacheSetResponse Set(string cacheName, string key, byte[] value, uint? ttlSeconds = null)
-        {
-            if (cacheName == null)
-            {
-                throw new ArgumentNullException(nameof(cacheName));
-            }
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-
-            return this.dataClient.Set(cacheName, key, value, ttlSeconds);
-        }
-
-        public void Dispose()
-        {
-            this.controlClient.Dispose();
-            this.dataClient.Dispose();
-            GC.SuppressFinalize(this);
-        }
-
-        private void ValidateRequestTimeout(uint? requestTimeoutMilliseconds = null)
-        {
-            if (requestTimeoutMilliseconds == null)
-            {
-                return;
-            }
-            if (requestTimeoutMilliseconds == 0)
-            {
-                throw new InvalidArgumentException("Request timeout must be greater than zero.");
-            }
+            throw new InvalidArgumentException("Request timeout must be greater than zero.");
         }
     }
 }

--- a/MomentoIntegrationTest/Fixtures.cs
+++ b/MomentoIntegrationTest/Fixtures.cs
@@ -1,46 +1,45 @@
-namespace MomentoIntegrationTest
+namespace MomentoIntegrationTest;
+
+/// <summary>
+/// A cache client fixture.
+/// Use this when not testing client-building edge cases:
+/// re-using the client drops overall integration test time down ~5X.
+/// </summary>
+public class SimpleCacheClientFixture : IDisposable
 {
-    /// <summary>
-    /// A cache client fixture.
-    /// Use this when not testing client-building edge cases:
-    /// re-using the client drops overall integration test time down ~5X.
-    /// </summary>
-    public class SimpleCacheClientFixture : IDisposable
+    public SimpleCacheClient Client { get; private set; }
+    public string AuthToken { get; private set; }
+
+    public const string CacheName = "client-sdk-csharp";
+    public const uint DefaultTtlSeconds = 10;
+
+    public SimpleCacheClientFixture()
     {
-        public SimpleCacheClient Client { get; private set; }
-        public string AuthToken { get; private set; }
+        AuthToken = Environment.GetEnvironmentVariable("TEST_AUTH_TOKEN") ??
+            throw new NullReferenceException("TEST_AUTH_TOKEN environment variable must be set.");
+        Client = new(AuthToken, defaultTtlSeconds: DefaultTtlSeconds);
 
-        public const string CacheName = "client-sdk-csharp";
-        public const uint DefaultTtlSeconds = 10;
-
-        public SimpleCacheClientFixture()
+        try
         {
-            AuthToken = Environment.GetEnvironmentVariable("TEST_AUTH_TOKEN") ??
-                throw new NullReferenceException("TEST_AUTH_TOKEN environment variable must be set.");
-            Client = new(AuthToken, defaultTtlSeconds: DefaultTtlSeconds);
-
-            try
-            {
-                Client.CreateCache(CacheName);
-            }
-            catch (AlreadyExistsException)
-            {
-            }
+            Client.CreateCache(CacheName);
         }
-
-        public void Dispose()
+        catch (AlreadyExistsException)
         {
-            Client.DeleteCache(CacheName);
-            Client.Dispose();
         }
     }
 
-    /// <summary>
-    /// Register the fixture in xUnit.
-    /// </summary>
-    [CollectionDefinition("SimpleCacheClient")]
-    public class SimpleCacheClientCollection : ICollectionFixture<SimpleCacheClientFixture>
+    public void Dispose()
     {
-
+        Client.DeleteCache(CacheName);
+        Client.Dispose();
     }
+}
+
+/// <summary>
+/// Register the fixture in xUnit.
+/// </summary>
+[CollectionDefinition("SimpleCacheClient")]
+public class SimpleCacheClientCollection : ICollectionFixture<SimpleCacheClientFixture>
+{
+
 }

--- a/MomentoIntegrationTest/SimpleCacheControlTest.cs
+++ b/MomentoIntegrationTest/SimpleCacheControlTest.cs
@@ -1,122 +1,121 @@
 ﻿using System.Linq;
 using System.Collections.Generic;
 
-namespace MomentoIntegrationTest
+namespace MomentoIntegrationTest;
+
+[Collection("SimpleCacheClient")]
+public class SimpleCacheControlTest
 {
-    [Collection("SimpleCacheClient")]
-    public class SimpleCacheControlTest
+    private SimpleCacheClient client;
+    private string authToken;
+
+    public SimpleCacheControlTest(SimpleCacheClientFixture fixture)
     {
-        private SimpleCacheClient client;
-        private string authToken;
+        client = fixture.Client;
+        authToken = fixture.AuthToken;
+    }
 
-        public SimpleCacheControlTest(SimpleCacheClientFixture fixture)
-        {
-            client = fixture.Client;
-            authToken = fixture.AuthToken;
-        }
+    [Fact]
+    public void SimpleCacheClientConstructor_BadRequestTimeout_ThrowsException()
+    {
+        Assert.Throws<InvalidArgumentException>(() => new SimpleCacheClient(authToken, defaultTtlSeconds: 10, dataClientOperationTimeoutMilliseconds: 0));
+    }
 
-        [Fact]
-        public void SimpleCacheClientConstructor_BadRequestTimeout_ThrowsException()
-        {
-            Assert.Throws<InvalidArgumentException>(() => new SimpleCacheClient(authToken, defaultTtlSeconds: 10, dataClientOperationTimeoutMilliseconds: 0));
-        }
+    [Fact]
+    public void SimpleCacheClientConstructor_BadJWT_InvalidJwtException()
+    {
+        Assert.Throws<InvalidArgumentException>(() => new SimpleCacheClient("eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJpbnRlZ3JhdGlvbiJ9.ZOgkTs", defaultTtlSeconds: 10));
+    }
 
-        [Fact]
-        public void SimpleCacheClientConstructor_BadJWT_InvalidJwtException()
-        {
-            Assert.Throws<InvalidArgumentException>(() => new SimpleCacheClient("eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJpbnRlZ3JhdGlvbiJ9.ZOgkTs", defaultTtlSeconds: 10));
-        }
+    [Fact]
+    public void SimpleCacheClientConstructor_NullJWT_InvalidJwtException()
+    {
+        Assert.Throws<InvalidArgumentException>(() => new SimpleCacheClient(null!, defaultTtlSeconds: 10));
+    }
 
-        [Fact]
-        public void SimpleCacheClientConstructor_NullJWT_InvalidJwtException()
-        {
-            Assert.Throws<InvalidArgumentException>(() => new SimpleCacheClient(null!, defaultTtlSeconds: 10));
-        }
+    [Fact]
+    public void DeleteCache_NullCache_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => client.DeleteCache(null!));
+    }
 
-        [Fact]
-        public void DeleteCache_NullCache_ArgumentNullException()
-        {
-            Assert.Throws<ArgumentNullException>(() => client.DeleteCache(null!));
-        }
+    [Fact]
+    public void DeleteCache_CacheDoesntExist_NotFoundException()
+    {
+        Assert.Throws<NotFoundException>(() => client.DeleteCache("non-existent cache"));
+    }
 
-        [Fact]
-        public void DeleteCache_CacheDoesntExist_NotFoundException()
-        {
-            Assert.Throws<NotFoundException>(() => client.DeleteCache("non-existent cache"));
-        }
+    [Fact]
+    public void CreateCache_NullCache_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => client.CreateCache(null!));
+    }
 
-        [Fact]
-        public void CreateCache_NullCache_ArgumentNullException()
-        {
-            Assert.Throws<ArgumentNullException>(() => client.CreateCache(null!));
-        }
+    // Tests: creating a cache, listing a cache, and deleting a cache.
+    [Fact]
+    public void ListCaches_OneCache_HappyPath()
+    {
+        // Create cache
+        string cacheName = Utils.GuidString();
+        client.CreateCache(cacheName);
 
-        // Tests: creating a cache, listing a cache, and deleting a cache.
-        [Fact]
-        public void ListCaches_OneCache_HappyPath()
+        // Test cache exists
+        ListCachesResponse result = client.ListCaches();
+        List<CacheInfo> caches = result.Caches();
+        Assert.Contains(new CacheInfo(cacheName), caches);
+
+        // Test deleting cache
+        client.DeleteCache(cacheName);
+        result = client.ListCaches();
+        caches = result.Caches();
+        Assert.DoesNotContain(new CacheInfo(cacheName), caches);
+    }
+
+    [Fact]
+    public void ListCaches_Iteration_HappyPath()
+    {
+        // Create caches
+        List<String> cacheNames = new List<String>();
+
+        // TODO: increase limit after pagination is enabled
+        foreach (int val in Enumerable.Range(1, 5))
         {
-            // Create cache
-            string cacheName = Utils.GuidString();
+            String cacheName = Utils.GuidString();
+            cacheNames.Add(cacheName);
             client.CreateCache(cacheName);
+        }
 
-            // Test cache exists
-            ListCachesResponse result = client.ListCaches();
-            List<CacheInfo> caches = result.Caches();
-            Assert.Contains(new CacheInfo(cacheName), caches);
+        // List caches
+        HashSet<String> retrievedCaches = new HashSet<string>();
+        ListCachesResponse result = client.ListCaches();
+        while (true)
+        {
+            foreach (CacheInfo cache in result.Caches())
+            {
+                retrievedCaches.Add(cache.Name());
+            }
+            if (result.NextPageToken() == null)
+            {
+                break;
+            }
+            result = client.ListCaches(result.NextPageToken());
+        }
 
-            // Test deleting cache
+        int sizeOverlap = cacheNames.Intersect(retrievedCaches).Count();
+
+        // Cleanup
+        foreach (String cacheName in cacheNames)
+        {
             client.DeleteCache(cacheName);
-            result = client.ListCaches();
-            caches = result.Caches();
-            Assert.DoesNotContain(new CacheInfo(cacheName), caches);
         }
 
-        [Fact]
-        public void ListCaches_Iteration_HappyPath()
-        {
-            // Create caches
-            List<String> cacheNames = new List<String>();
+        Assert.True(sizeOverlap == cacheNames.Count);
+    }
 
-            // TODO: increase limit after pagination is enabled
-            foreach (int val in Enumerable.Range(1, 5))
-            {
-                String cacheName = Utils.GuidString();
-                cacheNames.Add(cacheName);
-                client.CreateCache(cacheName);
-            }
-
-            // List caches
-            HashSet<String> retrievedCaches = new HashSet<string>();
-            ListCachesResponse result = client.ListCaches();
-            while (true)
-            {
-                foreach (CacheInfo cache in result.Caches())
-                {
-                    retrievedCaches.Add(cache.Name());
-                }
-                if (result.NextPageToken() == null)
-                {
-                    break;
-                }
-                result = client.ListCaches(result.NextPageToken());
-            }
-
-            int sizeOverlap = cacheNames.Intersect(retrievedCaches).Count();
-
-            // Cleanup
-            foreach (String cacheName in cacheNames)
-            {
-                client.DeleteCache(cacheName);
-            }
-
-            Assert.True(sizeOverlap == cacheNames.Count);
-        }
-
-        [Fact]
-        public void ListCaches_BadNextToken_NoException()
-        {
-            // A bad next token does not throw an exception
-            client.ListCaches(nextPageToken: "hello world");
-        }
+    [Fact]
+    public void ListCaches_BadNextToken_NoException()
+    {
+        // A bad next token does not throw an exception
+        client.ListCaches(nextPageToken: "hello world");
     }
 }

--- a/MomentoIntegrationTest/SimpleCacheDataTest.cs
+++ b/MomentoIntegrationTest/SimpleCacheDataTest.cs
@@ -1,654 +1,652 @@
 ﻿using System.Threading.Tasks;
-using System.Text;
 using System.Collections.Generic;
 
-namespace MomentoIntegrationTest
+namespace MomentoIntegrationTest;
+
+[Collection("SimpleCacheClient")]
+public class SimpleCacheDataTest
 {
-    [Collection("SimpleCacheClient")]
-    public class SimpleCacheDataTest
+    private readonly string authToken;
+    private const string CacheName = SimpleCacheClientFixture.CacheName;
+    private const uint DefaultTtlSeconds = SimpleCacheClientFixture.DefaultTtlSeconds;
+    private SimpleCacheClient client;
+
+    // Test initialization
+    public SimpleCacheDataTest(SimpleCacheClientFixture fixture)
     {
-        private readonly string authToken;
-        private const string CacheName = SimpleCacheClientFixture.CacheName;
-        private const uint DefaultTtlSeconds = SimpleCacheClientFixture.DefaultTtlSeconds;
-        private SimpleCacheClient client;
+        client = fixture.Client;
+        authToken = fixture.AuthToken;
+    }
 
-        // Test initialization
-        public SimpleCacheDataTest(SimpleCacheClientFixture fixture)
-        {
-            client = fixture.Client;
-            authToken = fixture.AuthToken;
-        }
+    [Theory]
+    [InlineData(null, new byte[] { 0x00 }, new byte[] { 0x00 })]
+    [InlineData("cache", null, new byte[] { 0x00 })]
+    [InlineData("cache", new byte[] { 0x00 }, null)]
+    public async void SetAsync_NullChecksBytesBytes_ThrowsException(string cacheName, byte[] key, byte[] value)
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAsync(cacheName, key, value));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAsync(cacheName, key, value, DefaultTtlSeconds));
+    }
 
-        [Theory]
-        [InlineData(null, new byte[] { 0x00 }, new byte[] { 0x00 })]
-        [InlineData("cache", null, new byte[] { 0x00 })]
-        [InlineData("cache", new byte[] { 0x00 }, null)]
-        public async void SetAsync_NullChecksBytesBytes_ThrowsException(string cacheName, byte[] key, byte[] value)
-        {
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAsync(cacheName, key, value));
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAsync(cacheName, key, value, DefaultTtlSeconds));
-        }
+    // Tests SetAsyc(cacheName, byte[], byte[]) as well as GetAsync(cacheName, byte[])
+    [Fact]
+    public async void SetAsync_KeyIsBytesValueIsBytes_HappyPath()
+    {
+        byte[] key = Utils.GuidBytes();
+        byte[] value = Utils.GuidBytes();
+        await client.SetAsync(CacheName, key, value);
+        byte[]? setValue = (await client.GetAsync(CacheName, key)).Bytes();
+        Assert.Equal(value, setValue);
 
-        // Tests SetAsyc(cacheName, byte[], byte[]) as well as GetAsync(cacheName, byte[])
-        [Fact]
-        public async void SetAsync_KeyIsBytesValueIsBytes_HappyPath()
-        {
-            byte[] key = Utils.GuidBytes();
-            byte[] value = Utils.GuidBytes();
-            await client.SetAsync(CacheName, key, value);
-            byte[]? setValue = (await client.GetAsync(CacheName, key)).Bytes();
-            Assert.Equal(value, setValue);
+        key = Utils.GuidBytes();
+        value = Utils.GuidBytes();
+        await client.SetAsync(CacheName, key, value, ttlSeconds: 15);
+        setValue = (await client.GetAsync(CacheName, key)).Bytes();
+        Assert.Equal(value, setValue);
+    }
 
-            key = Utils.GuidBytes();
-            value = Utils.GuidBytes();
-            await client.SetAsync(CacheName, key, value, ttlSeconds: 15);
-            setValue = (await client.GetAsync(CacheName, key)).Bytes();
-            Assert.Equal(value, setValue);
-        }
+    [Theory]
+    [InlineData(null, new byte[] { 0x00 })]
+    [InlineData("cache", null)]
+    public async void GetAsync_NullChecksBytes_ThrowsException(string cacheName, byte[] key)
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetAsync(cacheName, key));
+    }
 
-        [Theory]
-        [InlineData(null, new byte[] { 0x00 })]
-        [InlineData("cache", null)]
-        public async void GetAsync_NullChecksBytes_ThrowsException(string cacheName, byte[] key)
-        {
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetAsync(cacheName, key));
-        }
+    [Theory]
+    [InlineData(null, "key", "value")]
+    [InlineData("cache", null, "value")]
+    [InlineData("cache", "key", null)]
+    public async void SetAsync_NullChecksStringString_ThrowsException(string cacheName, string key, string value)
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAsync(cacheName, key, value));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAsync(cacheName, key, value, DefaultTtlSeconds));
+    }
 
-        [Theory]
-        [InlineData(null, "key", "value")]
-        [InlineData("cache", null, "value")]
-        [InlineData("cache", "key", null)]
-        public async void SetAsync_NullChecksStringString_ThrowsException(string cacheName, string key, string value)
-        {
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAsync(cacheName, key, value));
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAsync(cacheName, key, value, DefaultTtlSeconds));
-        }
+    // Also tests GetAsync(cacheName, string)
+    [Fact]
+    public async void SetAsync_KeyIsStringValueIsString_HappyPath()
+    {
+        string key = Utils.GuidString();
+        string value = Utils.GuidString();
+        await client.SetAsync(CacheName, key, value);
+        string? setValue = (await client.GetAsync(CacheName, key)).String();
+        Assert.Equal(value, setValue);
 
-        // Also tests GetAsync(cacheName, string)
-        [Fact]
-        public async void SetAsync_KeyIsStringValueIsString_HappyPath()
-        {
-            string key = Utils.GuidString();
-            string value = Utils.GuidString();
-            await client.SetAsync(CacheName, key, value);
-            string? setValue = (await client.GetAsync(CacheName, key)).String();
-            Assert.Equal(value, setValue);
+        key = Utils.GuidString();
+        value = Utils.GuidString();
+        await client.SetAsync(CacheName, key, value, ttlSeconds: 15);
+        setValue = (await client.GetAsync(CacheName, key)).String();
+        Assert.Equal(value, setValue);
+    }
 
-            key = Utils.GuidString();
-            value = Utils.GuidString();
-            await client.SetAsync(CacheName, key, value, ttlSeconds: 15);
-            setValue = (await client.GetAsync(CacheName, key)).String();
-            Assert.Equal(value, setValue);
-        }
+    [Theory]
+    [InlineData(null, "key")]
+    [InlineData("cache", null)]
+    public async void GetAsync_NullChecksString_ThrowsException(string cacheName, string key)
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetAsync(cacheName, key));
+    }
 
-        [Theory]
-        [InlineData(null, "key")]
-        [InlineData("cache", null)]
-        public async void GetAsync_NullChecksString_ThrowsException(string cacheName, string key)
-        {
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetAsync(cacheName, key));
-        }
+    [Theory]
+    [InlineData(null, "key", new byte[] { 0x00 })]
+    [InlineData("cache", null, new byte[] { 0x00 })]
+    [InlineData("cache", "key", null)]
+    public async void SetAsync_NullChecksStringBytes_ThrowsException(string cacheName, string key, byte[] value)
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAsync(cacheName, key, value));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAsync(cacheName, key, value, DefaultTtlSeconds));
+    }
 
-        [Theory]
-        [InlineData(null, "key", new byte[] { 0x00 })]
-        [InlineData("cache", null, new byte[] { 0x00 })]
-        [InlineData("cache", "key", null)]
-        public async void SetAsync_NullChecksStringBytes_ThrowsException(string cacheName, string key, byte[] value)
-        {
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAsync(cacheName, key, value));
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAsync(cacheName, key, value, DefaultTtlSeconds));
-        }
+    // Also tests GetAsync(cacheName, string)
+    [Fact]
+    public async void SetAsync_KeyIsStringValueIsBytes_HappyPath()
+    {
+        string key = Utils.GuidString();
+        byte[] value = Utils.GuidBytes();
+        await client.SetAsync(CacheName, key, value);
+        byte[]? setValue = (await client.GetAsync(CacheName, key)).Bytes();
+        Assert.Equal(value, setValue);
 
-        // Also tests GetAsync(cacheName, string)
-        [Fact]
-        public async void SetAsync_KeyIsStringValueIsBytes_HappyPath()
-        {
-            string key = Utils.GuidString();
-            byte[] value = Utils.GuidBytes();
-            await client.SetAsync(CacheName, key, value);
-            byte[]? setValue = (await client.GetAsync(CacheName, key)).Bytes();
-            Assert.Equal(value, setValue);
+        key = Utils.GuidString();
+        value = Utils.GuidBytes();
+        await client.SetAsync(CacheName, key, value, ttlSeconds: 15);
+        setValue = (await client.GetAsync(CacheName, key)).Bytes();
+        Assert.Equal(value, setValue);
+    }
 
-            key = Utils.GuidString();
-            value = Utils.GuidBytes();
-            await client.SetAsync(CacheName, key, value, ttlSeconds: 15);
-            setValue = (await client.GetAsync(CacheName, key)).Bytes();
-            Assert.Equal(value, setValue);
-        }
+    [Fact]
+    public async void GetMultiAsync_NullCheckBytes_ThrowsException()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync(null!, new List<byte[]>()));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", (List<byte[]>)null!));
 
-        [Fact]
-        public async void GetMultiAsync_NullCheckBytes_ThrowsException()
-        {
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync(null!, new List<byte[]>()));
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", (List<byte[]>)null!));
+        var badList = new List<byte[]>(new byte[][] { Utils.GuidBytes(), null! });
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", badList));
 
-            var badList = new List<byte[]>(new byte[][] { Utils.GuidBytes(), null! });
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", badList));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", Utils.GuidBytes(), null!));
+    }
 
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", Utils.GuidBytes(), null!));
-        }
+    [Fact]
+    public async void GetMultiAsync_KeysAreBytes_HappyPath()
+    {
+        string key1 = Utils.GuidString();
+        string value1 = Utils.GuidString();
+        string key2 = Utils.GuidString();
+        string value2 = Utils.GuidString();
+        client.Set(CacheName, key1, value1);
+        client.Set(CacheName, key2, value2);
 
-        [Fact]
-        public async void GetMultiAsync_KeysAreBytes_HappyPath()
-        {
-            string key1 = Utils.GuidString();
-            string value1 = Utils.GuidString();
-            string key2 = Utils.GuidString();
-            string value2 = Utils.GuidString();
-            client.Set(CacheName, key1, value1);
-            client.Set(CacheName, key2, value2);
+        List<byte[]> keys = new() { Utils.Utf8ToBytes(key1), Utils.Utf8ToBytes(key2) };
 
-            List<byte[]> keys = new() { Utils.Utf8ToBytes(key1), Utils.Utf8ToBytes(key2) };
+        CacheGetMultiResponse result = await client.GetMultiAsync(CacheName, keys);
+        string? stringResult1 = result.Strings()[0];
+        string? stringResult2 = result.Strings()[1];
+        Assert.Equal(value1, stringResult1);
+        Assert.Equal(value2, stringResult2);
+    }
 
-            CacheGetMultiResponse result = await client.GetMultiAsync(CacheName, keys);
-            string? stringResult1 = result.Strings()[0];
-            string? stringResult2 = result.Strings()[1];
-            Assert.Equal(value1, stringResult1);
-            Assert.Equal(value2, stringResult2);
-        }
+    [Fact]
+    public async void GetMultiAsync_KeysAreBytes_HappyPath2()
+    {
+        string key1 = Utils.GuidString();
+        string value1 = Utils.GuidString();
+        string key2 = Utils.GuidString();
+        string value2 = Utils.GuidString();
+        client.Set(CacheName, key1, value1);
+        client.Set(CacheName, key2, value2);
 
-        [Fact]
-        public async void GetMultiAsync_KeysAreBytes_HappyPath2()
-        {
-            string key1 = Utils.GuidString();
-            string value1 = Utils.GuidString();
-            string key2 = Utils.GuidString();
-            string value2 = Utils.GuidString();
-            client.Set(CacheName, key1, value1);
-            client.Set(CacheName, key2, value2);
+        CacheGetMultiResponse result = await client.GetMultiAsync(CacheName, key1, key2);
+        string? stringResult1 = result.Strings()[0];
+        string? stringResult2 = result.Strings()[1];
+        Assert.Equal(value1, stringResult1);
+        Assert.Equal(value2, stringResult2);
+    }
 
-            CacheGetMultiResponse result = await client.GetMultiAsync(CacheName, key1, key2);
-            string? stringResult1 = result.Strings()[0];
-            string? stringResult2 = result.Strings()[1];
-            Assert.Equal(value1, stringResult1);
-            Assert.Equal(value2, stringResult2);
-        }
+    [Fact]
+    public async void GetMultiAsync_NullCheckString_ThrowsException()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync(null!, new List<string>()));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", (List<string>)null!));
 
-        [Fact]
-        public async void GetMultiAsync_NullCheckString_ThrowsException()
-        {
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync(null!, new List<string>()));
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", (List<string>)null!));
+        List<string> strings = new(new string[] { "key1", "key2", null! });
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", strings));
 
-            List<string> strings = new(new string[] { "key1", "key2", null! });
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", strings));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", "key1", "key2", null!));
+    }
 
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetMultiAsync("cache", "key1", "key2", null!));
-        }
+    [Fact]
+    public async void GetMultiAsync_KeysAreString_HappyPath()
+    {
+        string key1 = Utils.GuidString();
+        string value1 = Utils.GuidString();
+        string key2 = Utils.GuidString();
+        string value2 = Utils.GuidString();
+        client.Set(CacheName, key1, value1);
+        client.Set(CacheName, key2, value2);
 
-        [Fact]
-        public async void GetMultiAsync_KeysAreString_HappyPath()
-        {
-            string key1 = Utils.GuidString();
-            string value1 = Utils.GuidString();
-            string key2 = Utils.GuidString();
-            string value2 = Utils.GuidString();
-            client.Set(CacheName, key1, value1);
-            client.Set(CacheName, key2, value2);
+        List<string> keys = new() { key1, key2, "key123123" };
+        CacheGetMultiResponse result = await client.GetMultiAsync(CacheName, keys);
 
-            List<string> keys = new() { key1, key2, "key123123" };
-            CacheGetMultiResponse result = await client.GetMultiAsync(CacheName, keys);
+        Assert.Equal(result.Strings(), new string[] { value1, value2, null! });
+        Assert.Equal(result.Status(), new CacheGetStatus[] { CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS });
+    }
 
-            Assert.Equal(result.Strings(), new string[] { value1, value2, null! });
-            Assert.Equal(result.Status(), new CacheGetStatus[] { CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS });
-        }
+    [Fact]
+    public void GetMultiAsync_Failure()
+    {
+        // Set very small timeout for dataClientOperationTimeoutMilliseconds
+        SimpleCacheClient simpleCacheClient = new SimpleCacheClient(authToken, DefaultTtlSeconds, 1);
+        List<string> keys = new() { Utils.GuidString(), Utils.GuidString(), Utils.GuidString(), Utils.GuidString() };
+        Assert.ThrowsAsync<MomentoSdk.Exceptions.TimeoutException>(() => simpleCacheClient.GetMultiAsync(CacheName, keys));
+    }
 
-        [Fact]
-        public void GetMultiAsync_Failure()
-        {
-            // Set very small timeout for dataClientOperationTimeoutMilliseconds
-            SimpleCacheClient simpleCacheClient = new SimpleCacheClient(authToken, DefaultTtlSeconds, 1);
-            List<string> keys = new() { Utils.GuidString(), Utils.GuidString(), Utils.GuidString(), Utils.GuidString() };
-            Assert.ThrowsAsync<MomentoSdk.Exceptions.TimeoutException>(() => simpleCacheClient.GetMultiAsync(CacheName, keys));
-        }
+    [Fact]
+    public async void SetMultiAsync_NullCheckBytes_ThrowsException()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync(null!, new Dictionary<byte[], byte[]>()));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync("cache", (Dictionary<byte[], byte[]>)null!));
 
-        [Fact]
-        public async void SetMultiAsync_NullCheckBytes_ThrowsException()
-        {
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync(null!, new Dictionary<byte[], byte[]>()));
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync("cache", (Dictionary<byte[], byte[]>)null!));
+        var badDictionary = new Dictionary<byte[], byte[]>() { { Utils.Utf8ToBytes("asdf"), null! } };
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync("cache", badDictionary));
+    }
 
-            var badDictionary = new Dictionary<byte[], byte[]>() { { Utils.Utf8ToBytes("asdf"), null! } };
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync("cache", badDictionary));
-        }
+    [Fact]
+    public async void SetMultiAsync_ItemsAreBytes_HappyPath()
+    {
+        var key1 = Utils.GuidBytes();
+        var key2 = Utils.GuidBytes();
+        var value1 = Utils.GuidBytes();
+        var value2 = Utils.GuidBytes();
 
-        [Fact]
-        public async void SetMultiAsync_ItemsAreBytes_HappyPath()
-        {
-            var key1 = Utils.GuidBytes();
-            var key2 = Utils.GuidBytes();
-            var value1 = Utils.GuidBytes();
-            var value2 = Utils.GuidBytes();
-
-            var dictionary = new Dictionary<byte[], byte[]>() {
+        var dictionary = new Dictionary<byte[], byte[]>() {
                 { key1, value1 },
                 { key2, value2 }
             };
-            CacheSetMultiResponse response = await client.SetMultiAsync(CacheName, dictionary);
-            Assert.Equal(dictionary, response.Bytes());
+        CacheSetMultiResponse response = await client.SetMultiAsync(CacheName, dictionary);
+        Assert.Equal(dictionary, response.Bytes());
 
-            var getResponse = await client.GetAsync(CacheName, key1);
-            Assert.Equal(value1, getResponse.Bytes());
+        var getResponse = await client.GetAsync(CacheName, key1);
+        Assert.Equal(value1, getResponse.Bytes());
 
-            getResponse = await client.GetAsync(CacheName, key2);
-            Assert.Equal(value2, getResponse.Bytes());
-        }
+        getResponse = await client.GetAsync(CacheName, key2);
+        Assert.Equal(value2, getResponse.Bytes());
+    }
 
-        [Fact]
-        public async void SetMultiAsync_NullCheckStrings_ThrowsException()
-        {
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync(null!, new Dictionary<string, string>()));
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync("cache", (Dictionary<string, string>)null!));
+    [Fact]
+    public async void SetMultiAsync_NullCheckStrings_ThrowsException()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync(null!, new Dictionary<string, string>()));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync("cache", (Dictionary<string, string>)null!));
 
-            var badDictionary = new Dictionary<string, string>() { { "asdf", null! } };
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync("cache", badDictionary));
-        }
+        var badDictionary = new Dictionary<string, string>() { { "asdf", null! } };
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetMultiAsync("cache", badDictionary));
+    }
 
-        [Fact]
-        public async void SetMultiAsync_KeysAreString_HappyPath()
-        {
-            var key1 = Utils.GuidString();
-            var key2 = Utils.GuidString();
-            var value1 = Utils.GuidString();
-            var value2 = Utils.GuidString();
+    [Fact]
+    public async void SetMultiAsync_KeysAreString_HappyPath()
+    {
+        var key1 = Utils.GuidString();
+        var key2 = Utils.GuidString();
+        var value1 = Utils.GuidString();
+        var value2 = Utils.GuidString();
 
-            var dictionary = new Dictionary<string, string>() {
+        var dictionary = new Dictionary<string, string>() {
                 { key1, value1 },
                 { key2, value2 }
             };
-            CacheSetMultiResponse response = await client.SetMultiAsync(CacheName, dictionary);
-            Assert.Equal(dictionary, response.Strings());
+        CacheSetMultiResponse response = await client.SetMultiAsync(CacheName, dictionary);
+        Assert.Equal(dictionary, response.Strings());
 
-            var getResponse = await client.GetAsync(CacheName, key1);
-            Assert.Equal(value1, getResponse.String());
+        var getResponse = await client.GetAsync(CacheName, key1);
+        Assert.Equal(value1, getResponse.String());
 
-            getResponse = await client.GetAsync(CacheName, key2);
-            Assert.Equal(value2, getResponse.String());
-        }
+        getResponse = await client.GetAsync(CacheName, key2);
+        Assert.Equal(value2, getResponse.String());
+    }
 
-        [Theory]
-        [InlineData(null, new byte[] { 0x00 }, new byte[] { 0x00 })]
-        [InlineData("cache", null, new byte[] { 0x00 })]
-        [InlineData("cache", new byte[] { 0x00 }, null)]
-        public void Set_NullChecksBytesBytes_ThrowsException(string cacheName, byte[] key, byte[] value)
-        {
-            Assert.Throws<ArgumentNullException>(() => client.Set(cacheName, key, value));
-            Assert.Throws<ArgumentNullException>(() => client.Set(cacheName, key, value, DefaultTtlSeconds));
-        }
+    [Theory]
+    [InlineData(null, new byte[] { 0x00 }, new byte[] { 0x00 })]
+    [InlineData("cache", null, new byte[] { 0x00 })]
+    [InlineData("cache", new byte[] { 0x00 }, null)]
+    public void Set_NullChecksBytesBytes_ThrowsException(string cacheName, byte[] key, byte[] value)
+    {
+        Assert.Throws<ArgumentNullException>(() => client.Set(cacheName, key, value));
+        Assert.Throws<ArgumentNullException>(() => client.Set(cacheName, key, value, DefaultTtlSeconds));
+    }
 
-        // Tests Set(cacheName, byte[], byte[]) as well as Get(cacheName, byte[])
-        [Fact]
-        public void Set_KeyIsBytesValueIsBytes_HappyPath()
-        {
-            byte[] key = Utils.GuidBytes();
-            byte[] value = Utils.GuidBytes();
-            client.Set(CacheName, key, value);
-            byte[]? setValue = client.Get(CacheName, key).Bytes();
-            Assert.Equal(value, setValue);
+    // Tests Set(cacheName, byte[], byte[]) as well as Get(cacheName, byte[])
+    [Fact]
+    public void Set_KeyIsBytesValueIsBytes_HappyPath()
+    {
+        byte[] key = Utils.GuidBytes();
+        byte[] value = Utils.GuidBytes();
+        client.Set(CacheName, key, value);
+        byte[]? setValue = client.Get(CacheName, key).Bytes();
+        Assert.Equal(value, setValue);
 
-            key = Utils.GuidBytes();
-            value = Utils.GuidBytes();
-            client.Set(CacheName, key, value, ttlSeconds: 15);
-            setValue = client.Get(CacheName, key).Bytes();
-            Assert.Equal(value, setValue);
-        }
+        key = Utils.GuidBytes();
+        value = Utils.GuidBytes();
+        client.Set(CacheName, key, value, ttlSeconds: 15);
+        setValue = client.Get(CacheName, key).Bytes();
+        Assert.Equal(value, setValue);
+    }
 
-        [Fact]
-        public void Get_NullChecksBytes_ThrowsException()
-        {
-            Assert.Throws<ArgumentNullException>(() => client.Get("cache", (byte[])null!));
-            Assert.Throws<ArgumentNullException>(() => client.Get(null!, new byte[] { 0x00 }));
-        }
+    [Fact]
+    public void Get_NullChecksBytes_ThrowsException()
+    {
+        Assert.Throws<ArgumentNullException>(() => client.Get("cache", (byte[])null!));
+        Assert.Throws<ArgumentNullException>(() => client.Get(null!, new byte[] { 0x00 }));
+    }
 
-        [Fact]
-        public async void Get_ExpiredTtl_HappyPath()
-        {
-            string key = Utils.GuidString();
-            string value = Utils.GuidString();
-            client.Set(CacheName, key, value, 1);
-            await Task.Delay(3000);
-            CacheGetResponse result = client.Get(CacheName, key);
-            Assert.Equal(CacheGetStatus.MISS, result.Status);
-        }
+    [Fact]
+    public async void Get_ExpiredTtl_HappyPath()
+    {
+        string key = Utils.GuidString();
+        string value = Utils.GuidString();
+        client.Set(CacheName, key, value, 1);
+        await Task.Delay(3000);
+        CacheGetResponse result = client.Get(CacheName, key);
+        Assert.Equal(CacheGetStatus.MISS, result.Status);
+    }
 
-        [Fact]
-        public void Get_Miss_HappyPath()
-        {
-            CacheGetResponse result = client.Get(CacheName, Utils.GuidString());
-            Assert.Equal(CacheGetStatus.MISS, result.Status);
-            Assert.Null(result.String());
-            Assert.Null(result.Bytes());
-        }
+    [Fact]
+    public void Get_Miss_HappyPath()
+    {
+        CacheGetResponse result = client.Get(CacheName, Utils.GuidString());
+        Assert.Equal(CacheGetStatus.MISS, result.Status);
+        Assert.Null(result.String());
+        Assert.Null(result.Bytes());
+    }
 
-        [Fact]
-        public void Get_CacheDoesntExist_ThrowsException()
-        {
-            SimpleCacheClient simpleCacheClient = new SimpleCacheClient(authToken, DefaultTtlSeconds);
-            Assert.Throws<NotFoundException>(() => simpleCacheClient.Get("non-existent-cache", Utils.GuidString()));
-        }
+    [Fact]
+    public void Get_CacheDoesntExist_ThrowsException()
+    {
+        SimpleCacheClient simpleCacheClient = new SimpleCacheClient(authToken, DefaultTtlSeconds);
+        Assert.Throws<NotFoundException>(() => simpleCacheClient.Get("non-existent-cache", Utils.GuidString()));
+    }
 
-        [Fact]
-        public void Set_CacheDoesntExist_ThrowsException()
-        {
-            SimpleCacheClient simpleCacheClient = new SimpleCacheClient(authToken, DefaultTtlSeconds);
-            Assert.Throws<NotFoundException>(() => simpleCacheClient.Set("non-existent-cache", Utils.GuidString(), Utils.GuidString()));
-        }
+    [Fact]
+    public void Set_CacheDoesntExist_ThrowsException()
+    {
+        SimpleCacheClient simpleCacheClient = new SimpleCacheClient(authToken, DefaultTtlSeconds);
+        Assert.Throws<NotFoundException>(() => simpleCacheClient.Set("non-existent-cache", Utils.GuidString(), Utils.GuidString()));
+    }
 
-        [Theory]
-        [InlineData(null, "key", "value")]
-        [InlineData("cache", null, "value")]
-        [InlineData("cache", "key", null)]
-        public void Set_NullChecksStringString_ThrowsException(string cacheName, string key, string value)
-        {
-            Assert.Throws<ArgumentNullException>(() => client.Set(cacheName, key, value));
-            Assert.Throws<ArgumentNullException>(() => client.Set(cacheName, key, value, DefaultTtlSeconds));
-        }
+    [Theory]
+    [InlineData(null, "key", "value")]
+    [InlineData("cache", null, "value")]
+    [InlineData("cache", "key", null)]
+    public void Set_NullChecksStringString_ThrowsException(string cacheName, string key, string value)
+    {
+        Assert.Throws<ArgumentNullException>(() => client.Set(cacheName, key, value));
+        Assert.Throws<ArgumentNullException>(() => client.Set(cacheName, key, value, DefaultTtlSeconds));
+    }
 
-        // Tests Set(cacheName, string, string) as well as Get(cacheName, string)
-        [Fact]
-        public void Set_KeyIsStringValueIsString_HappyPath()
-        {
-            string key = Utils.GuidString();
-            string value = Utils.GuidString();
-            client.Set(CacheName, key, value);
-            string? setValue = client.Get(CacheName, key).String();
-            Assert.Equal(value, setValue);
+    // Tests Set(cacheName, string, string) as well as Get(cacheName, string)
+    [Fact]
+    public void Set_KeyIsStringValueIsString_HappyPath()
+    {
+        string key = Utils.GuidString();
+        string value = Utils.GuidString();
+        client.Set(CacheName, key, value);
+        string? setValue = client.Get(CacheName, key).String();
+        Assert.Equal(value, setValue);
 
-            key = Utils.GuidString();
-            value = Utils.GuidString();
-            client.Set(CacheName, key, value, ttlSeconds: 15);
-            setValue = client.Get(CacheName, key).String();
-            Assert.Equal(value, setValue);
-        }
+        key = Utils.GuidString();
+        value = Utils.GuidString();
+        client.Set(CacheName, key, value, ttlSeconds: 15);
+        setValue = client.Get(CacheName, key).String();
+        Assert.Equal(value, setValue);
+    }
 
-        [Theory]
-        [InlineData(null, "key")]
-        [InlineData("cache", null)]
-        public void Get_NullChecksString_ThrowsException(string cacheName, string key)
-        {
-            Assert.Throws<ArgumentNullException>(() => client.Get(cacheName, key));
-        }
+    [Theory]
+    [InlineData(null, "key")]
+    [InlineData("cache", null)]
+    public void Get_NullChecksString_ThrowsException(string cacheName, string key)
+    {
+        Assert.Throws<ArgumentNullException>(() => client.Get(cacheName, key));
+    }
 
-        [Theory]
-        [InlineData(null, "key", new byte[] { 0x00 })]
-        [InlineData("cache", null, new byte[] { 0x00 })]
-        [InlineData("cache", "key", null)]
-        public void Set_NullChecksStringBytes_ThrowsException(string cacheName, string key, byte[] value)
-        {
-            Assert.Throws<ArgumentNullException>(() => client.Set(cacheName, key, value));
-            Assert.Throws<ArgumentNullException>(() => client.Set(cacheName, key, value, DefaultTtlSeconds));
-        }
+    [Theory]
+    [InlineData(null, "key", new byte[] { 0x00 })]
+    [InlineData("cache", null, new byte[] { 0x00 })]
+    [InlineData("cache", "key", null)]
+    public void Set_NullChecksStringBytes_ThrowsException(string cacheName, string key, byte[] value)
+    {
+        Assert.Throws<ArgumentNullException>(() => client.Set(cacheName, key, value));
+        Assert.Throws<ArgumentNullException>(() => client.Set(cacheName, key, value, DefaultTtlSeconds));
+    }
 
-        // Tests Set(cacheName, string, byte[]) as well as Get(cacheName, string)
-        [Fact]
-        public void Set_KeyIsStringValueIsBytes_HappyPath()
-        {
-            string key = Utils.GuidString();
-            byte[] value = Utils.GuidBytes();
-            client.Set(CacheName, key, value);
-            byte[]? setValue = client.Get(CacheName, key).Bytes();
-            Assert.Equal(value, setValue);
+    // Tests Set(cacheName, string, byte[]) as well as Get(cacheName, string)
+    [Fact]
+    public void Set_KeyIsStringValueIsBytes_HappyPath()
+    {
+        string key = Utils.GuidString();
+        byte[] value = Utils.GuidBytes();
+        client.Set(CacheName, key, value);
+        byte[]? setValue = client.Get(CacheName, key).Bytes();
+        Assert.Equal(value, setValue);
 
-            key = Utils.GuidString();
-            value = Utils.GuidBytes();
-            client.Set(CacheName, key, value, ttlSeconds: 15);
-            setValue = client.Get(CacheName, key).Bytes();
-            Assert.Equal(value, setValue);
-        }
+        key = Utils.GuidString();
+        value = Utils.GuidBytes();
+        client.Set(CacheName, key, value, ttlSeconds: 15);
+        setValue = client.Get(CacheName, key).Bytes();
+        Assert.Equal(value, setValue);
+    }
 
-        [Fact]
-        public void GetMulti_NullCheckBytes_ThrowsException()
-        {
-            Assert.Throws<ArgumentNullException>(() => client.GetMulti(null!, new List<byte[]>()));
-            Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", (List<byte[]>)null!));
+    [Fact]
+    public void GetMulti_NullCheckBytes_ThrowsException()
+    {
+        Assert.Throws<ArgumentNullException>(() => client.GetMulti(null!, new List<byte[]>()));
+        Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", (List<byte[]>)null!));
 
-            var badList = new List<byte[]>(new byte[][] { Utils.GuidBytes(), null! });
-            Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", badList));
+        var badList = new List<byte[]>(new byte[][] { Utils.GuidBytes(), null! });
+        Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", badList));
 
-            Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", Utils.GuidBytes(), null!));
-        }
+        Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", Utils.GuidBytes(), null!));
+    }
 
-        [Fact]
-        public void GetMulti_KeysAreBytes_HappyPath()
-        {
-            string key1 = Utils.GuidString();
-            string value1 = Utils.GuidString();
-            string key2 = Utils.GuidString();
-            string value2 = Utils.GuidString();
-            client.Set(CacheName, key1, value1);
-            client.Set(CacheName, key2, value2);
+    [Fact]
+    public void GetMulti_KeysAreBytes_HappyPath()
+    {
+        string key1 = Utils.GuidString();
+        string value1 = Utils.GuidString();
+        string key2 = Utils.GuidString();
+        string value2 = Utils.GuidString();
+        client.Set(CacheName, key1, value1);
+        client.Set(CacheName, key2, value2);
 
-            List<byte[]> keys = new() { Utils.Utf8ToBytes(key1), Utils.Utf8ToBytes(key2) };
+        List<byte[]> keys = new() { Utils.Utf8ToBytes(key1), Utils.Utf8ToBytes(key2) };
 
-            CacheGetMultiResponse result = client.GetMulti(CacheName, keys);
-            string? stringResult1 = result.Strings()[0];
-            string? stringResult2 = result.Strings()[1];
-            Assert.Equal(value1, stringResult1);
-            Assert.Equal(value2, stringResult2);
-        }
+        CacheGetMultiResponse result = client.GetMulti(CacheName, keys);
+        string? stringResult1 = result.Strings()[0];
+        string? stringResult2 = result.Strings()[1];
+        Assert.Equal(value1, stringResult1);
+        Assert.Equal(value2, stringResult2);
+    }
 
-        [Fact]
-        public void GetMulti_KeysAreBytes_HappyPath2()
-        {
-            string key1 = Utils.GuidString();
-            string value1 = Utils.GuidString();
-            string key2 = Utils.GuidString();
-            string value2 = Utils.GuidString();
-            client.Set(CacheName, key1, value1);
-            client.Set(CacheName, key2, value2);
+    [Fact]
+    public void GetMulti_KeysAreBytes_HappyPath2()
+    {
+        string key1 = Utils.GuidString();
+        string value1 = Utils.GuidString();
+        string key2 = Utils.GuidString();
+        string value2 = Utils.GuidString();
+        client.Set(CacheName, key1, value1);
+        client.Set(CacheName, key2, value2);
 
-            CacheGetMultiResponse result = client.GetMulti(CacheName, key1, key2);
-            string? stringResult1 = result.Strings()[0];
-            string? stringResult2 = result.Strings()[1];
-            Assert.Equal(value1, stringResult1);
-            Assert.Equal(value2, stringResult2);
-        }
+        CacheGetMultiResponse result = client.GetMulti(CacheName, key1, key2);
+        string? stringResult1 = result.Strings()[0];
+        string? stringResult2 = result.Strings()[1];
+        Assert.Equal(value1, stringResult1);
+        Assert.Equal(value2, stringResult2);
+    }
 
-        [Fact]
-        public void GetMulti_NullCheckString_ThrowsException()
-        {
-            Assert.Throws<ArgumentNullException>(() => client.GetMulti(null!, new List<string>()));
-            Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", (List<string>)null!));
+    [Fact]
+    public void GetMulti_NullCheckString_ThrowsException()
+    {
+        Assert.Throws<ArgumentNullException>(() => client.GetMulti(null!, new List<string>()));
+        Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", (List<string>)null!));
 
-            List<string> strings = new(new string[] { Utils.GuidString(), Utils.GuidString(), null! });
-            Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", strings));
+        List<string> strings = new(new string[] { Utils.GuidString(), Utils.GuidString(), null! });
+        Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", strings));
 
-            Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", Utils.GuidString(), Utils.GuidString(), null!));
-        }
+        Assert.Throws<ArgumentNullException>(() => client.GetMulti("cache", Utils.GuidString(), Utils.GuidString(), null!));
+    }
 
-        [Fact]
-        public void GetMulti_KeysAreString_HappyPath()
-        {
-            string key1 = Utils.GuidString();
-            string value1 = Utils.GuidString();
-            string key2 = Utils.GuidString();
-            string value2 = Utils.GuidString();
-            client.Set(CacheName, key1, value1);
-            client.Set(CacheName, key2, value2);
+    [Fact]
+    public void GetMulti_KeysAreString_HappyPath()
+    {
+        string key1 = Utils.GuidString();
+        string value1 = Utils.GuidString();
+        string key2 = Utils.GuidString();
+        string value2 = Utils.GuidString();
+        client.Set(CacheName, key1, value1);
+        client.Set(CacheName, key2, value2);
 
-            List<string> keys = new() { key1, key2, "key123123" };
-            CacheGetMultiResponse result = client.GetMulti(CacheName, keys);
+        List<string> keys = new() { key1, key2, "key123123" };
+        CacheGetMultiResponse result = client.GetMulti(CacheName, keys);
 
-            Assert.Equal(result.Strings(), new string[] { value1, value2, null! });
-            Assert.Equal(result.Status(), new CacheGetStatus[] { CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS });
-        }
+        Assert.Equal(result.Strings(), new string[] { value1, value2, null! });
+        Assert.Equal(result.Status(), new CacheGetStatus[] { CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS });
+    }
 
-        [Fact]
-        public void GetMulti_Failure()
-        {
-            // Set very small timeout for dataClientOperationTimeoutMilliseconds
-            SimpleCacheClient simpleCacheClient = new SimpleCacheClient(authToken, DefaultTtlSeconds, 1);
-            List<string> keys = new() { Utils.GuidString(), Utils.GuidString(), Utils.GuidString(), Utils.GuidString() };
-            Assert.Throws<MomentoSdk.Exceptions.TimeoutException>(() => simpleCacheClient.GetMulti(CacheName, keys));
-        }
+    [Fact]
+    public void GetMulti_Failure()
+    {
+        // Set very small timeout for dataClientOperationTimeoutMilliseconds
+        SimpleCacheClient simpleCacheClient = new SimpleCacheClient(authToken, DefaultTtlSeconds, 1);
+        List<string> keys = new() { Utils.GuidString(), Utils.GuidString(), Utils.GuidString(), Utils.GuidString() };
+        Assert.Throws<MomentoSdk.Exceptions.TimeoutException>(() => simpleCacheClient.GetMulti(CacheName, keys));
+    }
 
-        [Fact]
-        public void SetMulti_NullCheckBytes_ThrowsException()
-        {
-            Assert.Throws<ArgumentNullException>(() => client.SetMulti(null!, new Dictionary<byte[], byte[]>()));
-            Assert.Throws<ArgumentNullException>(() => client.SetMulti("cache", (Dictionary<byte[], byte[]>)null!));
+    [Fact]
+    public void SetMulti_NullCheckBytes_ThrowsException()
+    {
+        Assert.Throws<ArgumentNullException>(() => client.SetMulti(null!, new Dictionary<byte[], byte[]>()));
+        Assert.Throws<ArgumentNullException>(() => client.SetMulti("cache", (Dictionary<byte[], byte[]>)null!));
 
-            var badDictionary = new Dictionary<byte[], byte[]>() { { Utils.GuidBytes(), null! } };
-            Assert.Throws<ArgumentNullException>(() => client.SetMulti("cache", badDictionary));
-        }
+        var badDictionary = new Dictionary<byte[], byte[]>() { { Utils.GuidBytes(), null! } };
+        Assert.Throws<ArgumentNullException>(() => client.SetMulti("cache", badDictionary));
+    }
 
-        [Fact]
-        public void SetMulti_ItemsAreBytes_HappyPath()
-        {
-            var key1 = Utils.GuidBytes();
-            var key2 = Utils.GuidBytes();
-            var value1 = Utils.GuidBytes();
-            var value2 = Utils.GuidBytes();
+    [Fact]
+    public void SetMulti_ItemsAreBytes_HappyPath()
+    {
+        var key1 = Utils.GuidBytes();
+        var key2 = Utils.GuidBytes();
+        var value1 = Utils.GuidBytes();
+        var value2 = Utils.GuidBytes();
 
-            var dictionary = new Dictionary<byte[], byte[]>() {
+        var dictionary = new Dictionary<byte[], byte[]>() {
                     { key1, value1 },
                     { key2, value2 }
                 };
-            CacheSetMultiResponse response = client.SetMulti(CacheName, dictionary);
-            Assert.Equal(dictionary, response.Bytes());
+        CacheSetMultiResponse response = client.SetMulti(CacheName, dictionary);
+        Assert.Equal(dictionary, response.Bytes());
 
-            var getResponse = client.Get(CacheName, key1);
-            Assert.Equal(value1, getResponse.Bytes());
+        var getResponse = client.Get(CacheName, key1);
+        Assert.Equal(value1, getResponse.Bytes());
 
-            getResponse = client.Get(CacheName, key2);
-            Assert.Equal(value2, getResponse.Bytes());
-        }
+        getResponse = client.Get(CacheName, key2);
+        Assert.Equal(value2, getResponse.Bytes());
+    }
 
 
-        [Fact]
-        public void SetMulti_NullCheckString_ThrowsException()
-        {
-            Assert.Throws<ArgumentNullException>(() => client.SetMulti(null!, new Dictionary<string, string>()));
-            Assert.Throws<ArgumentNullException>(() => client.SetMulti("cache", (Dictionary<string, string>)null!));
+    [Fact]
+    public void SetMulti_NullCheckString_ThrowsException()
+    {
+        Assert.Throws<ArgumentNullException>(() => client.SetMulti(null!, new Dictionary<string, string>()));
+        Assert.Throws<ArgumentNullException>(() => client.SetMulti("cache", (Dictionary<string, string>)null!));
 
-            var badDictionary = new Dictionary<string, string>() { { "asdf", null! } };
-            Assert.Throws<ArgumentNullException>(() => client.SetMulti("cache", badDictionary));
-        }
+        var badDictionary = new Dictionary<string, string>() { { "asdf", null! } };
+        Assert.Throws<ArgumentNullException>(() => client.SetMulti("cache", badDictionary));
+    }
 
-        [Fact]
-        public void SetMulti_KeysAreString_HappyPath()
-        {
-	    var key1 = Utils.GuidString();
-            var key2 = Utils.GuidString();
-            var value1 = Utils.GuidString();
-            var value2 = Utils.GuidString();
+    [Fact]
+    public void SetMulti_KeysAreString_HappyPath()
+    {
+        var key1 = Utils.GuidString();
+        var key2 = Utils.GuidString();
+        var value1 = Utils.GuidString();
+        var value2 = Utils.GuidString();
 
-            var dictionary = new Dictionary<string, string>() {
+        var dictionary = new Dictionary<string, string>() {
                     { key1, value1 },
                     { key2, value2 }
                 };
-            CacheSetMultiResponse response = client.SetMulti(CacheName, dictionary);
-            Assert.Equal(dictionary, response.Strings());
+        CacheSetMultiResponse response = client.SetMulti(CacheName, dictionary);
+        Assert.Equal(dictionary, response.Strings());
 
-            var getResponse = client.Get(CacheName, key1);
-            Assert.Equal(value1, getResponse.String());
+        var getResponse = client.Get(CacheName, key1);
+        Assert.Equal(value1, getResponse.String());
 
-            getResponse = client.Get(CacheName, key2);
-            Assert.Equal(value2, getResponse.String());
-        }
+        getResponse = client.Get(CacheName, key2);
+        Assert.Equal(value2, getResponse.String());
+    }
 
-        [Theory]
-        [InlineData(null, new byte[] { 0x00 })]
-        [InlineData("cache", null)]
-        public void Delete_NullChecksBytes_ThrowsException(string cacheName, byte[] key)
-        {
-            Assert.Throws<ArgumentNullException>(() => client.Delete(cacheName, key));
-        }
+    [Theory]
+    [InlineData(null, new byte[] { 0x00 })]
+    [InlineData("cache", null)]
+    public void Delete_NullChecksBytes_ThrowsException(string cacheName, byte[] key)
+    {
+        Assert.Throws<ArgumentNullException>(() => client.Delete(cacheName, key));
+    }
 
-        [Fact]
-        public void Delete_KeyIsBytes_HappyPath()
-        {
-            // Set a key to then delete
-            byte[] key = new byte[] { 0x01, 0x02, 0x03, 0x04 };
-            byte[] value = new byte[] { 0x05, 0x06, 0x07, 0x08 };
-            client.Set(CacheName, key, value, ttlSeconds: 60);
-            CacheGetResponse getResponse = client.Get(CacheName, key);
-            Assert.Equal(CacheGetStatus.HIT, getResponse.Status);
+    [Fact]
+    public void Delete_KeyIsBytes_HappyPath()
+    {
+        // Set a key to then delete
+        byte[] key = new byte[] { 0x01, 0x02, 0x03, 0x04 };
+        byte[] value = new byte[] { 0x05, 0x06, 0x07, 0x08 };
+        client.Set(CacheName, key, value, ttlSeconds: 60);
+        CacheGetResponse getResponse = client.Get(CacheName, key);
+        Assert.Equal(CacheGetStatus.HIT, getResponse.Status);
 
-            // Delete
-            client.Delete(CacheName, key);
+        // Delete
+        client.Delete(CacheName, key);
 
-            // Check deleted
-            getResponse = client.Get(CacheName, key);
-            Assert.Equal(CacheGetStatus.MISS, getResponse.Status);
-        }
+        // Check deleted
+        getResponse = client.Get(CacheName, key);
+        Assert.Equal(CacheGetStatus.MISS, getResponse.Status);
+    }
 
-        [Theory]
-        [InlineData(null, new byte[] { 0x00 })]
-        [InlineData("cache", null)]
-        public async void DeleteAsync_NullChecksByte_ThrowsException(string cacheName, byte[] key)
-        {
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.DeleteAsync(cacheName, key));
-        }
+    [Theory]
+    [InlineData(null, new byte[] { 0x00 })]
+    [InlineData("cache", null)]
+    public async void DeleteAsync_NullChecksByte_ThrowsException(string cacheName, byte[] key)
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.DeleteAsync(cacheName, key));
+    }
 
-        [Fact]
-        public async void DeleteAsync_KeyIsBytes_HappyPath()
-        {
-            // Set a key to then delete
-            byte[] key = new byte[] { 0x01, 0x02, 0x03, 0x04 };
-            byte[] value = new byte[] { 0x05, 0x06, 0x07, 0x08 };
-            await client.SetAsync(CacheName, key, value, ttlSeconds: 60);
-            CacheGetResponse getResponse = await client.GetAsync(CacheName, key);
-            Assert.Equal(CacheGetStatus.HIT, getResponse.Status);
+    [Fact]
+    public async void DeleteAsync_KeyIsBytes_HappyPath()
+    {
+        // Set a key to then delete
+        byte[] key = new byte[] { 0x01, 0x02, 0x03, 0x04 };
+        byte[] value = new byte[] { 0x05, 0x06, 0x07, 0x08 };
+        await client.SetAsync(CacheName, key, value, ttlSeconds: 60);
+        CacheGetResponse getResponse = await client.GetAsync(CacheName, key);
+        Assert.Equal(CacheGetStatus.HIT, getResponse.Status);
 
-            // Delete
-            await client.DeleteAsync(CacheName, key);
+        // Delete
+        await client.DeleteAsync(CacheName, key);
 
-            // Check deleted
-            getResponse = await client.GetAsync(CacheName, key);
-            Assert.Equal(CacheGetStatus.MISS, getResponse.Status);
-        }
+        // Check deleted
+        getResponse = await client.GetAsync(CacheName, key);
+        Assert.Equal(CacheGetStatus.MISS, getResponse.Status);
+    }
 
-        [Theory]
-        [InlineData(null, "key")]
-        [InlineData("cache", null)]
-        public void Delete_NullChecksString_ThrowsException(string cacheName, string key)
-        {
-            Assert.Throws<ArgumentNullException>(() => client.Delete(cacheName, key));
-        }
+    [Theory]
+    [InlineData(null, "key")]
+    [InlineData("cache", null)]
+    public void Delete_NullChecksString_ThrowsException(string cacheName, string key)
+    {
+        Assert.Throws<ArgumentNullException>(() => client.Delete(cacheName, key));
+    }
 
-        [Fact]
-        public void Delete_KeyIsString_HappyPath()
-        {
-            // Set a key to then delete
-            string key = Utils.GuidString();
-            string value = Utils.GuidString();
-            client.Set(CacheName, key, value, ttlSeconds: 60);
-            CacheGetResponse getResponse = client.Get(CacheName, key);
-            Assert.Equal(CacheGetStatus.HIT, getResponse.Status);
+    [Fact]
+    public void Delete_KeyIsString_HappyPath()
+    {
+        // Set a key to then delete
+        string key = Utils.GuidString();
+        string value = Utils.GuidString();
+        client.Set(CacheName, key, value, ttlSeconds: 60);
+        CacheGetResponse getResponse = client.Get(CacheName, key);
+        Assert.Equal(CacheGetStatus.HIT, getResponse.Status);
 
-            // Delete
-            client.Delete(CacheName, key);
+        // Delete
+        client.Delete(CacheName, key);
 
-            // Check deleted
-            getResponse = client.Get(CacheName, key);
-            Assert.Equal(CacheGetStatus.MISS, getResponse.Status);
-        }
+        // Check deleted
+        getResponse = client.Get(CacheName, key);
+        Assert.Equal(CacheGetStatus.MISS, getResponse.Status);
+    }
 
-        [Theory]
-        [InlineData(null, "key")]
-        [InlineData("cache", null)]
-        public async void DeleteAsync_NullChecksString_ThrowsException(string cacheName, string key)
-        {
-            await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.DeleteAsync(cacheName, key));
-        }
+    [Theory]
+    [InlineData(null, "key")]
+    [InlineData("cache", null)]
+    public async void DeleteAsync_NullChecksString_ThrowsException(string cacheName, string key)
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.DeleteAsync(cacheName, key));
+    }
 
-        [Fact]
-        public async void DeleteAsync_KeyIsString_HappyPath()
-        {
-            // Set a key to then delete
-            string key = Utils.GuidString();
-            string value = Utils.GuidString();
-            await client.SetAsync(CacheName, key, value, ttlSeconds: 60);
-            CacheGetResponse getResponse = await client.GetAsync(CacheName, key);
-            Assert.Equal(CacheGetStatus.HIT, getResponse.Status);
+    [Fact]
+    public async void DeleteAsync_KeyIsString_HappyPath()
+    {
+        // Set a key to then delete
+        string key = Utils.GuidString();
+        string value = Utils.GuidString();
+        await client.SetAsync(CacheName, key, value, ttlSeconds: 60);
+        CacheGetResponse getResponse = await client.GetAsync(CacheName, key);
+        Assert.Equal(CacheGetStatus.HIT, getResponse.Status);
 
-            // Delete
-            await client.DeleteAsync(CacheName, key);
+        // Delete
+        await client.DeleteAsync(CacheName, key);
 
-            // Check deleted
-            getResponse = await client.GetAsync(CacheName, key);
-            Assert.Equal(CacheGetStatus.MISS, getResponse.Status);
-        }
+        // Check deleted
+        getResponse = await client.GetAsync(CacheName, key);
+        Assert.Equal(CacheGetStatus.MISS, getResponse.Status);
     }
 }

--- a/MomentoTest/MomentoSignerTest.cs
+++ b/MomentoTest/MomentoSignerTest.cs
@@ -1,99 +1,98 @@
-﻿using System;
+﻿using Microsoft.IdentityModel.Tokens;
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Web;
 using Xunit;
 using MomentoSdk;
-using System.IdentityModel.Tokens.Jwt;
-using Microsoft.IdentityModel.Tokens;
-using System.Web;
 using MomentoSdk.Exceptions;
 
-namespace MomentoTest
+namespace MomentoTest;
+
+public class MomentoSignerTest
 {
-    public class MomentoSignerTest
+    private const string RS256_JWK = "{\"p\":\"_oJd2v0VrexsvlfO0O0i6MFfgy3yyRh6cUjCOrFxGccFVFsIBfa6zbo78Wsx_kDx75Z4k9x_Mw8lueP7e4nGyzDDODPo2l5ERnVvtcKndN1N9WKp8MJHm7T9FTx6tXf2f6sfUmzDchTGZT3MuZ5K1lYpfAcWb9G7e_1kiUMfgTU\",\"kty\":\"RSA\",\"q\":\"vTSy0-0qS71GDt9e6Tj12XO_bhDVifgrkrSL92llmfRPxv7KQeUE3gDO90YR6K7PHBbcB60Z69lTpk374zniI4E38mvSmB4box0E2ATpzMvX6on-H4mCjUvePd2Qj0JAg2Uyqeze9lunh2C2KXul4VHzBiygCOIHu_r86Wa5iPs\",\"d\":\"Ou0zcMZ6gL3c79W82wqVqZTggJZSDOe_1l4klAvitTeg48nE31nQAzeT0cn8YyjY2nDA9iBc8jGrCnV9HaYhRlCZ_XE8036HVm9Sw1WjmJqDqWyhDsfV4o74jcxn8QNOKLX2NcWJxo11kOWdMh5AMYXQt2xh2yeV4QG996-EnC-8aoBYbRJO93ZTiJss1FPgXfe8gEJnv27ShjD1MjCl2ikGvTa5HOX3aUYvPJezN_HvKfovbp9h77DE5y9V2KewqGI5m25b97CzBn_pcQioiPlzoHck_x9C77GOsySOg3C3Le0fJdGXgMJmyBrDlmjF7YfeRbqwxUSX0CzdubVldQ\",\"e\":\"AQAB\",\"kid\":\"fooKeyId\",\"qi\":\"CnV6ziWMCxQvPe447kifPXAY9fqMv47RcHZmS3Co1EQNnP1CGO5H8tFgAso6IxPWyFexaRqPtX8JYgpjiR3fm-PwjD7RI50XU3cNOw2SRxpdA5KDGgZXecMOx81DRTBPAtDOUII-pmEfvJKXVQCiRnoiFbFqr66nXaO6mTe0Xm4\",\"dp\":\"MsSsli9f8La1pm57md-D1CwmslMrGAQjAJAD9pNIvVye6onSGuZxsvIQXQMGEPLBkApS-SPF19iQrPkWRDlih0ut1Xs9WrntIqTwaLBwmPZAQ8-vmJAYmq3Kwj6zN5m7eRIYiGebwRj1zmI6gVhbE1BSrCP5zMpofL46HMtf8HU\",\"alg\":\"RS256\",\"dq\":\"G5LliOskYdtYrWwyOcz6T1GGEXVUmYHYX83-I_VxQCmRws95DHdi6TO29eR5Ua7AMjjGojvA7lVC0pbE4c2avk_jpmm-TDr_Dht5jD3TEOyYL-8iYNg6dXscDWoP2kDug_eolYkWyVJ8LMeUZKFHgHnf8ANq40CFngiq-RzmZyc\",\"n\":\"vBqjjxPSxtoLutQ5C0ivkbQmjFoJNIMC4CjWDK_gMTU2wF8S5g3FRSsGjqIj0EIWUtQOn_wMU5n98bRRnOwhGVRqFsWNwNwxQ_v_9VTSPBDWOJOd9Zlsey6UjklA7SfikqCgwBK_hDIaWhrlt7vY0Zu2eMdGTVb9_lyfDPfEiv5ONPOnaFK98EP-WYvmfulaWvqTTUVHaRZps4sZsrftsVShupBKjzttADXz9KRePOjUgxIAfg42yAm1YnGIJk36tdUo_HczpDQat0UdI0x4gI3baNdXIYdDazzziJyxbZaD9c7ii1Vm4PAyhAIpxeIh8TDsrzUyTneGaVK6CdTW9w\"}";
+    private const string ES256_JWK = "{\"kty\":\"EC\",\"d\":\"wLj6mq_IqGAqz40RyR1QiH1KElvhECQ8dQAcu7iRwWE\",\"crv\":\"P-256\",\"kid\":\"fooKeyId\",\"x\":\"pSU203ud3cNnVeCgaho2z-JBao21EHFm4or75sV8RkY\",\"y\":\"uSwevlzSV3kyArKAu7qv7I_ffaXAvAp98YM0zwUA5jA\",\"alg\":\"ES256\"}";
+    private const string RS384_JWK = "{\"p\":\"_LVm8mWfx8Td7zg7Xupll_2pVGyhwmos18Mi6_vr0DglnDWOg3nsfjaS6j5a_mwgeEHUUjXaORf5zZMI3hVaD9-1WaaErmrUlZuNDvAtgb1MLLzgzP2WYmdAAzSn1-0fOqUiiZtAADEr-gmCrN-ofbDcKmppdwA1DbOaCMmVvc0\",\"kty\":\"RSA\",\"q\":\"yr9ZUQAotA7KllPB7klkeDwfDv2FIz-N7Yms20Nv20oALB3XLWlEkG85AOuYwAk-gXBtu45piM4D3jfHDsP5uycvXdxVGlna56XKUjgfSHW3UdfKxhd9FzOY4MvPG_Aj1rdkuNOPCNUGtRRbXA3HNjhBoJoSg5dbSCwnQzi10rM\",\"d\":\"DsnOr7w7Zo5qmNMr7sfhKvtQOJFaUwS_IhLyyNntmn57FuqlqMO1cv7_uzRer-LbI9dF7J4DVjtf6jEe7CcbYQHMCQqbj2RPrubprqYojjBKVtSlUt9hOIK8DswgyrXX8JnpMsLIw8Mdvyo5EbCw7tt4qKeTePFk-xA7GAqHi3FLisst3ijkpQT5OjbUA1GYMIijzJfcFOgjtbvLghDl1XLW29ZP3K1MYkNtX9P3bbbI5GRwWSo5SsGzzcNCbI4unfHU8MIf-cDUDopeAM6ixjB-OXzz6Fq4J-XeIS0-4vZMYD2l5OuD0gQfkCiYfOyrNPL0KqZxolioRvD1dRzTXQ\",\"e\":\"AQAB\",\"kid\":\"fooKeyId\",\"qi\":\"YWx6rzgadSyrpCc4YTmq_ly_JHXxPO5ddZoWmukVb_tF-3E-sBaOd7jBj4OJnrHqTz2EkwUw8krexoptZEvMPjvLRxdubwgqw6d8SCC-6DKOfUJB43diY56lzIxlIA32BemLx6B0SrBIbgWhY1IkAJlj2AiAh01ygDh1tH-FoKI\",\"dp\":\"x152MZZrUDfIwAolDOTv8dF13d02YSNS7YZN7s95Y3Rod6zpGmD-azSzA4reTwsPMtD8qT9DQvffZIgz3sIJo6xibrAozVILFVz7FGX4APtPNZxt3kvScR_0KJNKN9gjYykU7mtFOuGQSFtodOqfC0qU6AG74t6O_JhNVdF0CaE\",\"alg\":\"RS384\",\"dq\":\"C53ZFT4IFwD99I0KAIgt_IGdWfOGrFVY4XJQ-CMuBod_6QcwrAZrCkeFIZteHiqpbSsu7l8jhtYe_J1_h0YNSf7dxOf57E-XrkwegoV6rWEpRsQxdxYjca_gI4kp7bTdqNDLMZfVizEBeGCZN3YGowGoKPaK9wU2ErWM7loSeOc\",\"n\":\"yCQGvhlh6_RTK3gtJPgllHHUYT_hx9xgeDhLRQAadHd0FjCCBHXLisTABHIu568rn86chznbzN0yLDJ-C5Q8YM46xxJZgDfG3Sq4NlZJcrxjBeTIVXeqWj0W5HDK8PDIYgEZfXmJ4AKeB3PQT5o25zN92ja45bFHk8vHBo_TECYYxHvI7TzbMOs5Z4PvWQnfR34GR0TvD4iHSEq6r0TTrYhdtLRq-PsIOk--0subO7uTEVqLCU99wQmsty0VacmIeezuap2OgR0EG4nlAzjqs8EyZqJKin8b9dRfQm8UOpQ1GbU7pKxymQc7pb1K54YSXFF5lYalcQOWlhmM01bgVw\"}";
+
+    [Theory]
+    [InlineData(RS256_JWK)]
+    [InlineData(ES256_JWK)]
+    [InlineData(RS384_JWK)]
+    public void TestJwkRoundTrip(string jwk)
     {
-        private const string RS256_JWK = "{\"p\":\"_oJd2v0VrexsvlfO0O0i6MFfgy3yyRh6cUjCOrFxGccFVFsIBfa6zbo78Wsx_kDx75Z4k9x_Mw8lueP7e4nGyzDDODPo2l5ERnVvtcKndN1N9WKp8MJHm7T9FTx6tXf2f6sfUmzDchTGZT3MuZ5K1lYpfAcWb9G7e_1kiUMfgTU\",\"kty\":\"RSA\",\"q\":\"vTSy0-0qS71GDt9e6Tj12XO_bhDVifgrkrSL92llmfRPxv7KQeUE3gDO90YR6K7PHBbcB60Z69lTpk374zniI4E38mvSmB4box0E2ATpzMvX6on-H4mCjUvePd2Qj0JAg2Uyqeze9lunh2C2KXul4VHzBiygCOIHu_r86Wa5iPs\",\"d\":\"Ou0zcMZ6gL3c79W82wqVqZTggJZSDOe_1l4klAvitTeg48nE31nQAzeT0cn8YyjY2nDA9iBc8jGrCnV9HaYhRlCZ_XE8036HVm9Sw1WjmJqDqWyhDsfV4o74jcxn8QNOKLX2NcWJxo11kOWdMh5AMYXQt2xh2yeV4QG996-EnC-8aoBYbRJO93ZTiJss1FPgXfe8gEJnv27ShjD1MjCl2ikGvTa5HOX3aUYvPJezN_HvKfovbp9h77DE5y9V2KewqGI5m25b97CzBn_pcQioiPlzoHck_x9C77GOsySOg3C3Le0fJdGXgMJmyBrDlmjF7YfeRbqwxUSX0CzdubVldQ\",\"e\":\"AQAB\",\"kid\":\"fooKeyId\",\"qi\":\"CnV6ziWMCxQvPe447kifPXAY9fqMv47RcHZmS3Co1EQNnP1CGO5H8tFgAso6IxPWyFexaRqPtX8JYgpjiR3fm-PwjD7RI50XU3cNOw2SRxpdA5KDGgZXecMOx81DRTBPAtDOUII-pmEfvJKXVQCiRnoiFbFqr66nXaO6mTe0Xm4\",\"dp\":\"MsSsli9f8La1pm57md-D1CwmslMrGAQjAJAD9pNIvVye6onSGuZxsvIQXQMGEPLBkApS-SPF19iQrPkWRDlih0ut1Xs9WrntIqTwaLBwmPZAQ8-vmJAYmq3Kwj6zN5m7eRIYiGebwRj1zmI6gVhbE1BSrCP5zMpofL46HMtf8HU\",\"alg\":\"RS256\",\"dq\":\"G5LliOskYdtYrWwyOcz6T1GGEXVUmYHYX83-I_VxQCmRws95DHdi6TO29eR5Ua7AMjjGojvA7lVC0pbE4c2avk_jpmm-TDr_Dht5jD3TEOyYL-8iYNg6dXscDWoP2kDug_eolYkWyVJ8LMeUZKFHgHnf8ANq40CFngiq-RzmZyc\",\"n\":\"vBqjjxPSxtoLutQ5C0ivkbQmjFoJNIMC4CjWDK_gMTU2wF8S5g3FRSsGjqIj0EIWUtQOn_wMU5n98bRRnOwhGVRqFsWNwNwxQ_v_9VTSPBDWOJOd9Zlsey6UjklA7SfikqCgwBK_hDIaWhrlt7vY0Zu2eMdGTVb9_lyfDPfEiv5ONPOnaFK98EP-WYvmfulaWvqTTUVHaRZps4sZsrftsVShupBKjzttADXz9KRePOjUgxIAfg42yAm1YnGIJk36tdUo_HczpDQat0UdI0x4gI3baNdXIYdDazzziJyxbZaD9c7ii1Vm4PAyhAIpxeIh8TDsrzUyTneGaVK6CdTW9w\"}";
-        private const string ES256_JWK = "{\"kty\":\"EC\",\"d\":\"wLj6mq_IqGAqz40RyR1QiH1KElvhECQ8dQAcu7iRwWE\",\"crv\":\"P-256\",\"kid\":\"fooKeyId\",\"x\":\"pSU203ud3cNnVeCgaho2z-JBao21EHFm4or75sV8RkY\",\"y\":\"uSwevlzSV3kyArKAu7qv7I_ffaXAvAp98YM0zwUA5jA\",\"alg\":\"ES256\"}";
-        private const string RS384_JWK = "{\"p\":\"_LVm8mWfx8Td7zg7Xupll_2pVGyhwmos18Mi6_vr0DglnDWOg3nsfjaS6j5a_mwgeEHUUjXaORf5zZMI3hVaD9-1WaaErmrUlZuNDvAtgb1MLLzgzP2WYmdAAzSn1-0fOqUiiZtAADEr-gmCrN-ofbDcKmppdwA1DbOaCMmVvc0\",\"kty\":\"RSA\",\"q\":\"yr9ZUQAotA7KllPB7klkeDwfDv2FIz-N7Yms20Nv20oALB3XLWlEkG85AOuYwAk-gXBtu45piM4D3jfHDsP5uycvXdxVGlna56XKUjgfSHW3UdfKxhd9FzOY4MvPG_Aj1rdkuNOPCNUGtRRbXA3HNjhBoJoSg5dbSCwnQzi10rM\",\"d\":\"DsnOr7w7Zo5qmNMr7sfhKvtQOJFaUwS_IhLyyNntmn57FuqlqMO1cv7_uzRer-LbI9dF7J4DVjtf6jEe7CcbYQHMCQqbj2RPrubprqYojjBKVtSlUt9hOIK8DswgyrXX8JnpMsLIw8Mdvyo5EbCw7tt4qKeTePFk-xA7GAqHi3FLisst3ijkpQT5OjbUA1GYMIijzJfcFOgjtbvLghDl1XLW29ZP3K1MYkNtX9P3bbbI5GRwWSo5SsGzzcNCbI4unfHU8MIf-cDUDopeAM6ixjB-OXzz6Fq4J-XeIS0-4vZMYD2l5OuD0gQfkCiYfOyrNPL0KqZxolioRvD1dRzTXQ\",\"e\":\"AQAB\",\"kid\":\"fooKeyId\",\"qi\":\"YWx6rzgadSyrpCc4YTmq_ly_JHXxPO5ddZoWmukVb_tF-3E-sBaOd7jBj4OJnrHqTz2EkwUw8krexoptZEvMPjvLRxdubwgqw6d8SCC-6DKOfUJB43diY56lzIxlIA32BemLx6B0SrBIbgWhY1IkAJlj2AiAh01ygDh1tH-FoKI\",\"dp\":\"x152MZZrUDfIwAolDOTv8dF13d02YSNS7YZN7s95Y3Rod6zpGmD-azSzA4reTwsPMtD8qT9DQvffZIgz3sIJo6xibrAozVILFVz7FGX4APtPNZxt3kvScR_0KJNKN9gjYykU7mtFOuGQSFtodOqfC0qU6AG74t6O_JhNVdF0CaE\",\"alg\":\"RS384\",\"dq\":\"C53ZFT4IFwD99I0KAIgt_IGdWfOGrFVY4XJQ-CMuBod_6QcwrAZrCkeFIZteHiqpbSsu7l8jhtYe_J1_h0YNSf7dxOf57E-XrkwegoV6rWEpRsQxdxYjca_gI4kp7bTdqNDLMZfVizEBeGCZN3YGowGoKPaK9wU2ErWM7loSeOc\",\"n\":\"yCQGvhlh6_RTK3gtJPgllHHUYT_hx9xgeDhLRQAadHd0FjCCBHXLisTABHIu568rn86chznbzN0yLDJ-C5Q8YM46xxJZgDfG3Sq4NlZJcrxjBeTIVXeqWj0W5HDK8PDIYgEZfXmJ4AKeB3PQT5o25zN92ja45bFHk8vHBo_TECYYxHvI7TzbMOs5Z4PvWQnfR34GR0TvD4iHSEq6r0TTrYhdtLRq-PsIOk--0subO7uTEVqLCU99wQmsty0VacmIeezuap2OgR0EG4nlAzjqs8EyZqJKin8b9dRfQm8UOpQ1GbU7pKxymQc7pb1K54YSXFF5lYalcQOWlhmM01bgVw\"}";
+        MomentoSigner signer = new MomentoSigner(jwk);
+        uint expiryEpochSeconds = uint.MaxValue;
+        var url = signer.CreatePresignedUrl("foobar.com", new SigningRequest("testCacheName", "testCacheKey", CacheOperation.GET, expiryEpochSeconds)); ;
 
-        [Theory]
-        [InlineData(RS256_JWK)]
-        [InlineData(ES256_JWK)]
-        [InlineData(RS384_JWK)]
-        public void TestJwkRoundTrip(string jwk)
+        string? jwt = HttpUtility.ParseQueryString(new Uri(url).Query).Get("token");
+
+        var securityKey = new JsonWebKey(jwk);
+        TokenValidationParameters validationParameters = new TokenValidationParameters()
         {
-            MomentoSigner signer = new MomentoSigner(jwk);
-            uint expiryEpochSeconds = uint.MaxValue;
-            var url = signer.CreatePresignedUrl("foobar.com", new SigningRequest("testCacheName", "testCacheKey", CacheOperation.GET, expiryEpochSeconds)); ;
+            RequireExpirationTime = false,
+            ValidateAudience = false,
+            ValidateIssuer = false,
+            IssuerSigningKey = securityKey
+        };
+        SecurityToken validatedToken;
+        new JwtSecurityTokenHandler().ValidateToken(jwt, validationParameters, out validatedToken);
+        Assert.Equal(new DateTime(2106, 02, 07, 06, 28, 15), validatedToken.ValidTo);
+    }
 
-            string? jwt = HttpUtility.ParseQueryString(new Uri(url).Query).Get("token");
+    [Fact]
+    public void TestPresignedUrlForGet()
+    {
+        MomentoSigner signer = new MomentoSigner(RS256_JWK);
+        uint expiryEpochSeconds = uint.MaxValue;
+        var url = signer.CreatePresignedUrl("foobar.com", new SigningRequest("testCacheName", "testCacheKey", CacheOperation.GET, expiryEpochSeconds));
 
-            var securityKey = new JsonWebKey(jwk);
-            TokenValidationParameters validationParameters = new TokenValidationParameters()
-            {
-                RequireExpirationTime = false,
-                ValidateAudience = false,
-                ValidateIssuer = false,
-                IssuerSigningKey = securityKey
-            };
-            SecurityToken validatedToken;
-            new JwtSecurityTokenHandler().ValidateToken(jwt, validationParameters, out validatedToken);
-            Assert.Equal(new DateTime(2106, 02, 07, 06, 28, 15), validatedToken.ValidTo);
-        }
+        Uri? uriResult;
+        bool result = Uri.TryCreate(url, UriKind.Absolute, out uriResult);
+        Assert.True(result);
+        Assert.Equal(Uri.UriSchemeHttps, uriResult?.Scheme);
+        Assert.StartsWith("https://rest.foobar.com/cache/get/testCacheName/testCacheKey?token=", url);
+    }
 
-        [Fact]
-        public void TestPresignedUrlForGet()
+    [Fact]
+    public void TestPresignedUrlForSet()
+    {
+        MomentoSigner signer = new MomentoSigner(RS256_JWK);
+        uint expiryEpochSeconds = uint.MaxValue;
+        var req = new SigningRequest("testCacheName", "testCacheKey", CacheOperation.SET, expiryEpochSeconds)
         {
-            MomentoSigner signer = new MomentoSigner(RS256_JWK);
-            uint expiryEpochSeconds = uint.MaxValue;
-            var url = signer.CreatePresignedUrl("foobar.com", new SigningRequest("testCacheName", "testCacheKey", CacheOperation.GET, expiryEpochSeconds));
+            TtlSeconds = uint.MaxValue
+        };
+        var url = signer.CreatePresignedUrl("foobar.com", req);
 
-            Uri? uriResult;
-            bool result = Uri.TryCreate(url, UriKind.Absolute, out uriResult);
-            Assert.True(result);
-            Assert.Equal(Uri.UriSchemeHttps, uriResult?.Scheme);
-            Assert.StartsWith("https://rest.foobar.com/cache/get/testCacheName/testCacheKey?token=", url);
-        }
+        Uri? uriResult;
+        bool result = Uri.TryCreate(url, UriKind.Absolute, out uriResult);
+        Assert.True(result);
+        Assert.Equal(Uri.UriSchemeHttps, uriResult?.Scheme);
+        Assert.StartsWith("https://rest.foobar.com/cache/set/testCacheName/testCacheKey?ttl_milliseconds=4294967295000&token=", url);
+    }
 
-        [Fact]
-        public void TestPresignedUrlForSet()
-        {
-            MomentoSigner signer = new MomentoSigner(RS256_JWK);
-            uint expiryEpochSeconds = uint.MaxValue;
-            var req = new SigningRequest("testCacheName", "testCacheKey", CacheOperation.SET, expiryEpochSeconds)
-            {
-                TtlSeconds = uint.MaxValue
-            };
-            var url = signer.CreatePresignedUrl("foobar.com", req);
+    [Fact]
+    public void TestUrlEncoding()
+    {
+        MomentoSigner signer = new MomentoSigner(RS256_JWK);
+        uint expiryEpochSeconds = uint.MaxValue;
+        var testCacheKey = "#$&\\'+,/:;=?@[]";
+        var url = signer.CreatePresignedUrl("foobar.com", new SigningRequest("testCacheName", testCacheKey, CacheOperation.GET, expiryEpochSeconds));
 
-            Uri? uriResult;
-            bool result = Uri.TryCreate(url, UriKind.Absolute, out uriResult);
-            Assert.True(result);
-            Assert.Equal(Uri.UriSchemeHttps, uriResult?.Scheme);
-            Assert.StartsWith("https://rest.foobar.com/cache/set/testCacheName/testCacheKey?ttl_milliseconds=4294967295000&token=", url);
-        }
+        Uri? uriResult;
+        bool result = Uri.TryCreate(url, UriKind.Absolute, out uriResult);
+        Assert.True(result);
+        Assert.Equal(Uri.UriSchemeHttps, uriResult?.Scheme);
+        Assert.StartsWith("https://rest.foobar.com/cache/get/testCacheName/%23%24%26%5c%27%2b%2c%2f%3a%3b%3d%3f%40%5b%5d?token=", url);
+    }
 
-        [Fact]
-        public void TestUrlEncoding()
-        {
-            MomentoSigner signer = new MomentoSigner(RS256_JWK);
-            uint expiryEpochSeconds = uint.MaxValue;
-            var testCacheKey = "#$&\\'+,/:;=?@[]";
-            var url = signer.CreatePresignedUrl("foobar.com", new SigningRequest("testCacheName", testCacheKey, CacheOperation.GET, expiryEpochSeconds));
+    [Fact]
+    public void TestJwkError()
+    {
+        uint expiryEpochSeconds = uint.MaxValue;
+        var invalidJwk = "{\"alg\":\"foo\"}";
+        MomentoSigner signer = new MomentoSigner(invalidJwk);
 
-            Uri? uriResult;
-            bool result = Uri.TryCreate(url, UriKind.Absolute, out uriResult);
-            Assert.True(result);
-            Assert.Equal(Uri.UriSchemeHttps, uriResult?.Scheme);
-            Assert.StartsWith("https://rest.foobar.com/cache/get/testCacheName/%23%24%26%5c%27%2b%2c%2f%3a%3b%3d%3f%40%5b%5d?token=", url);
-        }
-
-        [Fact]
-        public void TestJwkError()
-        {
-            uint expiryEpochSeconds = uint.MaxValue;
-            var invalidJwk = "{\"alg\":\"foo\"}";
-            MomentoSigner signer = new MomentoSigner(invalidJwk);
-
-            Assert.Throws<InvalidArgumentException>(() => signer.SignAccessToken(new SigningRequest("testCacheName", "testCacheKey", CacheOperation.GET, expiryEpochSeconds)));
-        }
+        Assert.Throws<InvalidArgumentException>(() => signer.SignAccessToken(new SigningRequest("testCacheName", "testCacheKey", CacheOperation.GET, expiryEpochSeconds)));
     }
 }

--- a/MomentoTest/Responses/CacheGetResponseTest.cs
+++ b/MomentoTest/Responses/CacheGetResponseTest.cs
@@ -1,30 +1,29 @@
-﻿using Xunit;
-using MomentoSdk.Responses;
-using CacheClient;
+﻿using CacheClient;
 using Google.Protobuf;
+using Xunit;
 using MomentoSdk.Exceptions;
+using MomentoSdk.Responses;
 
-namespace MomentoTest.Responses
+namespace MomentoTest.Responses;
+
+public class CacheGetResponseTest
 {
-    public class CacheGetResponseTest
+    [Fact]
+    public void CorrectResultMapping()
     {
-        [Fact]
-        public void CorrectResultMapping()
-        {
-            string cacheBody = "test body";
-            ByteString body = ByteString.CopyFromUtf8(cacheBody);
-            _GetResponse serverResponseHit = new _GetResponse() { CacheBody = body, Result = ECacheResult.Hit };
-            CacheGetResponse responseHit = new CacheGetResponse(serverResponseHit);
-            Assert.Equal(CacheGetStatus.HIT, responseHit.Status);
-            Assert.Equal(cacheBody, responseHit.String());
+        string cacheBody = "test body";
+        ByteString body = ByteString.CopyFromUtf8(cacheBody);
+        _GetResponse serverResponseHit = new _GetResponse() { CacheBody = body, Result = ECacheResult.Hit };
+        CacheGetResponse responseHit = new CacheGetResponse(serverResponseHit);
+        Assert.Equal(CacheGetStatus.HIT, responseHit.Status);
+        Assert.Equal(cacheBody, responseHit.String());
 
-            _GetResponse serverResponseMiss = new _GetResponse() { Result = ECacheResult.Miss };
-            CacheGetResponse responseMiss = new CacheGetResponse(serverResponseMiss);
-            Assert.Equal(CacheGetStatus.MISS, responseMiss.Status);
+        _GetResponse serverResponseMiss = new _GetResponse() { Result = ECacheResult.Miss };
+        CacheGetResponse responseMiss = new CacheGetResponse(serverResponseMiss);
+        Assert.Equal(CacheGetStatus.MISS, responseMiss.Status);
 
-            _GetResponse serverResponseBadRequest = new _GetResponse() { Result = ECacheResult.Invalid };
-            _ = Assert.Throws<InternalServerException>(() => new CacheGetResponse(serverResponseBadRequest));
+        _GetResponse serverResponseBadRequest = new _GetResponse() { Result = ECacheResult.Invalid };
+        _ = Assert.Throws<InternalServerException>(() => new CacheGetResponse(serverResponseBadRequest));
 
-        }
     }
 }


### PR DESCRIPTION
This PR refactors the code to use namespace statements where
appropriate. In our case, that is everywhere. In C# there are two ways
to place code in a namespace:

(1) Using a namespace block (good when only part of the file should be
in this namespace):
```csharp
namespace MyNamespace
{
	// Code here indented +1 level
}
```

(2) To the entire file using a statement
```csharp
namespace MyNamespace;

// Code here with no extra indent necessary
```

All of our code used style (1), which was unncessary. In every case
the namespace applied to the whole file. Because we opted to use
blocks, every file carried an extra level of indentation.

This PR undoes this by switching to namespace statements (2). We
unindent each file by one level as a result.