### PR TITLE
chore: removing encoding from get response

### DIFF
--- a/Momento/Responses/CacheGetMultiResponse.cs
+++ b/Momento/Responses/CacheGetMultiResponse.cs
@@ -17,9 +17,9 @@ public class CacheGetMultiResponse
         get => Responses.Select(response => response.Status).ToList();
     }
 
-    public List<string?> Strings
+    public List<string?> Strings()
     {
-        get => Responses.Select(response => response.String()).ToList();
+        return Responses.Select(response => response.String()).ToList();
     }
 
     public List<byte[]?> Bytes

--- a/Momento/Responses/CacheGetResponse.cs
+++ b/Momento/Responses/CacheGetResponse.cs
@@ -16,14 +16,13 @@ public class CacheGetResponse
         Bytes = (Status == CacheGetStatus.HIT) ? response.CacheBody.ToByteArray() : null;
     }
 
-    public string? String(Encoding? encoding = null)
+    public string? String()
     {
-        encoding ??= Encoding.UTF8;
         if (Bytes == null)
         {
             return null;
         }
-        return encoding.GetString(Bytes);
+        return Encoding.UTF8.GetString(Bytes);
     }
 
     private static CacheGetStatus From(ECacheResult result)

--- a/MomentoIntegrationTest/SimpleCacheDataTest.cs
+++ b/MomentoIntegrationTest/SimpleCacheDataTest.cs
@@ -140,8 +140,8 @@ public class SimpleCacheDataTest
         List<byte[]> keys = new() { Utils.Utf8ToBytes(key1), Utils.Utf8ToBytes(key2) };
 
         CacheGetMultiResponse result = await client.GetMultiAsync(CacheName, keys);
-        string? stringResult1 = result.Strings[0];
-        string? stringResult2 = result.Strings[1];
+        string? stringResult1 = result.Strings()[0];
+        string? stringResult2 = result.Strings()[1];
         Assert.Equal(value1, stringResult1);
         Assert.Equal(value2, stringResult2);
     }
@@ -157,8 +157,8 @@ public class SimpleCacheDataTest
         client.Set(CacheName, key2, value2);
 
         CacheGetMultiResponse result = await client.GetMultiAsync(CacheName, key1, key2);
-        string? stringResult1 = result.Strings[0];
-        string? stringResult2 = result.Strings[1];
+        string? stringResult1 = result.Strings()[0];
+        string? stringResult2 = result.Strings()[1];
         Assert.Equal(value1, stringResult1);
         Assert.Equal(value2, stringResult2);
     }
@@ -188,7 +188,7 @@ public class SimpleCacheDataTest
         List<string> keys = new() { key1, key2, "key123123" };
         CacheGetMultiResponse result = await client.GetMultiAsync(CacheName, keys);
 
-        Assert.Equal(result.Strings, new string[] { value1, value2, null! });
+        Assert.Equal(result.Strings(), new string[] { value1, value2, null! });
         Assert.Equal(result.Status, new CacheGetStatus[] { CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS });
     }
 
@@ -420,8 +420,8 @@ public class SimpleCacheDataTest
         List<byte[]> keys = new() { Utils.Utf8ToBytes(key1), Utils.Utf8ToBytes(key2) };
 
         CacheGetMultiResponse result = client.GetMulti(CacheName, keys);
-        string? stringResult1 = result.Strings[0];
-        string? stringResult2 = result.Strings[1];
+        string? stringResult1 = result.Strings()[0];
+        string? stringResult2 = result.Strings()[1];
         Assert.Equal(value1, stringResult1);
         Assert.Equal(value2, stringResult2);
     }
@@ -437,8 +437,8 @@ public class SimpleCacheDataTest
         client.Set(CacheName, key2, value2);
 
         CacheGetMultiResponse result = client.GetMulti(CacheName, key1, key2);
-        string? stringResult1 = result.Strings[0];
-        string? stringResult2 = result.Strings[1];
+        string? stringResult1 = result.Strings()[0];
+        string? stringResult2 = result.Strings()[1];
         Assert.Equal(value1, stringResult1);
         Assert.Equal(value2, stringResult2);
     }
@@ -468,7 +468,7 @@ public class SimpleCacheDataTest
         List<string> keys = new() { key1, key2, "key123123" };
         CacheGetMultiResponse result = client.GetMulti(CacheName, keys);
 
-        Assert.Equal(result.Strings, new string[] { value1, value2, null! });
+        Assert.Equal(result.Strings(), new string[] { value1, value2, null! });
         Assert.Equal(result.Status, new CacheGetStatus[] { CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS });
     }
 


### PR DESCRIPTION
We have decided that the convenience methods will use UTF-8 only. A future PR may enable other encodings depending on customer use cases.