### PR TITLE
chore: update documentation

### DIFF
--- a/Momento/ISimpleCacheClient.cs
+++ b/Momento/ISimpleCacheClient.cs
@@ -4,6 +4,11 @@ using System.Threading.Tasks;
 using MomentoSdk.Responses;
 namespace MomentoSdk;
 
+/// <summary>
+/// Minimum viable functionality of a cache client.
+///
+/// Includes control operations and data operations.
+/// </summary>
 public interface ISimpleCacheClient : IDisposable
 {
     /// <summary>
@@ -126,6 +131,7 @@ public interface ISimpleCacheClient : IDisposable
     /// </summary>
     /// <param name="cacheName">Name of the cache to store the items in.</param>
     /// <param name="items">The items to set.</param>
+    /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <returns>Task object representing the result of the set operation.</returns>
     public Task<CacheSetBatchResponse> SetBatchAsync(string cacheName, IEnumerable<KeyValuePair<byte[], byte[]>> items, uint? ttlSeconds = null);
 
@@ -134,6 +140,7 @@ public interface ISimpleCacheClient : IDisposable
     /// </summary>
     /// <param name="cacheName">Name of the cache to store the items in.</param>
     /// <param name="items">The items to set.</param>
+    /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <returns>Task object representing the result of the set operation.</returns>
     public Task<CacheSetBatchResponse> SetBatchAsync(string cacheName, IEnumerable<KeyValuePair<string, string>> items, uint? ttlSeconds = null);
 }

--- a/Momento/Incubating/SimpleCacheClient.cs
+++ b/Momento/Incubating/SimpleCacheClient.cs
@@ -8,11 +8,25 @@ using MomentoSdk.Incubating.Responses;
 
 namespace MomentoSdk.Incubating;
 
+/// <summary>
+/// Incubating cache client.
+///
+/// This enables preview features not ready for general release.
+/// </summary>
 public class SimpleCacheClient : ISimpleCacheClient
 {
     private readonly ISimpleCacheClient simpleCacheClient;
     private readonly ScsDataClient dataClient;
 
+    /// <summary>
+    /// Client to perform operations against the Simple Cache Service.
+    /// 
+    /// Enables preview features.
+    /// </summary>
+    /// <param name="simpleCacheClient">Instance of release cache client to delegate operations to.</param>
+    /// <param name="authToken">Momento JWT.</param>
+    /// <param name="defaultTtlSeconds">Default time to live for the item in cache.</param>
+    /// <param name="dataClientOperationTimeoutMilliseconds">Deadline (timeout) for communicating to the server. Defaults to 5 seconds.</param>
     public SimpleCacheClient(ISimpleCacheClient simpleCacheClient, string authToken, uint defaultTtlSeconds, uint? dataClientOperationTimeoutMilliseconds = null)
     {
         this.simpleCacheClient = simpleCacheClient;
@@ -663,6 +677,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.SetDeleteAsync(cacheName, setName);
     }
 
+    /// <inheritdoc />
     public void Dispose()
     {
         this.simpleCacheClient.Dispose();

--- a/Momento/Incubating/SimpleCacheClientFactory.cs
+++ b/Momento/Incubating/SimpleCacheClientFactory.cs
@@ -1,7 +1,19 @@
 namespace MomentoSdk.Incubating;
 
+/// <summary>
+/// Factory class used to instantiate the incubating Simple Cache Client.
+///
+/// Use this to enable preview features in the cache client.
+/// </summary>
 public class SimpleCacheClientFactory
 {
+    /// <summary>
+    /// Instantiate an instance of the incubating Simple Cache Client.
+    /// </summary>
+    /// <param name="authToken">Momento JWT.</param>
+    /// <param name="defaultTtlSeconds">Default time to live for the item in cache.</param>
+    /// <param name="dataClientOperationTimeoutMilliseconds">Deadline (timeout) for communicating to the server. Defaults to 5 seconds.</param>
+    /// <returns>An instance of the incubating Simple Cache Client.</returns>
     public static SimpleCacheClient CreateClient(string authToken, uint defaultTtlSeconds, uint? dataClientOperationTimeoutMilliseconds = null)
     {
         var simpleCacheClient = new MomentoSdk.SimpleCacheClient(authToken, defaultTtlSeconds, dataClientOperationTimeoutMilliseconds);

--- a/Momento/MomentoSdk.csproj
+++ b/Momento/MomentoSdk.csproj
@@ -5,6 +5,7 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<PackageId>Momento.Sdk</PackageId>
 		<Authors>Momento</Authors>
 		<Company>Momento Inc</Company>

--- a/Momento/MomentoSigner.cs
+++ b/Momento/MomentoSigner.cs
@@ -3,13 +3,24 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Web;
 using Microsoft.IdentityModel.Tokens;
 using MomentoSdk.Exceptions;
+using MomentoSdk.Requests;
 
 namespace MomentoSdk;
 
+/// <summary>
+/// Manage presigned URLs on the Simple Cache Service.
+///
+/// See <see href="https://github.com/momentohq/client-sdk-examples/tree/main/dotnet/MomentoExamples/MomentoApplicationPresignedUrl">the examples repo</see> for an example workflow.
+/// </summary>
 public class MomentoSigner
 {
     private readonly JwtHeader jwtHeader;
 
+    /// <summary>
+    /// Instantiate a signer using a JSON web key.
+    /// </summary>
+    /// <param name="jwkJsonString">The JSON web key containing signing credentials.</param>
+    /// <exception cref="InvalidArgumentException">The JSON web key is invalid.</exception>
     public MomentoSigner(string jwkJsonString)
     {
         try
@@ -47,7 +58,6 @@ public class MomentoSigner
     /// <summary>
     /// Create the signature for auth to be used in JWT.
     /// </summary>
-    /// <param name="hostname">Hostname of the SimpleCacheService. Use the value returned from CreateSigningKey's response.</param>
     /// <param name="signingRequest">The parameters used for generating a pre-signed URL</param>
     /// <returns></returns>
     public string SignAccessToken(SigningRequest signingRequest)

--- a/Momento/Requests/SigningRequest.cs
+++ b/Momento/Requests/SigningRequest.cs
@@ -1,11 +1,23 @@
-﻿namespace MomentoSdk;
+﻿namespace MomentoSdk.Requests;
 
+/// <summary>
+/// Type of operation to performed on the cache for the signed url.
+/// </summary>
 public enum CacheOperation
 {
+    /// <summary>
+    /// Store an item in the cache.
+    /// </summary>
     SET,
+    /// <summary>
+    /// Retrieve a value from the cache.
+    /// </summary>
     GET
 };
 
+/// <summary>
+/// Metadata to create a pre-signed URL.
+/// </summary>
 public class SigningRequest
 {
     /// <summary>
@@ -46,6 +58,13 @@ public class SigningRequest
         set;
     }
 
+    /// <summary>
+    /// Instantiate a request for a pre-signed URL.
+    /// </summary>
+    /// <param name="cacheName">The cache where the key to pre-sign is.</param>
+    /// <param name="cacheKey">The key to pre-sign.</param>
+    /// <param name="cacheOperation">Type of operation (eg `get`, `set`) to pre-sign.</param>
+    /// <param name="expiryEpochSeconds">Duration the pre-signed URL is valid for.</param>
     public SigningRequest(string cacheName, string cacheKey, CacheOperation cacheOperation, uint expiryEpochSeconds)
     {
         CacheName = cacheName;

--- a/Momento/SimpleCacheClient.cs
+++ b/Momento/SimpleCacheClient.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Threading.Tasks;
 using MomentoSdk.Internal;
 using MomentoSdk.Responses;
@@ -8,6 +7,11 @@ using System.Collections.Generic;
 
 namespace MomentoSdk;
 
+/// <summary>
+/// Client to perform control and data operations against the Simple Cache Service.
+/// 
+/// See <see href="https://github.com/momentohq/client-sdk-examples/tree/main/dotnet/MomentoExamples">the examples repo</see> for complete workflows.
+/// </summary>
 public class SimpleCacheClient : ISimpleCacheClient
 {
     private readonly ScsControlClient controlClient;
@@ -174,6 +178,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.SetBatchAsync(cacheName, items, ttlSeconds);
     }
 
+    /// <inheritdoc />
     public void Dispose()
     {
         this.controlClient.Dispose();

--- a/MomentoTest/MomentoSignerTest.cs
+++ b/MomentoTest/MomentoSignerTest.cs
@@ -5,6 +5,7 @@ using System.Web;
 using Xunit;
 using MomentoSdk;
 using MomentoSdk.Exceptions;
+using MomentoSdk.Requests;
 
 namespace MomentoTest;
 


### PR DESCRIPTION
This enables documentation in the SDK assembly. By default the `dotnet` tooling does not enable this. We have enabled this and also completed documentation for the cache client and signer classes.

In a future PR we will complete documentation for all public classes and methods in the SDK assembly.