### PR TITLE
chore: prefer properties to basic getter accessors

### DIFF
--- a/Momento/ControlGrpcManager.cs
+++ b/Momento/ControlGrpcManager.cs
@@ -11,7 +11,7 @@ namespace MomentoSdk;
 internal sealed class ControlGrpcManager : IDisposable
 {
     private readonly GrpcChannel channel;
-    private readonly ScsControl.ScsControlClient client;
+    public ScsControl.ScsControlClient Client { get; }
     private readonly string version = "csharp:" + GetAssembly(typeof(MomentoSdk.Responses.CacheGetResponse)).GetName().Version.ToString();
 
     public ControlGrpcManager(string authToken, string endpoint)
@@ -19,12 +19,7 @@ internal sealed class ControlGrpcManager : IDisposable
         this.channel = GrpcChannel.ForAddress(endpoint, new GrpcChannelOptions() { Credentials = ChannelCredentials.SecureSsl });
         List<Header> headers = new List<Header> { new Header(name: Header.AuthorizationKey, value: authToken), new Header(name: Header.AgentKey, value: version) };
         CallInvoker invoker = channel.Intercept(new HeaderInterceptor(headers));
-        this.client = new ScsControl.ScsControlClient(invoker);
-    }
-
-    public ScsControl.ScsControlClient Client()
-    {
-        return this.client;
+        Client = new ScsControl.ScsControlClient(invoker);
     }
 
     public void Dispose()

--- a/Momento/DataGrpcManager.cs
+++ b/Momento/DataGrpcManager.cs
@@ -11,7 +11,7 @@ namespace MomentoSdk;
 internal sealed class DataGrpcManager : IDisposable
 {
     private readonly GrpcChannel channel;
-    private readonly Scs.ScsClient client;
+    public Scs.ScsClient Client { get; }
 
     private readonly string version = "csharp:" + GetAssembly(typeof(MomentoSdk.Responses.CacheGetResponse)).GetName().Version.ToString();
 
@@ -20,12 +20,7 @@ internal sealed class DataGrpcManager : IDisposable
         this.channel = GrpcChannel.ForAddress(endpoint, new GrpcChannelOptions() { Credentials = ChannelCredentials.SecureSsl });
         List<Header> headers = new List<Header> { new Header(name: Header.AuthorizationKey, value: authToken), new Header(name: Header.AgentKey, value: version) };
         CallInvoker invoker = this.channel.Intercept(new HeaderInterceptor(headers));
-        this.client = new Scs.ScsClient(invoker);
-    }
-
-    internal Scs.ScsClient Client()
-    {
-        return this.client;
+        Client = new Scs.ScsClient(invoker);
     }
 
     public void Dispose()

--- a/Momento/Responses/CacheGetMultiResponse.cs
+++ b/Momento/Responses/CacheGetMultiResponse.cs
@@ -5,30 +5,25 @@ namespace MomentoSdk.Responses;
 
 public class CacheGetMultiResponse
 {
-    private readonly List<CacheGetResponse> responses;
+    public List<CacheGetResponse> Responses { get; }
 
     public CacheGetMultiResponse(IEnumerable<CacheGetResponse> responses)
     {
-        this.responses = new(responses);
+        this.Responses = new(responses);
     }
 
-    public List<CacheGetResponse> ToList()
+    public List<CacheGetStatus> Status
     {
-        return responses;
+        get => Responses.Select(response => response.Status).ToList();
     }
 
-    public List<CacheGetStatus> Status()
+    public List<string?> Strings
     {
-        return responses.Select(response => response.Status).ToList();
+	get => Responses.Select(response => response.String()).ToList();
     }
 
-    public List<string?> Strings()
+    public List<byte[]?> Bytes
     {
-        return responses.Select(response => response.String()).ToList();
-    }
-
-    public List<byte[]?> Bytes()
-    {
-        return responses.Select(response => response.Bytes()).ToList();
+        get => Responses.Select(response => response.Bytes).ToList();
     }
 }

--- a/Momento/Responses/CacheGetMultiResponse.cs
+++ b/Momento/Responses/CacheGetMultiResponse.cs
@@ -19,7 +19,7 @@ public class CacheGetMultiResponse
 
     public List<string?> Strings
     {
-	get => Responses.Select(response => response.String()).ToList();
+        get => Responses.Select(response => response.String()).ToList();
     }
 
     public List<byte[]?> Bytes

--- a/Momento/Responses/CacheGetResponse.cs
+++ b/Momento/Responses/CacheGetResponse.cs
@@ -7,35 +7,24 @@ namespace MomentoSdk.Responses;
 
 public class CacheGetResponse
 {
-    public CacheGetStatus Status { get; private set; }
-    private readonly ByteString body;
+    public CacheGetStatus Status { get; }
+    public byte[]? Bytes { get; }
 
     public CacheGetResponse(_GetResponse response)
     {
-        body = response.CacheBody;
         Status = From(response.Result);
+        Bytes = (Status == CacheGetStatus.HIT) ? response.CacheBody.ToByteArray() : null;
     }
 
     public string? String(Encoding? encoding = null)
     {
         encoding ??= Encoding.UTF8;
-
-        if (Status == CacheGetStatus.HIT)
+        if (Bytes == null)
         {
-            return body.ToString(encoding);
+            return null;
         }
-        return null;
+        return encoding.GetString(Bytes);
     }
-
-    public byte[]? Bytes()
-    {
-        if (Status == CacheGetStatus.HIT)
-        {
-            return body.ToByteArray();
-        }
-        return null;
-    }
-
 
     private static CacheGetStatus From(ECacheResult result)
     {

--- a/Momento/Responses/CacheInfo.cs
+++ b/Momento/Responses/CacheInfo.cs
@@ -4,16 +4,9 @@ namespace MomentoSdk.Responses;
 
 public class CacheInfo : IEquatable<CacheInfo>
 {
-    private readonly string name;
-    public CacheInfo(string cachename)
-    {
-        name = cachename;
-    }
+    public string Name { get; }
 
-    public string Name()
-    {
-        return name;
-    }
+    public CacheInfo(string cacheName) => Name = cacheName;
 
     // override object.Equals
     public bool Equals(CacheInfo? other)
@@ -23,7 +16,7 @@ public class CacheInfo : IEquatable<CacheInfo>
             return false;
         }
 
-        return this.name == other.name;
+        return this.Name == other.Name;
     }
 
     public override bool Equals(Object? obj)
@@ -38,6 +31,6 @@ public class CacheInfo : IEquatable<CacheInfo>
 
     public override int GetHashCode()
     {
-        return name.GetHashCode();
+        return Name.GetHashCode();
     }
 }

--- a/Momento/Responses/CacheSetMultiResponse.cs
+++ b/Momento/Responses/CacheSetMultiResponse.cs
@@ -16,13 +16,13 @@ public class CacheSetMultiResponse
         this.items = (object)items;
     }
 
-    public IDictionary<string, string> Strings()
+    public IDictionary<string, string> Strings
     {
-        return (IDictionary<string, string>)items;
+	get => (IDictionary<string, string>)items;
     }
 
-    public IDictionary<byte[], byte[]> Bytes()
+    public IDictionary<byte[], byte[]> Bytes
     {
-        return (IDictionary<byte[], byte[]>)items;
+	get => (IDictionary<byte[], byte[]>)items;
     }
 }

--- a/Momento/Responses/CacheSetMultiResponse.cs
+++ b/Momento/Responses/CacheSetMultiResponse.cs
@@ -18,11 +18,11 @@ public class CacheSetMultiResponse
 
     public IDictionary<string, string> Strings
     {
-	get => (IDictionary<string, string>)items;
+        get => (IDictionary<string, string>)items;
     }
 
     public IDictionary<byte[], byte[]> Bytes
     {
-	get => (IDictionary<byte[], byte[]>)items;
+        get => (IDictionary<byte[], byte[]>)items;
     }
 }

--- a/Momento/Responses/ListCachesResponse.cs
+++ b/Momento/Responses/ListCachesResponse.cs
@@ -4,26 +4,16 @@ namespace MomentoSdk.Responses;
 
 public class ListCachesResponse
 {
-    private readonly List<CacheInfo> caches;
-    private readonly string? nextPageToken;
+    public List<CacheInfo> Caches { get; }
+    public string? NextPageToken { get; }
 
     public ListCachesResponse(ControlClient._ListCachesResponse result)
     {
-        nextPageToken = result.NextToken == "" ? null : result.NextToken;
-        caches = new List<CacheInfo>();
+        NextPageToken = result.NextToken == "" ? null : result.NextToken;
+        Caches = new List<CacheInfo>();
         foreach (ControlClient._Cache c in result.Cache)
         {
-            caches.Add(new CacheInfo(c.CacheName));
+            Caches.Add(new CacheInfo(c.CacheName));
         }
-    }
-
-    public List<CacheInfo> Caches()
-    {
-        return caches;
-    }
-
-    public string? NextPageToken()
-    {
-        return nextPageToken;
     }
 }

--- a/Momento/ScsControlClient.cs
+++ b/Momento/ScsControlClient.cs
@@ -26,7 +26,7 @@ internal sealed class ScsControlClient : IDisposable
         try
         {
             _CreateCacheRequest request = new _CreateCacheRequest() { CacheName = cacheName };
-            this.grpcManager.Client().CreateCache(request, deadline: CalculateDeadline());
+            this.grpcManager.Client.CreateCache(request, deadline: CalculateDeadline());
             return new CreateCacheResponse();
         }
         catch (Exception e)
@@ -40,7 +40,7 @@ internal sealed class ScsControlClient : IDisposable
         _DeleteCacheRequest request = new _DeleteCacheRequest() { CacheName = cacheName };
         try
         {
-            this.grpcManager.Client().DeleteCache(request, deadline: CalculateDeadline());
+            this.grpcManager.Client.DeleteCache(request, deadline: CalculateDeadline());
             return new DeleteCacheResponse();
         }
         catch (Exception e)
@@ -54,7 +54,7 @@ internal sealed class ScsControlClient : IDisposable
         _ListCachesRequest request = new _ListCachesRequest() { NextToken = nextPageToken == null ? "" : nextPageToken };
         try
         {
-            ControlClient._ListCachesResponse result = this.grpcManager.Client().ListCaches(request, deadline: CalculateDeadline());
+            ControlClient._ListCachesResponse result = this.grpcManager.Client.ListCaches(request, deadline: CalculateDeadline());
             return new ListCachesResponse(result);
         }
         catch (Exception e)

--- a/Momento/ScsDataClient.cs
+++ b/Momento/ScsDataClient.cs
@@ -195,7 +195,7 @@ internal sealed class ScsDataClient : IDisposable
         _SetRequest request = new _SetRequest() { CacheBody = value, CacheKey = key, TtlMilliseconds = ttlSecondsToMilliseconds(ttlSeconds) };
         try
         {
-            return await this.grpcManager.Client().SetAsync(request, new Metadata { { "cache", cacheName } }, deadline: CalculateDeadline());
+            return await this.grpcManager.Client.SetAsync(request, new Metadata { { "cache", cacheName } }, deadline: CalculateDeadline());
         }
         catch (Exception e)
         {
@@ -208,7 +208,7 @@ internal sealed class ScsDataClient : IDisposable
         _GetRequest request = new _GetRequest() { CacheKey = key };
         try
         {
-            return this.grpcManager.Client().Get(request, new Metadata { { "cache", cacheName } }, deadline: CalculateDeadline());
+            return this.grpcManager.Client.Get(request, new Metadata { { "cache", cacheName } }, deadline: CalculateDeadline());
         }
         catch (Exception e)
         {
@@ -221,7 +221,7 @@ internal sealed class ScsDataClient : IDisposable
         _GetRequest request = new _GetRequest() { CacheKey = key };
         try
         {
-            return await this.grpcManager.Client().GetAsync(request, new Metadata { { "cache", cacheName } }, deadline: CalculateDeadline());
+            return await this.grpcManager.Client.GetAsync(request, new Metadata { { "cache", cacheName } }, deadline: CalculateDeadline());
         }
         catch (Exception e)
         {
@@ -234,7 +234,7 @@ internal sealed class ScsDataClient : IDisposable
         _SetRequest request = new _SetRequest() { CacheBody = value, CacheKey = key, TtlMilliseconds = ttlSecondsToMilliseconds(ttlSeconds) };
         try
         {
-            return this.grpcManager.Client().Set(request, new Metadata { { "cache", cacheName } }, deadline: CalculateDeadline());
+            return this.grpcManager.Client.Set(request, new Metadata { { "cache", cacheName } }, deadline: CalculateDeadline());
         }
         catch (Exception e)
         {
@@ -247,7 +247,7 @@ internal sealed class ScsDataClient : IDisposable
         _DeleteRequest request = new _DeleteRequest() { CacheKey = key };
         try
         {
-            return this.grpcManager.Client().Delete(request, new Metadata { { "cache", cacheName } }, deadline: CalculateDeadline());
+            return this.grpcManager.Client.Delete(request, new Metadata { { "cache", cacheName } }, deadline: CalculateDeadline());
         }
         catch (Exception e)
         {
@@ -260,7 +260,7 @@ internal sealed class ScsDataClient : IDisposable
         _DeleteRequest request = new _DeleteRequest() { CacheKey = key };
         try
         {
-            return await this.grpcManager.Client().DeleteAsync(request, new Metadata { { "cache", cacheName } }, deadline: CalculateDeadline());
+            return await this.grpcManager.Client.DeleteAsync(request, new Metadata { { "cache", cacheName } }, deadline: CalculateDeadline());
         }
         catch (Exception e)
         {

--- a/MomentoIntegrationTest/SimpleCacheControlTest.cs
+++ b/MomentoIntegrationTest/SimpleCacheControlTest.cs
@@ -61,13 +61,13 @@ public class SimpleCacheControlTest
 
         // Test cache exists
         ListCachesResponse result = client.ListCaches();
-        List<CacheInfo> caches = result.Caches();
+        List<CacheInfo> caches = result.Caches;
         Assert.Contains(new CacheInfo(cacheName), caches);
 
         // Test deleting cache
         client.DeleteCache(cacheName);
         result = client.ListCaches();
-        caches = result.Caches();
+        caches = result.Caches;
         Assert.DoesNotContain(new CacheInfo(cacheName), caches);
     }
 
@@ -90,15 +90,15 @@ public class SimpleCacheControlTest
         ListCachesResponse result = client.ListCaches();
         while (true)
         {
-            foreach (CacheInfo cache in result.Caches())
+            foreach (CacheInfo cache in result.Caches)
             {
-                retrievedCaches.Add(cache.Name());
+                retrievedCaches.Add(cache.Name);
             }
-            if (result.NextPageToken() == null)
+            if (result.NextPageToken == null)
             {
                 break;
             }
-            result = client.ListCaches(result.NextPageToken());
+            result = client.ListCaches(result.NextPageToken);
         }
 
         int sizeOverlap = cacheNames.Intersect(retrievedCaches).Count();

--- a/MomentoIntegrationTest/SimpleCacheDataTest.cs
+++ b/MomentoIntegrationTest/SimpleCacheDataTest.cs
@@ -35,13 +35,13 @@ public class SimpleCacheDataTest
         byte[] key = Utils.GuidBytes();
         byte[] value = Utils.GuidBytes();
         await client.SetAsync(CacheName, key, value);
-        byte[]? setValue = (await client.GetAsync(CacheName, key)).Bytes();
+        byte[]? setValue = (await client.GetAsync(CacheName, key)).Bytes;
         Assert.Equal(value, setValue);
 
         key = Utils.GuidBytes();
         value = Utils.GuidBytes();
         await client.SetAsync(CacheName, key, value, ttlSeconds: 15);
-        setValue = (await client.GetAsync(CacheName, key)).Bytes();
+        setValue = (await client.GetAsync(CacheName, key)).Bytes;
         Assert.Equal(value, setValue);
     }
 
@@ -105,13 +105,13 @@ public class SimpleCacheDataTest
         string key = Utils.GuidString();
         byte[] value = Utils.GuidBytes();
         await client.SetAsync(CacheName, key, value);
-        byte[]? setValue = (await client.GetAsync(CacheName, key)).Bytes();
+        byte[]? setValue = (await client.GetAsync(CacheName, key)).Bytes;
         Assert.Equal(value, setValue);
 
         key = Utils.GuidString();
         value = Utils.GuidBytes();
         await client.SetAsync(CacheName, key, value, ttlSeconds: 15);
-        setValue = (await client.GetAsync(CacheName, key)).Bytes();
+        setValue = (await client.GetAsync(CacheName, key)).Bytes;
         Assert.Equal(value, setValue);
     }
 
@@ -140,8 +140,8 @@ public class SimpleCacheDataTest
         List<byte[]> keys = new() { Utils.Utf8ToBytes(key1), Utils.Utf8ToBytes(key2) };
 
         CacheGetMultiResponse result = await client.GetMultiAsync(CacheName, keys);
-        string? stringResult1 = result.Strings()[0];
-        string? stringResult2 = result.Strings()[1];
+        string? stringResult1 = result.Strings[0];
+        string? stringResult2 = result.Strings[1];
         Assert.Equal(value1, stringResult1);
         Assert.Equal(value2, stringResult2);
     }
@@ -157,8 +157,8 @@ public class SimpleCacheDataTest
         client.Set(CacheName, key2, value2);
 
         CacheGetMultiResponse result = await client.GetMultiAsync(CacheName, key1, key2);
-        string? stringResult1 = result.Strings()[0];
-        string? stringResult2 = result.Strings()[1];
+        string? stringResult1 = result.Strings[0];
+        string? stringResult2 = result.Strings[1];
         Assert.Equal(value1, stringResult1);
         Assert.Equal(value2, stringResult2);
     }
@@ -188,8 +188,8 @@ public class SimpleCacheDataTest
         List<string> keys = new() { key1, key2, "key123123" };
         CacheGetMultiResponse result = await client.GetMultiAsync(CacheName, keys);
 
-        Assert.Equal(result.Strings(), new string[] { value1, value2, null! });
-        Assert.Equal(result.Status(), new CacheGetStatus[] { CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS });
+        Assert.Equal(result.Strings, new string[] { value1, value2, null! });
+        Assert.Equal(result.Status, new CacheGetStatus[] { CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS });
     }
 
     [Fact]
@@ -224,13 +224,13 @@ public class SimpleCacheDataTest
                 { key2, value2 }
             };
         CacheSetMultiResponse response = await client.SetMultiAsync(CacheName, dictionary);
-        Assert.Equal(dictionary, response.Bytes());
+        Assert.Equal(dictionary, response.Bytes);
 
         var getResponse = await client.GetAsync(CacheName, key1);
-        Assert.Equal(value1, getResponse.Bytes());
+        Assert.Equal(value1, getResponse.Bytes);
 
         getResponse = await client.GetAsync(CacheName, key2);
-        Assert.Equal(value2, getResponse.Bytes());
+        Assert.Equal(value2, getResponse.Bytes);
     }
 
     [Fact]
@@ -256,7 +256,7 @@ public class SimpleCacheDataTest
                 { key2, value2 }
             };
         CacheSetMultiResponse response = await client.SetMultiAsync(CacheName, dictionary);
-        Assert.Equal(dictionary, response.Strings());
+        Assert.Equal(dictionary, response.Strings);
 
         var getResponse = await client.GetAsync(CacheName, key1);
         Assert.Equal(value1, getResponse.String());
@@ -282,13 +282,13 @@ public class SimpleCacheDataTest
         byte[] key = Utils.GuidBytes();
         byte[] value = Utils.GuidBytes();
         client.Set(CacheName, key, value);
-        byte[]? setValue = client.Get(CacheName, key).Bytes();
+        byte[]? setValue = client.Get(CacheName, key).Bytes;
         Assert.Equal(value, setValue);
 
         key = Utils.GuidBytes();
         value = Utils.GuidBytes();
         client.Set(CacheName, key, value, ttlSeconds: 15);
-        setValue = client.Get(CacheName, key).Bytes();
+        setValue = client.Get(CacheName, key).Bytes;
         Assert.Equal(value, setValue);
     }
 
@@ -316,7 +316,7 @@ public class SimpleCacheDataTest
         CacheGetResponse result = client.Get(CacheName, Utils.GuidString());
         Assert.Equal(CacheGetStatus.MISS, result.Status);
         Assert.Null(result.String());
-        Assert.Null(result.Bytes());
+        Assert.Null(result.Bytes);
     }
 
     [Fact]
@@ -385,13 +385,13 @@ public class SimpleCacheDataTest
         string key = Utils.GuidString();
         byte[] value = Utils.GuidBytes();
         client.Set(CacheName, key, value);
-        byte[]? setValue = client.Get(CacheName, key).Bytes();
+        byte[]? setValue = client.Get(CacheName, key).Bytes;
         Assert.Equal(value, setValue);
 
         key = Utils.GuidString();
         value = Utils.GuidBytes();
         client.Set(CacheName, key, value, ttlSeconds: 15);
-        setValue = client.Get(CacheName, key).Bytes();
+        setValue = client.Get(CacheName, key).Bytes;
         Assert.Equal(value, setValue);
     }
 
@@ -420,8 +420,8 @@ public class SimpleCacheDataTest
         List<byte[]> keys = new() { Utils.Utf8ToBytes(key1), Utils.Utf8ToBytes(key2) };
 
         CacheGetMultiResponse result = client.GetMulti(CacheName, keys);
-        string? stringResult1 = result.Strings()[0];
-        string? stringResult2 = result.Strings()[1];
+        string? stringResult1 = result.Strings[0];
+        string? stringResult2 = result.Strings[1];
         Assert.Equal(value1, stringResult1);
         Assert.Equal(value2, stringResult2);
     }
@@ -437,8 +437,8 @@ public class SimpleCacheDataTest
         client.Set(CacheName, key2, value2);
 
         CacheGetMultiResponse result = client.GetMulti(CacheName, key1, key2);
-        string? stringResult1 = result.Strings()[0];
-        string? stringResult2 = result.Strings()[1];
+        string? stringResult1 = result.Strings[0];
+        string? stringResult2 = result.Strings[1];
         Assert.Equal(value1, stringResult1);
         Assert.Equal(value2, stringResult2);
     }
@@ -468,8 +468,8 @@ public class SimpleCacheDataTest
         List<string> keys = new() { key1, key2, "key123123" };
         CacheGetMultiResponse result = client.GetMulti(CacheName, keys);
 
-        Assert.Equal(result.Strings(), new string[] { value1, value2, null! });
-        Assert.Equal(result.Status(), new CacheGetStatus[] { CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS });
+        Assert.Equal(result.Strings, new string[] { value1, value2, null! });
+        Assert.Equal(result.Status, new CacheGetStatus[] { CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS });
     }
 
     [Fact]
@@ -504,13 +504,13 @@ public class SimpleCacheDataTest
                     { key2, value2 }
                 };
         CacheSetMultiResponse response = client.SetMulti(CacheName, dictionary);
-        Assert.Equal(dictionary, response.Bytes());
+        Assert.Equal(dictionary, response.Bytes);
 
         var getResponse = client.Get(CacheName, key1);
-        Assert.Equal(value1, getResponse.Bytes());
+        Assert.Equal(value1, getResponse.Bytes);
 
         getResponse = client.Get(CacheName, key2);
-        Assert.Equal(value2, getResponse.Bytes());
+        Assert.Equal(value2, getResponse.Bytes);
     }
 
 
@@ -537,7 +537,7 @@ public class SimpleCacheDataTest
                     { key2, value2 }
                 };
         CacheSetMultiResponse response = client.SetMulti(CacheName, dictionary);
-        Assert.Equal(dictionary, response.Strings());
+        Assert.Equal(dictionary, response.Strings);
 
         var getResponse = client.Get(CacheName, key1);
         Assert.Equal(value1, getResponse.String());


### PR DESCRIPTION
Customers and a language expert have recommended to use properties
where appropriate. Since many response objects just wrap data, we
should use properties to access that data.

For reference: [C# programming guide](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/properties)