### PR TITLE
chore: prefer ienumerable over dictionary + other style issues

### DIFF
--- a/Momento/ISimpleCacheClient.cs
+++ b/Momento/ISimpleCacheClient.cs
@@ -127,7 +127,7 @@ public interface ISimpleCacheClient : IDisposable
     /// <param name="cacheName">Name of the cache to store the items in.</param>
     /// <param name="items">The items to set.</param>
     /// <returns>Task object representing the result of the set operation.</returns>
-    public Task<CacheSetMultiResponse> SetMultiAsync(string cacheName, IDictionary<byte[], byte[]> items, uint? ttlSeconds = null);
+    public Task<CacheSetMultiResponse> SetMultiAsync(string cacheName, IEnumerable<KeyValuePair<byte[], byte[]>> items, uint? ttlSeconds = null);
 
     /// <summary>
     /// Sets multiple items in the cache. Overwrites existing items.
@@ -135,7 +135,7 @@ public interface ISimpleCacheClient : IDisposable
     /// <param name="cacheName">Name of the cache to store the items in.</param>
     /// <param name="items">The items to set.</param>
     /// <returns>Task object representing the result of the set operation.</returns>
-    public Task<CacheSetMultiResponse> SetMultiAsync(string cacheName, IDictionary<string, string> items, uint? ttlSeconds = null);
+    public Task<CacheSetMultiResponse> SetMultiAsync(string cacheName, IEnumerable<KeyValuePair<string, string>> items, uint? ttlSeconds = null);
 
     /// <summary>
     ///  Set the value in the cache. If a value for this key is already present it will be replaced by the new value.
@@ -218,7 +218,7 @@ public interface ISimpleCacheClient : IDisposable
     /// <param name="cacheName">Name of the cache to store the items in.</param>
     /// <param name="items">The items to set.</param>
     /// <returns>Result of the set operation.</returns>
-    public CacheSetMultiResponse SetMulti(string cacheName, IDictionary<byte[], byte[]> items, uint? ttlSeconds = null);
+    public CacheSetMultiResponse SetMulti(string cacheName, IEnumerable<KeyValuePair<byte[], byte[]>> items, uint? ttlSeconds = null);
 
     /// <summary>
     /// Sets multiple items in the cache. Overwrites existing items.
@@ -226,7 +226,7 @@ public interface ISimpleCacheClient : IDisposable
     /// <param name="cacheName">Name of the cache to store the items in.</param>
     /// <param name="items">The items to set.</param>
     /// <returns>Result of the set operation.</returns>
-    public CacheSetMultiResponse SetMulti(string cacheName, IDictionary<string, string> items, uint? ttlSeconds = null);
+    public CacheSetMultiResponse SetMulti(string cacheName, IEnumerable<KeyValuePair<string, string>> items, uint? ttlSeconds = null);
 
     /// <summary>
     /// Remove the key from the cache.

--- a/Momento/Incubating/Internal/ScsDataClient.cs
+++ b/Momento/Incubating/Internal/ScsDataClient.cs
@@ -42,12 +42,12 @@ internal sealed class ScsDataClient : ScsDataClientBase
         try
         {
             this.grpcManager.Client.DictionarySet(request, MetadataWithCache(cacheName), deadline: CalculateDeadline());
-            return new CacheDictionarySetResponse();
         }
         catch (Exception e)
         {
             throw CacheExceptionMapper.Convert(e);
         }
+        return new CacheDictionarySetResponse();
     }
 
     public async Task<CacheDictionarySetResponse> DictionarySetAsync(string cacheName, string dictionaryName, byte[] field, byte[] value, bool refreshTtl, uint? ttlSeconds = null)
@@ -74,12 +74,12 @@ internal sealed class ScsDataClient : ScsDataClientBase
         try
         {
             await this.grpcManager.Client.DictionarySetAsync(request, MetadataWithCache(cacheName), deadline: CalculateDeadline());
-            return new CacheDictionarySetResponse();
         }
         catch (Exception e)
         {
             throw CacheExceptionMapper.Convert(e);
         }
+        return new CacheDictionarySetResponse();
     }
 
     public CacheDictionaryGetResponse DictionaryGet(string cacheName, string dictionaryName, byte[] field)
@@ -162,12 +162,12 @@ internal sealed class ScsDataClient : ScsDataClientBase
         try
         {
             this.grpcManager.Client.DictionarySet(request, MetadataWithCache(cacheName), deadline: CalculateDeadline());
-            return new CacheDictionarySetMultiResponse();
         }
         catch (Exception e)
         {
             throw CacheExceptionMapper.Convert(e);
         }
+        return new CacheDictionarySetMultiResponse();
     }
 
     public async Task<CacheDictionarySetMultiResponse> DictionarySetMultiAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<byte[], byte[]>> items, bool refreshTtl, uint? ttlSeconds = null)
@@ -195,12 +195,12 @@ internal sealed class ScsDataClient : ScsDataClientBase
         try
         {
             await this.grpcManager.Client.DictionarySetAsync(request, MetadataWithCache(cacheName), deadline: CalculateDeadline());
-            return new CacheDictionarySetMultiResponse();
         }
         catch (Exception e)
         {
             throw CacheExceptionMapper.Convert(e);
         }
+        return new CacheDictionarySetMultiResponse();
     }
 
     public CacheDictionaryGetMultiResponse DictionaryGetMulti(string cacheName, string dictionaryName, params byte[][] fields)
@@ -228,15 +228,16 @@ internal sealed class ScsDataClient : ScsDataClientBase
         _DictionaryGetRequest request = new() { DictionaryName = dictionaryName.ToByteString() };
         request.DictionaryKeys.Add(fields);
 
+        _DictionaryGetResponse response;
         try
         {
-            var response = this.grpcManager.Client.DictionaryGet(request, MetadataWithCache(cacheName), deadline: CalculateDeadline());
-            return new CacheDictionaryGetMultiResponse(response);
+            response = this.grpcManager.Client.DictionaryGet(request, MetadataWithCache(cacheName), deadline: CalculateDeadline());
         }
         catch (Exception e)
         {
             throw CacheExceptionMapper.Convert(e);
         }
+        return new CacheDictionaryGetMultiResponse(response);
     }
 
     public async Task<CacheDictionaryGetMultiResponse> DictionaryGetMultiAsync(string cacheName, string dictionaryName, params byte[][] fields)
@@ -264,15 +265,16 @@ internal sealed class ScsDataClient : ScsDataClientBase
         _DictionaryGetRequest request = new() { DictionaryName = dictionaryName.ToByteString() };
         request.DictionaryKeys.Add(fields);
 
+        _DictionaryGetResponse response;
         try
         {
-            var response = await this.grpcManager.Client.DictionaryGetAsync(request, MetadataWithCache(cacheName), deadline: CalculateDeadline());
-            return new CacheDictionaryGetMultiResponse(response);
+            response = await this.grpcManager.Client.DictionaryGetAsync(request, MetadataWithCache(cacheName), deadline: CalculateDeadline());
         }
         catch (Exception e)
         {
             throw CacheExceptionMapper.Convert(e);
         }
+        return new CacheDictionaryGetMultiResponse(response);
     }
 
     public CacheDictionaryGetAllResponse DictionaryGetAll(string cacheName, string dictionaryName)

--- a/Momento/Incubating/SimpleCacheClient.cs
+++ b/Momento/Incubating/SimpleCacheClient.cs
@@ -91,12 +91,12 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.simpleCacheClient.GetMultiAsync(cacheName, keys);
     }
 
-    public async Task<CacheSetMultiResponse> SetMultiAsync(string cacheName, IDictionary<byte[], byte[]> items, uint? ttlSeconds = null)
+    public async Task<CacheSetMultiResponse> SetMultiAsync(string cacheName, IEnumerable<KeyValuePair<byte[], byte[]>> items, uint? ttlSeconds = null)
     {
         return await this.simpleCacheClient.SetMultiAsync(cacheName, items, ttlSeconds);
     }
 
-    public async Task<CacheSetMultiResponse> SetMultiAsync(string cacheName, IDictionary<string, string> items, uint? ttlSeconds = null)
+    public async Task<CacheSetMultiResponse> SetMultiAsync(string cacheName, IEnumerable<KeyValuePair<string, string>> items, uint? ttlSeconds = null)
     {
         return await this.simpleCacheClient.SetMultiAsync(cacheName, items, ttlSeconds);
     }
@@ -146,12 +146,12 @@ public class SimpleCacheClient : ISimpleCacheClient
         return this.simpleCacheClient.GetMulti(cacheName, keys);
     }
 
-    public CacheSetMultiResponse SetMulti(string cacheName, IDictionary<byte[], byte[]> items, uint? ttlSeconds = null)
+    public CacheSetMultiResponse SetMulti(string cacheName, IEnumerable<KeyValuePair<byte[], byte[]>> items, uint? ttlSeconds = null)
     {
         return this.simpleCacheClient.SetMulti(cacheName, items, ttlSeconds);
     }
 
-    public CacheSetMultiResponse SetMulti(string cacheName, IDictionary<string, string> items, uint? ttlSeconds = null)
+    public CacheSetMultiResponse SetMulti(string cacheName, IEnumerable<KeyValuePair<string, string>> items, uint? ttlSeconds = null)
     {
         return this.simpleCacheClient.SetMulti(cacheName, items, ttlSeconds);
     }
@@ -353,7 +353,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
         Utils.ArgumentNotNull(dictionaryName, nameof(dictionaryName));
         Utils.ArgumentNotNull(items, nameof(items));
-        Utils.ValuesNotNull(items, nameof(items));
+        Utils.KeysAndValuesNotNull(items, nameof(items));
 
         return this.dataClient.DictionarySetMulti(cacheName, dictionaryName, items, refreshTtl, ttlSeconds);
     }
@@ -377,7 +377,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
         Utils.ArgumentNotNull(dictionaryName, nameof(dictionaryName));
         Utils.ArgumentNotNull(items, nameof(items));
-        Utils.ValuesNotNull(items, nameof(items));
+        Utils.KeysAndValuesNotNull(items, nameof(items));
 
         return this.dataClient.DictionarySetMulti(cacheName, dictionaryName, items, refreshTtl, ttlSeconds);
     }
@@ -401,7 +401,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
         Utils.ArgumentNotNull(dictionaryName, nameof(dictionaryName));
         Utils.ArgumentNotNull(items, nameof(items));
-        Utils.ValuesNotNull(items, nameof(items));
+        Utils.KeysAndValuesNotNull(items, nameof(items));
 
         return await this.dataClient.DictionarySetMultiAsync(cacheName, dictionaryName, items, refreshTtl, ttlSeconds);
     }
@@ -425,7 +425,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
         Utils.ArgumentNotNull(dictionaryName, nameof(dictionaryName));
         Utils.ArgumentNotNull(items, nameof(items));
-        Utils.ValuesNotNull(items, nameof(items));
+        Utils.KeysAndValuesNotNull(items, nameof(items));
 
         return await this.dataClient.DictionarySetMultiAsync(cacheName, dictionaryName, items, refreshTtl, ttlSeconds);
     }

--- a/Momento/Internal/ScsDataClient.cs
+++ b/Momento/Internal/ScsDataClient.cs
@@ -59,8 +59,8 @@ internal sealed class ScsDataClient : ScsDataClientBase
 
     public async Task<CacheSetResponse> SetAsync(string cacheName, byte[] key, byte[] value, uint? ttlSeconds = null)
     {
-        _SetResponse response = await this.SendSetAsync(cacheName, value: value.ToByteString(), key: key.ToByteString(), ttlSeconds: ttlSeconds);
-        return new CacheSetResponse(response);
+        await this.SendSetAsync(cacheName, value: value.ToByteString(), key: key.ToByteString(), ttlSeconds: ttlSeconds);
+        return new CacheSetResponse();
     }
 
     public async Task<CacheGetResponse> GetAsync(string cacheName, byte[] key)
@@ -77,8 +77,8 @@ internal sealed class ScsDataClient : ScsDataClientBase
 
     public async Task<CacheSetResponse> SetAsync(string cacheName, string key, string value, uint? ttlSeconds = null)
     {
-        _SetResponse response = await this.SendSetAsync(cacheName, key: key.ToByteString(), value: value.ToByteString(), ttlSeconds: ttlSeconds);
-        return new CacheSetResponse(response);
+        await this.SendSetAsync(cacheName, key: key.ToByteString(), value: value.ToByteString(), ttlSeconds: ttlSeconds);
+        return new CacheSetResponse();
     }
 
     public async Task<CacheGetResponse> GetAsync(string cacheName, string key)
@@ -95,8 +95,8 @@ internal sealed class ScsDataClient : ScsDataClientBase
 
     public async Task<CacheSetResponse> SetAsync(string cacheName, string key, byte[] value, uint? ttlSeconds = null)
     {
-        _SetResponse response = await this.SendSetAsync(cacheName, value: value.ToByteString(), key: key.ToByteString(), ttlSeconds: ttlSeconds);
-        return new CacheSetResponse(response);
+        await this.SendSetAsync(cacheName, value: value.ToByteString(), key: key.ToByteString(), ttlSeconds: ttlSeconds);
+        return new CacheSetResponse();
     }
 
     public async Task<CacheGetMultiResponse> GetMultiAsync(string cacheName, IEnumerable<string> keys)
@@ -140,21 +140,23 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheGetMultiResponse(results);
     }
 
-    public async Task SetMultiAsync(string cacheName, IDictionary<string, string> items, uint? ttlSeconds = null)
+    public async Task<CacheSetMultiResponse> SetMultiAsync(string cacheName, IEnumerable<KeyValuePair<string, string>> items, uint? ttlSeconds = null)
     {
-        await SetMultiAsync(cacheName: cacheName,
-            items: items.ToDictionary(item => item.Key.ToByteString(), item => item.Value.ToByteString()),
+        await SendSetMultiAsync(cacheName: cacheName,
+            items: items.Select(item => new KeyValuePair<ByteString, ByteString>(item.Key.ToByteString(), item.Value.ToByteString())),
             ttlSeconds: ttlSeconds);
+        return new CacheSetMultiResponse();
     }
 
-    public async Task SetMultiAsync(string cacheName, IDictionary<byte[], byte[]> items, uint? ttlSeconds = null)
+    public async Task<CacheSetMultiResponse> SetMultiAsync(string cacheName, IEnumerable<KeyValuePair<byte[], byte[]>> items, uint? ttlSeconds = null)
     {
-        await SetMultiAsync(cacheName: cacheName,
-            items: items.ToDictionary(item => item.Key.ToByteString(), item => item.Value.ToByteString()),
+        await SendSetMultiAsync(cacheName: cacheName,
+            items: items.Select(item => new KeyValuePair<ByteString, ByteString>(item.Key.ToByteString(), item.Value.ToByteString())),
             ttlSeconds: ttlSeconds);
+        return new CacheSetMultiResponse();
     }
 
-    public async Task SetMultiAsync(string cacheName, IDictionary<ByteString, ByteString> items, uint? ttlSeconds = null)
+    public async Task SendSetMultiAsync(string cacheName, IEnumerable<KeyValuePair<ByteString, ByteString>> items, uint? ttlSeconds = null)
     {
         // Gather the tasks
         var tasks = items.Select(item => SendSetAsync(cacheName, item.Key, item.Value, ttlSeconds));
@@ -183,8 +185,8 @@ internal sealed class ScsDataClient : ScsDataClientBase
 
     public CacheSetResponse Set(string cacheName, byte[] key, byte[] value, uint? ttlSeconds = null)
     {
-        _SetResponse resp = this.SendSet(cacheName, key: key.ToByteString(), value: value.ToByteString(), ttlSeconds: ttlSeconds);
-        return new CacheSetResponse(resp);
+        this.SendSet(cacheName, key: key.ToByteString(), value: value.ToByteString(), ttlSeconds: ttlSeconds);
+        return new CacheSetResponse();
     }
 
     public CacheGetResponse Get(string cacheName, byte[] key)
@@ -201,8 +203,8 @@ internal sealed class ScsDataClient : ScsDataClientBase
 
     public CacheSetResponse Set(string cacheName, string key, string value, uint? ttlSeconds = null)
     {
-        _SetResponse response = this.SendSet(cacheName, key: key.ToByteString(), value: value.ToByteString(), ttlSeconds: ttlSeconds);
-        return new CacheSetResponse(response);
+        this.SendSet(cacheName, key: key.ToByteString(), value: value.ToByteString(), ttlSeconds: ttlSeconds);
+        return new CacheSetResponse();
     }
 
     public CacheGetResponse Get(string cacheName, string key)
@@ -219,8 +221,8 @@ internal sealed class ScsDataClient : ScsDataClientBase
 
     public CacheSetResponse Set(string cacheName, string key, byte[] value, uint? ttlSeconds = null)
     {
-        _SetResponse response = this.SendSet(cacheName, key: key.ToByteString(), value: value.ToByteString(), ttlSeconds: ttlSeconds);
-        return new CacheSetResponse(response);
+        this.SendSet(cacheName, key: key.ToByteString(), value: value.ToByteString(), ttlSeconds: ttlSeconds);
+        return new CacheSetResponse();
     }
 
     private async Task<_SetResponse> SendSetAsync(string cacheName, ByteString key, ByteString value, uint? ttlSeconds = null)

--- a/Momento/Internal/ScsDataClient.cs
+++ b/Momento/Internal/ScsDataClient.cs
@@ -59,44 +59,37 @@ internal sealed class ScsDataClient : ScsDataClientBase
 
     public async Task<CacheSetResponse> SetAsync(string cacheName, byte[] key, byte[] value, uint? ttlSeconds = null)
     {
-        await this.SendSetAsync(cacheName, value: value.ToByteString(), key: key.ToByteString(), ttlSeconds: ttlSeconds);
-        return new CacheSetResponse();
+        return await this.SendSetAsync(cacheName, value: value.ToByteString(), key: key.ToByteString(), ttlSeconds: ttlSeconds);
     }
 
     public async Task<CacheGetResponse> GetAsync(string cacheName, byte[] key)
     {
-        _GetResponse resp = await this.SendGetAsync(cacheName, key.ToByteString());
-        return new CacheGetResponse(resp);
+        return await this.SendGetAsync(cacheName, key.ToByteString());
     }
 
     public async Task<CacheDeleteResponse> DeleteAsync(string cacheName, byte[] key)
     {
-        await this.SendDeleteAsync(cacheName, key.ToByteString());
-        return new CacheDeleteResponse();
+        return await this.SendDeleteAsync(cacheName, key.ToByteString());
     }
 
     public async Task<CacheSetResponse> SetAsync(string cacheName, string key, string value, uint? ttlSeconds = null)
     {
-        await this.SendSetAsync(cacheName, key: key.ToByteString(), value: value.ToByteString(), ttlSeconds: ttlSeconds);
-        return new CacheSetResponse();
+        return await this.SendSetAsync(cacheName, key: key.ToByteString(), value: value.ToByteString(), ttlSeconds: ttlSeconds);
     }
 
     public async Task<CacheGetResponse> GetAsync(string cacheName, string key)
     {
-        _GetResponse resp = await this.SendGetAsync(cacheName, key.ToByteString());
-        return new CacheGetResponse(resp);
+        return await this.SendGetAsync(cacheName, key.ToByteString());
     }
 
     public async Task<CacheDeleteResponse> DeleteAsync(string cacheName, string key)
     {
-        await this.SendDeleteAsync(cacheName, key.ToByteString());
-        return new CacheDeleteResponse();
+        return await this.SendDeleteAsync(cacheName, key.ToByteString());
     }
 
     public async Task<CacheSetResponse> SetAsync(string cacheName, string key, byte[] value, uint? ttlSeconds = null)
     {
-        await this.SendSetAsync(cacheName, value: value.ToByteString(), key: key.ToByteString(), ttlSeconds: ttlSeconds);
-        return new CacheSetResponse();
+        return await this.SendSetAsync(cacheName, value: value.ToByteString(), key: key.ToByteString(), ttlSeconds: ttlSeconds);
     }
 
     public async Task<CacheGetMultiResponse> GetMultiAsync(string cacheName, IEnumerable<string> keys)
@@ -136,27 +129,24 @@ internal sealed class ScsDataClient : ScsDataClientBase
         }
 
         // Package results
-        var results = continuation.Result.Select(response => new CacheGetResponse(response));
-        return new CacheGetMultiResponse(results);
+        return new CacheGetMultiResponse(continuation.Result);
     }
 
     public async Task<CacheSetMultiResponse> SetMultiAsync(string cacheName, IEnumerable<KeyValuePair<string, string>> items, uint? ttlSeconds = null)
     {
-        await SendSetMultiAsync(cacheName: cacheName,
+        return await SendSetMultiAsync(cacheName: cacheName,
             items: items.Select(item => new KeyValuePair<ByteString, ByteString>(item.Key.ToByteString(), item.Value.ToByteString())),
             ttlSeconds: ttlSeconds);
-        return new CacheSetMultiResponse();
     }
 
     public async Task<CacheSetMultiResponse> SetMultiAsync(string cacheName, IEnumerable<KeyValuePair<byte[], byte[]>> items, uint? ttlSeconds = null)
     {
-        await SendSetMultiAsync(cacheName: cacheName,
+        return await SendSetMultiAsync(cacheName: cacheName,
             items: items.Select(item => new KeyValuePair<ByteString, ByteString>(item.Key.ToByteString(), item.Value.ToByteString())),
             ttlSeconds: ttlSeconds);
-        return new CacheSetMultiResponse();
     }
 
-    public async Task SendSetMultiAsync(string cacheName, IEnumerable<KeyValuePair<ByteString, ByteString>> items, uint? ttlSeconds = null)
+    public async Task<CacheSetMultiResponse> SendSetMultiAsync(string cacheName, IEnumerable<KeyValuePair<ByteString, ByteString>> items, uint? ttlSeconds = null)
     {
         // Gather the tasks
         var tasks = items.Select(item => SendSetAsync(cacheName, item.Key, item.Value, ttlSeconds));
@@ -181,125 +171,127 @@ internal sealed class ScsDataClient : ScsDataClientBase
         {
             throw CacheExceptionMapper.Convert(new Exception(String.Format("Failure issuing multi-set: {0}", continuation.Status)));
         }
+        return new CacheSetMultiResponse();
     }
 
     public CacheSetResponse Set(string cacheName, byte[] key, byte[] value, uint? ttlSeconds = null)
     {
-        this.SendSet(cacheName, key: key.ToByteString(), value: value.ToByteString(), ttlSeconds: ttlSeconds);
-        return new CacheSetResponse();
+        return this.SendSet(cacheName, key: key.ToByteString(), value: value.ToByteString(), ttlSeconds: ttlSeconds);
     }
 
     public CacheGetResponse Get(string cacheName, byte[] key)
     {
-        _GetResponse resp = this.SendGet(cacheName, key.ToByteString());
-        return new CacheGetResponse(resp);
+        return this.SendGet(cacheName, key.ToByteString());
     }
 
     public CacheDeleteResponse Delete(string cacheName, byte[] key)
     {
-        this.SendDelete(cacheName, key.ToByteString());
-        return new CacheDeleteResponse();
+        return this.SendDelete(cacheName, key.ToByteString());
     }
 
     public CacheSetResponse Set(string cacheName, string key, string value, uint? ttlSeconds = null)
     {
-        this.SendSet(cacheName, key: key.ToByteString(), value: value.ToByteString(), ttlSeconds: ttlSeconds);
-        return new CacheSetResponse();
+        return this.SendSet(cacheName, key: key.ToByteString(), value: value.ToByteString(), ttlSeconds: ttlSeconds);
     }
 
     public CacheGetResponse Get(string cacheName, string key)
     {
-        _GetResponse resp = this.SendGet(cacheName, key.ToByteString());
-        return new CacheGetResponse(resp);
+        return this.SendGet(cacheName, key.ToByteString());
     }
 
     public CacheDeleteResponse Delete(string cacheName, string key)
     {
-        this.SendDelete(cacheName, key.ToByteString());
-        return new CacheDeleteResponse();
+        return this.SendDelete(cacheName, key.ToByteString());
     }
 
     public CacheSetResponse Set(string cacheName, string key, byte[] value, uint? ttlSeconds = null)
     {
-        this.SendSet(cacheName, key: key.ToByteString(), value: value.ToByteString(), ttlSeconds: ttlSeconds);
+        return this.SendSet(cacheName, key: key.ToByteString(), value: value.ToByteString(), ttlSeconds: ttlSeconds);
+    }
+
+    private async Task<CacheSetResponse> SendSetAsync(string cacheName, ByteString key, ByteString value, uint? ttlSeconds = null)
+    {
+        _SetRequest request = new _SetRequest() { CacheBody = value, CacheKey = key, TtlMilliseconds = ttlSecondsToMilliseconds(ttlSeconds) };
+        try
+        {
+            await this.grpcManager.Client.SetAsync(request, MetadataWithCache(cacheName), deadline: CalculateDeadline());
+        }
+        catch (Exception e)
+        {
+            throw CacheExceptionMapper.Convert(e);
+        }
         return new CacheSetResponse();
     }
 
-    private async Task<_SetResponse> SendSetAsync(string cacheName, ByteString key, ByteString value, uint? ttlSeconds = null)
+    private CacheGetResponse SendGet(string cacheName, ByteString key)
+    {
+        _GetRequest request = new _GetRequest() { CacheKey = key };
+        _GetResponse response;
+        try
+        {
+            response = this.grpcManager.Client.Get(request, new Metadata { { "cache", cacheName } }, deadline: CalculateDeadline());
+        }
+        catch (Exception e)
+        {
+            throw CacheExceptionMapper.Convert(e);
+        }
+        return new CacheGetResponse(response);
+    }
+
+    private async Task<CacheGetResponse> SendGetAsync(string cacheName, ByteString key)
+    {
+        _GetRequest request = new _GetRequest() { CacheKey = key };
+        _GetResponse response;
+        try
+        {
+            response = await this.grpcManager.Client.GetAsync(request, MetadataWithCache(cacheName), deadline: CalculateDeadline());
+        }
+        catch (Exception e)
+        {
+            throw CacheExceptionMapper.Convert(e);
+        }
+        return new CacheGetResponse(response);
+    }
+
+    private CacheSetResponse SendSet(string cacheName, ByteString key, ByteString value, uint? ttlSeconds = null)
     {
         _SetRequest request = new _SetRequest() { CacheBody = value, CacheKey = key, TtlMilliseconds = ttlSecondsToMilliseconds(ttlSeconds) };
         try
         {
-            return await this.grpcManager.Client.SetAsync(request, MetadataWithCache(cacheName), deadline: CalculateDeadline());
+            this.grpcManager.Client.Set(request, MetadataWithCache(cacheName), deadline: CalculateDeadline());
         }
         catch (Exception e)
         {
             throw CacheExceptionMapper.Convert(e);
         }
+        return new CacheSetResponse();
     }
 
-    private _GetResponse SendGet(string cacheName, ByteString key)
-    {
-        _GetRequest request = new _GetRequest() { CacheKey = key };
-        try
-        {
-            return this.grpcManager.Client.Get(request, new Metadata { { "cache", cacheName } }, deadline: CalculateDeadline());
-        }
-        catch (Exception e)
-        {
-            throw CacheExceptionMapper.Convert(e);
-        }
-    }
-
-    private async Task<_GetResponse> SendGetAsync(string cacheName, ByteString key)
-    {
-        _GetRequest request = new _GetRequest() { CacheKey = key };
-        try
-        {
-            return await this.grpcManager.Client.GetAsync(request, MetadataWithCache(cacheName), deadline: CalculateDeadline());
-        }
-        catch (Exception e)
-        {
-            throw CacheExceptionMapper.Convert(e);
-        }
-    }
-
-    private _SetResponse SendSet(string cacheName, ByteString key, ByteString value, uint? ttlSeconds = null)
-    {
-        _SetRequest request = new _SetRequest() { CacheBody = value, CacheKey = key, TtlMilliseconds = ttlSecondsToMilliseconds(ttlSeconds) };
-        try
-        {
-            return this.grpcManager.Client.Set(request, MetadataWithCache(cacheName), deadline: CalculateDeadline());
-        }
-        catch (Exception e)
-        {
-            throw CacheExceptionMapper.Convert(e);
-        }
-    }
-
-    private _DeleteResponse SendDelete(string cacheName, ByteString key)
+    private CacheDeleteResponse SendDelete(string cacheName, ByteString key)
     {
         _DeleteRequest request = new _DeleteRequest() { CacheKey = key };
         try
         {
-            return this.grpcManager.Client.Delete(request, MetadataWithCache(cacheName), deadline: CalculateDeadline());
+            this.grpcManager.Client.Delete(request, MetadataWithCache(cacheName), deadline: CalculateDeadline());
         }
         catch (Exception e)
         {
             throw CacheExceptionMapper.Convert(e);
         }
+        return new CacheDeleteResponse();
     }
 
-    private async Task<_DeleteResponse> SendDeleteAsync(string cacheName, ByteString key)
+    private async Task<CacheDeleteResponse> SendDeleteAsync(string cacheName, ByteString key)
     {
         _DeleteRequest request = new _DeleteRequest() { CacheKey = key };
         try
         {
-            return await this.grpcManager.Client.DeleteAsync(request, MetadataWithCache(cacheName), deadline: CalculateDeadline());
+            await this.grpcManager.Client.DeleteAsync(request, MetadataWithCache(cacheName), deadline: CalculateDeadline());
         }
         catch (Exception e)
         {
             throw CacheExceptionMapper.Convert(e);
         }
+        return new CacheDeleteResponse();
     }
 }

--- a/Momento/Internal/Utils.cs
+++ b/Momento/Internal/Utils.cs
@@ -46,26 +46,18 @@ namespace MomentoSdk.Internal
         }
 
         /// <summary>
-        /// Throw an exception if any of the dictionary values is null.
+        /// Throw an exception if any of the keys or values is null.
         /// </summary>
-        /// <typeparam name="TKey">Dictionary key type.</typeparam>
-        /// <typeparam name="TValue">Dictionary value type.</typeparam>
-        /// <param name="argument">Dictionary to check for null values.</param>
-        /// <param name="paramName">Name of the dictionary to propagate to the exception.</param>
-        /// <exception cref="ArgumentNullException">Any of `argument` values is `null`.</exception>
-        public static void DictionaryValuesNotNull<TKey, TValue>(IDictionary<TKey, TValue> argument, string paramName)
+        /// <typeparam name="TKey">Key type.</typeparam>
+        /// <typeparam name="TValue">Value type.</typeparam>
+        /// <param name="argument">Enumerable to check for null keys/values.</param>
+        /// <param name="paramName">Name of the enumerable to propagate to the exception.</param>
+        /// <exception cref="ArgumentNullException">Any of `argument` keys or values is `null`.</exception>
+        public static void KeysAndValuesNotNull<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> argument, string paramName)
         {
-            if (argument.Values.Any(value => value == null))
+            if (argument.Any(kv => kv.Key == null || kv.Value == null))
             {
-                throw new ArgumentNullException(paramName, "Each value must be non-null");
-            }
-        }
-
-        public static void ValuesNotNull<_, TValue>(IEnumerable<KeyValuePair<_, TValue>> argument, string paramName)
-        {
-            if (argument.Any(kv => kv.Value == null))
-            {
-                throw new ArgumentNullException(paramName, "Each value must be non-null");
+                throw new ArgumentNullException(paramName, "Each key and value must be non-null");
             }
         }
 

--- a/Momento/Responses/CacheSetMultiResponse.cs
+++ b/Momento/Responses/CacheSetMultiResponse.cs
@@ -4,25 +4,4 @@ namespace MomentoSdk.Responses;
 
 public class CacheSetMultiResponse
 {
-    private readonly object items;
-
-    public CacheSetMultiResponse(IDictionary<byte[], byte[]> items)
-    {
-        this.items = (object)items;
-    }
-
-    public CacheSetMultiResponse(IDictionary<string, string> items)
-    {
-        this.items = (object)items;
-    }
-
-    public IDictionary<string, string> Strings
-    {
-        get => (IDictionary<string, string>)items;
-    }
-
-    public IDictionary<byte[], byte[]> Bytes
-    {
-        get => (IDictionary<byte[], byte[]>)items;
-    }
 }

--- a/Momento/Responses/CacheSetResponse.cs
+++ b/Momento/Responses/CacheSetResponse.cs
@@ -4,9 +4,4 @@ namespace MomentoSdk.Responses;
 
 public class CacheSetResponse
 {
-    public CacheSetResponse(_SetResponse response)
-    {
-    }
-
-    // TODO: Add values that were set.
 }

--- a/Momento/SimpleCacheClient.cs
+++ b/Momento/SimpleCacheClient.cs
@@ -140,24 +140,22 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.GetMultiAsync(cacheName, keys);
     }
 
-    public async Task<CacheSetMultiResponse> SetMultiAsync(string cacheName, IDictionary<byte[], byte[]> items, uint? ttlSeconds = null)
+    public async Task<CacheSetMultiResponse> SetMultiAsync(string cacheName, IEnumerable<KeyValuePair<byte[], byte[]>> items, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
         Utils.ArgumentNotNull(items, nameof(items));
-        Utils.DictionaryValuesNotNull(items, nameof(items));
+        Utils.KeysAndValuesNotNull(items, nameof(items));
 
-        await this.dataClient.SetMultiAsync(cacheName, items, ttlSeconds);
-        return new CacheSetMultiResponse(items);
+        return await this.dataClient.SetMultiAsync(cacheName, items, ttlSeconds);
     }
 
-    public async Task<CacheSetMultiResponse> SetMultiAsync(string cacheName, IDictionary<string, string> items, uint? ttlSeconds = null)
+    public async Task<CacheSetMultiResponse> SetMultiAsync(string cacheName, IEnumerable<KeyValuePair<string, string>> items, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
         Utils.ArgumentNotNull(items, nameof(items));
-        Utils.DictionaryValuesNotNull(items, nameof(items));
+        Utils.KeysAndValuesNotNull(items, nameof(items));
 
-        await this.dataClient.SetMultiAsync(cacheName, items, ttlSeconds);
-        return new CacheSetMultiResponse(items);
+        return await this.dataClient.SetMultiAsync(cacheName, items, ttlSeconds);
     }
 
     public CacheSetResponse Set(string cacheName, byte[] key, byte[] value, uint? ttlSeconds = null)
@@ -250,7 +248,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         }
     }
 
-    public CacheSetMultiResponse SetMulti(string cacheName, IDictionary<byte[], byte[]> items, uint? ttlSeconds = null)
+    public CacheSetMultiResponse SetMulti(string cacheName, IEnumerable<KeyValuePair<byte[], byte[]>> items, uint? ttlSeconds = null)
     {
         try
         {
@@ -262,7 +260,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         }
     }
 
-    public CacheSetMultiResponse SetMulti(string cacheName, IDictionary<string, string> items, uint? ttlSeconds = null)
+    public CacheSetMultiResponse SetMulti(string cacheName, IEnumerable<KeyValuePair<string, string>> items, uint? ttlSeconds = null)
     {
         try
         {

--- a/MomentoIntegrationTest/SimpleCacheDataTest.cs
+++ b/MomentoIntegrationTest/SimpleCacheDataTest.cs
@@ -223,8 +223,7 @@ public class SimpleCacheDataTest
                 { key1, value1 },
                 { key2, value2 }
             };
-        CacheSetMultiResponse response = await client.SetMultiAsync(CacheName, dictionary);
-        Assert.Equal(dictionary, response.Bytes);
+        await client.SetMultiAsync(CacheName, dictionary);
 
         var getResponse = await client.GetAsync(CacheName, key1);
         Assert.Equal(value1, getResponse.Bytes);
@@ -255,8 +254,7 @@ public class SimpleCacheDataTest
                 { key1, value1 },
                 { key2, value2 }
             };
-        CacheSetMultiResponse response = await client.SetMultiAsync(CacheName, dictionary);
-        Assert.Equal(dictionary, response.Strings);
+        await client.SetMultiAsync(CacheName, dictionary);
 
         var getResponse = await client.GetAsync(CacheName, key1);
         Assert.Equal(value1, getResponse.String());
@@ -503,8 +501,7 @@ public class SimpleCacheDataTest
                     { key1, value1 },
                     { key2, value2 }
                 };
-        CacheSetMultiResponse response = client.SetMulti(CacheName, dictionary);
-        Assert.Equal(dictionary, response.Bytes);
+        client.SetMulti(CacheName, dictionary);
 
         var getResponse = client.Get(CacheName, key1);
         Assert.Equal(value1, getResponse.Bytes);
@@ -536,8 +533,7 @@ public class SimpleCacheDataTest
                     { key1, value1 },
                     { key2, value2 }
                 };
-        CacheSetMultiResponse response = client.SetMulti(CacheName, dictionary);
-        Assert.Equal(dictionary, response.Strings);
+        client.SetMulti(CacheName, dictionary);
 
         var getResponse = client.Get(CacheName, key1);
         Assert.Equal(value1, getResponse.String());


### PR DESCRIPTION
This changes the client API to use the broadest interfaces where possible. `IEnumerable<KeyValuePair>` affords the end-user more options than `IDictionary` without limiting the implementation.

While updating this, we corrected the implementation of `CacheSetMultiResponse` to not propagate user-data. And while doing this made some minor style changes to the data client.