### PR TITLE
feat: align SDK namespace with NuGet package and assembly name

### DIFF
--- a/IncubatingIntegrationTest/DictionaryTest.cs
+++ b/IncubatingIntegrationTest/DictionaryTest.cs
@@ -1,5 +1,5 @@
-using MomentoSdk.Internal.ExtensionMethods;
-using MomentoSdk.Responses;
+using Momento.Sdk.Internal.ExtensionMethods;
+using Momento.Sdk.Responses;
 
 namespace IncubatingIntegrationTest;
 

--- a/IncubatingIntegrationTest/SetTest.cs
+++ b/IncubatingIntegrationTest/SetTest.cs
@@ -1,4 +1,4 @@
-using MomentoSdk.Responses;
+using Momento.Sdk.Responses;
 
 namespace IncubatingIntegrationTest;
 

--- a/IncubatingIntegrationTest/Usings.cs
+++ b/IncubatingIntegrationTest/Usings.cs
@@ -1,4 +1,4 @@
+global using Momento.Sdk.Exceptions;
+global using Momento.Sdk.Incubating;
 global using Xunit;
-global using MomentoSdk.Incubating;
-global using MomentoSdk.Exceptions;
-global using Utils = MomentoSdk.Internal.Utils;
+global using Utils = Momento.Sdk.Internal.Utils;

--- a/Momento/Exceptions/AlreadyExistsException.cs
+++ b/Momento/Exceptions/AlreadyExistsException.cs
@@ -1,4 +1,4 @@
-﻿namespace MomentoSdk.Exceptions;
+﻿namespace Momento.Sdk.Exceptions;
 
 /// <summary>
 /// Resource already exists

--- a/Momento/Exceptions/AuthenticationException.cs
+++ b/Momento/Exceptions/AuthenticationException.cs
@@ -1,4 +1,4 @@
-﻿namespace MomentoSdk.Exceptions;
+﻿namespace Momento.Sdk.Exceptions;
 
 /// <summary>
 /// Authentication token is not provided or is invalid.

--- a/Momento/Exceptions/BadRequestException.cs
+++ b/Momento/Exceptions/BadRequestException.cs
@@ -1,4 +1,4 @@
-﻿namespace MomentoSdk.Exceptions;
+﻿namespace Momento.Sdk.Exceptions;
 
 /// <summary>
 /// Invalid parameters sent to Momento Services.

--- a/Momento/Exceptions/CacheExceptionMapper.cs
+++ b/Momento/Exceptions/CacheExceptionMapper.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Grpc.Core;
 
-namespace MomentoSdk.Exceptions;
+namespace Momento.Sdk.Exceptions;
 
 class CacheExceptionMapper
 {

--- a/Momento/Exceptions/CancelledException.cs
+++ b/Momento/Exceptions/CancelledException.cs
@@ -1,4 +1,4 @@
-﻿namespace MomentoSdk.Exceptions;
+﻿namespace Momento.Sdk.Exceptions;
 
 public class CancelledException : MomentoServiceException
 {

--- a/Momento/Exceptions/ClientSdkException.cs
+++ b/Momento/Exceptions/ClientSdkException.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace MomentoSdk.Exceptions;
+namespace Momento.Sdk.Exceptions;
 
 public class ClientSdkException : SdkException
 {

--- a/Momento/Exceptions/InternalServerException.cs
+++ b/Momento/Exceptions/InternalServerException.cs
@@ -1,5 +1,6 @@
 ﻿using System;
-namespace MomentoSdk.Exceptions;
+
+namespace Momento.Sdk.Exceptions;
 
 /// <summary>
 /// Momento Service encountered an unexpected exception while trying to fulfill the request.

--- a/Momento/Exceptions/InvalidArgumentException.cs
+++ b/Momento/Exceptions/InvalidArgumentException.cs
@@ -1,5 +1,6 @@
 ﻿using System;
-namespace MomentoSdk.Exceptions;
+
+namespace Momento.Sdk.Exceptions;
 
 /// <summary>
 /// SDK client side validation failed.

--- a/Momento/Exceptions/LimitExceededException.cs
+++ b/Momento/Exceptions/LimitExceededException.cs
@@ -1,4 +1,4 @@
-﻿namespace MomentoSdk.Exceptions;
+﻿namespace Momento.Sdk.Exceptions;
 
 /// <summary>
 /// Requested operation couldn't be completed because system limits were hit.

--- a/Momento/Exceptions/MomentoServiceException.cs
+++ b/Momento/Exceptions/MomentoServiceException.cs
@@ -1,5 +1,6 @@
 ﻿using System;
-namespace MomentoSdk.Exceptions;
+
+namespace Momento.Sdk.Exceptions;
 
 /// <summary>
 /// Base type for all the exceptions resulting from invalid interactions with Momento Services.

--- a/Momento/Exceptions/NotFoundException.cs
+++ b/Momento/Exceptions/NotFoundException.cs
@@ -1,4 +1,4 @@
-﻿namespace MomentoSdk.Exceptions;
+﻿namespace Momento.Sdk.Exceptions;
 
 /// <summary>
 /// Requested resource or the resource on which an operation was requested doesn't exist.

--- a/Momento/Exceptions/PermissionDeniedException.cs
+++ b/Momento/Exceptions/PermissionDeniedException.cs
@@ -1,4 +1,4 @@
-﻿namespace MomentoSdk.Exceptions;
+﻿namespace Momento.Sdk.Exceptions;
 
 /// <summary>
 /// Insufficient permissions to execute an operation.

--- a/Momento/Exceptions/SdkException.cs
+++ b/Momento/Exceptions/SdkException.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace MomentoSdk.Exceptions;
+namespace Momento.Sdk.Exceptions;
 
 public abstract class SdkException : Exception
 {

--- a/Momento/Exceptions/TimeoutException.cs
+++ b/Momento/Exceptions/TimeoutException.cs
@@ -1,4 +1,4 @@
-﻿namespace MomentoSdk.Exceptions;
+﻿namespace Momento.Sdk.Exceptions;
 
 /// <summary>
 /// Requested operation did not complete in allotted time.

--- a/Momento/ISimpleCacheClient.cs
+++ b/Momento/ISimpleCacheClient.cs
@@ -1,8 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using MomentoSdk.Responses;
-namespace MomentoSdk;
+using Momento.Sdk.Responses;
+
+namespace Momento.Sdk;
 
 /// <summary>
 /// Minimum viable functionality of a cache client.

--- a/Momento/Incubating/Internal/ScsDataClient.cs
+++ b/Momento/Incubating/Internal/ScsDataClient.cs
@@ -4,12 +4,12 @@ using System.Linq;
 using System.Threading.Tasks;
 using Google.Protobuf;
 using Momento.Protos.CacheClient;
-using MomentoSdk.Exceptions;
-using MomentoSdk.Incubating.Responses;
-using MomentoSdk.Internal;
-using MomentoSdk.Internal.ExtensionMethods;
+using Momento.Sdk.Exceptions;
+using Momento.Sdk.Incubating.Responses;
+using Momento.Sdk.Internal;
+using Momento.Sdk.Internal.ExtensionMethods;
 
-namespace MomentoSdk.Incubating.Internal;
+namespace Momento.Sdk.Incubating.Internal;
 
 internal sealed class ScsDataClient : ScsDataClientBase
 {

--- a/Momento/Incubating/README.md
+++ b/Momento/Incubating/README.md
@@ -1,19 +1,19 @@
 # Incubating
 
-The `MomentoSdk.Incubating` namespace has work-in-progress features that may or may be be in the final version.
+The `Momento.Sdk.Incubating` namespace has work-in-progress features that may or may be be in the final version.
 
 # Dictionary Methods
 
 This demonstrates the methods and response types for a dictionary data type in the cache:
 
 ```csharp
-using MomentoSdk.Incubating;
+using Momento.Sdk.Incubating;
 
 class Driver
 {
     public static void Main()
     {
-        var client = SimpleCacheClientFactory.CreateClient(authToken: "YOUR-AUTH-TOKEN", defaultTtlSeconds: 60);
+        using var client = SimpleCacheClientFactory.CreateClient(authToken: "YOUR-AUTH-TOKEN", defaultTtlSeconds: 60);
         var cacheName = "my-cache";
 
         // Set a value

--- a/Momento/Incubating/Responses/CacheDictionaryDeleteResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictionaryDeleteResponse.cs
@@ -1,4 +1,4 @@
-namespace MomentoSdk.Incubating.Responses;
+namespace Momento.Sdk.Incubating.Responses;
 
 public class CacheDictionaryDeleteResponse
 {

--- a/Momento/Incubating/Responses/CacheDictionaryFetchResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictionaryFetchResponse.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using Google.Protobuf.Collections;
 using Momento.Protos.CacheClient;
-using MomentoSdk.Internal;
-using MomentoSdk.Responses;
+using Momento.Sdk.Internal;
+using Momento.Sdk.Responses;
 
-namespace MomentoSdk.Incubating.Responses;
+namespace Momento.Sdk.Incubating.Responses;
 
 public class CacheDictionaryFetchResponse
 {

--- a/Momento/Incubating/Responses/CacheDictionaryGetBatchResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictionaryGetBatchResponse.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Momento.Protos.CacheClient;
-using MomentoSdk.Responses;
+using Momento.Sdk.Responses;
 
 
-namespace MomentoSdk.Incubating.Responses;
+namespace Momento.Sdk.Incubating.Responses;
 
 public class CacheDictionaryGetBatchResponse
 {

--- a/Momento/Incubating/Responses/CacheDictionaryGetResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictionaryGetResponse.cs
@@ -1,9 +1,9 @@
 ﻿using Google.Protobuf;
 using Momento.Protos.CacheClient;
-using MomentoSdk.Exceptions;
-using MomentoSdk.Responses;
+using Momento.Sdk.Exceptions;
+using Momento.Sdk.Responses;
 
-namespace MomentoSdk.Incubating.Responses;
+namespace Momento.Sdk.Incubating.Responses;
 
 public class CacheDictionaryGetResponse
 {

--- a/Momento/Incubating/Responses/CacheDictionaryRemoveFieldResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictionaryRemoveFieldResponse.cs
@@ -1,4 +1,4 @@
-namespace MomentoSdk.Incubating.Responses;
+namespace Momento.Sdk.Incubating.Responses;
 
 public class CacheDictionaryRemoveFieldResponse
 {

--- a/Momento/Incubating/Responses/CacheDictionaryRemoveFieldsResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictionaryRemoveFieldsResponse.cs
@@ -1,4 +1,4 @@
-namespace MomentoSdk.Incubating.Responses;
+namespace Momento.Sdk.Incubating.Responses;
 
 public class CacheDictionaryRemoveFieldsResponse
 {

--- a/Momento/Incubating/Responses/CacheDictionarySetBatchResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictionarySetBatchResponse.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace MomentoSdk.Incubating.Responses;
+﻿namespace Momento.Sdk.Incubating.Responses;
 
 public class CacheDictionarySetBatchResponse
 {

--- a/Momento/Incubating/Responses/CacheDictionarySetResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictionarySetResponse.cs
@@ -1,4 +1,4 @@
-﻿namespace MomentoSdk.Incubating.Responses;
+﻿namespace Momento.Sdk.Incubating.Responses;
 
 public class CacheDictionarySetResponse
 {

--- a/Momento/Incubating/Responses/CacheSetAddBatchResponse.cs
+++ b/Momento/Incubating/Responses/CacheSetAddBatchResponse.cs
@@ -1,4 +1,4 @@
-namespace MomentoSdk.Incubating.Responses;
+namespace Momento.Sdk.Incubating.Responses;
 
 public class CacheSetAddBatchResponse
 {

--- a/Momento/Incubating/Responses/CacheSetAddResponse.cs
+++ b/Momento/Incubating/Responses/CacheSetAddResponse.cs
@@ -1,4 +1,4 @@
-namespace MomentoSdk.Incubating.Responses;
+namespace Momento.Sdk.Incubating.Responses;
 
 public class CacheSetAddResponse
 {

--- a/Momento/Incubating/Responses/CacheSetDeleteResponse.cs
+++ b/Momento/Incubating/Responses/CacheSetDeleteResponse.cs
@@ -1,4 +1,4 @@
-namespace MomentoSdk.Incubating.Responses;
+namespace Momento.Sdk.Incubating.Responses;
 
 public class CacheSetDeleteResponse
 {

--- a/Momento/Incubating/Responses/CacheSetFetchResponse.cs
+++ b/Momento/Incubating/Responses/CacheSetFetchResponse.cs
@@ -4,10 +4,10 @@ using System.Linq;
 using Google.Protobuf;
 using Google.Protobuf.Collections;
 using Momento.Protos.CacheClient;
-using MomentoSdk.Internal;
-using MomentoSdk.Responses;
+using Momento.Sdk.Internal;
+using Momento.Sdk.Responses;
 
-namespace MomentoSdk.Incubating.Responses;
+namespace Momento.Sdk.Incubating.Responses;
 
 public class CacheSetFetchResponse
 {

--- a/Momento/Incubating/SimpleCacheClient.cs
+++ b/Momento/Incubating/SimpleCacheClient.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using MomentoSdk.Responses;
-using Utils = MomentoSdk.Internal.Utils;
-using MomentoSdk.Incubating.Internal;
-using MomentoSdk.Incubating.Responses;
+using Momento.Sdk.Incubating.Internal;
+using Momento.Sdk.Incubating.Responses;
+using Momento.Sdk.Responses;
+using Utils = Momento.Sdk.Internal.Utils;
 
-namespace MomentoSdk.Incubating;
+namespace Momento.Sdk.Incubating;
 
 /// <summary>
 /// Incubating cache client.
@@ -31,7 +31,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     {
         this.simpleCacheClient = simpleCacheClient;
 
-        var claims = MomentoSdk.Internal.JwtUtils.DecodeJwt(authToken);
+        var claims = Momento.Sdk.Internal.JwtUtils.DecodeJwt(authToken);
         this.dataClient = new(authToken, claims.CacheEndpoint, defaultTtlSeconds, dataClientOperationTimeoutMilliseconds);
     }
 

--- a/Momento/Incubating/SimpleCacheClientFactory.cs
+++ b/Momento/Incubating/SimpleCacheClientFactory.cs
@@ -1,4 +1,4 @@
-namespace MomentoSdk.Incubating;
+namespace Momento.Sdk.Incubating;
 
 /// <summary>
 /// Factory class used to instantiate the incubating Simple Cache Client.
@@ -16,7 +16,7 @@ public class SimpleCacheClientFactory
     /// <returns>An instance of the incubating Simple Cache Client.</returns>
     public static SimpleCacheClient CreateClient(string authToken, uint defaultTtlSeconds, uint? dataClientOperationTimeoutMilliseconds = null)
     {
-        var simpleCacheClient = new MomentoSdk.SimpleCacheClient(authToken, defaultTtlSeconds, dataClientOperationTimeoutMilliseconds);
+        var simpleCacheClient = new Momento.Sdk.SimpleCacheClient(authToken, defaultTtlSeconds, dataClientOperationTimeoutMilliseconds);
         return new SimpleCacheClient(simpleCacheClient, authToken, defaultTtlSeconds, dataClientOperationTimeoutMilliseconds);
     }
 }

--- a/Momento/Internal/ControlGrpcManager.cs
+++ b/Momento/Internal/ControlGrpcManager.cs
@@ -6,13 +6,13 @@ using Grpc.Net.Client;
 using Momento.Protos.ControlClient;
 using static System.Reflection.Assembly;
 
-namespace MomentoSdk.Internal;
+namespace Momento.Sdk.Internal;
 
 internal sealed class ControlGrpcManager : IDisposable
 {
     private readonly GrpcChannel channel;
     public ScsControl.ScsControlClient Client { get; }
-    private readonly string version = "csharp:" + GetAssembly(typeof(MomentoSdk.Responses.CacheGetResponse)).GetName().Version.ToString();
+    private readonly string version = "csharp:" + GetAssembly(typeof(Momento.Sdk.Responses.CacheGetResponse)).GetName().Version.ToString();
 
     public ControlGrpcManager(string authToken, string endpoint)
     {

--- a/Momento/Internal/DataGrpcManager.cs
+++ b/Momento/Internal/DataGrpcManager.cs
@@ -6,14 +6,14 @@ using Grpc.Net.Client;
 using Momento.Protos.CacheClient;
 using static System.Reflection.Assembly;
 
-namespace MomentoSdk.Internal;
+namespace Momento.Sdk.Internal;
 
 public class DataGrpcManager : IDisposable
 {
     private readonly GrpcChannel channel;
     public Scs.ScsClient Client { get; }
 
-    private readonly string version = "csharp:" + GetAssembly(typeof(MomentoSdk.Responses.CacheGetResponse)).GetName().Version.ToString();
+    private readonly string version = "csharp:" + GetAssembly(typeof(Momento.Sdk.Responses.CacheGetResponse)).GetName().Version.ToString();
 
     internal DataGrpcManager(string authToken, string host)
     {

--- a/Momento/Internal/HeaderInterceptor.cs
+++ b/Momento/Internal/HeaderInterceptor.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using Grpc.Core;
-using Grpc.Core.Interceptors;
 using System.Collections.Generic;
 using System.Linq;
+using Grpc.Core;
+using Grpc.Core.Interceptors;
 
-namespace MomentoSdk.Internal;
+namespace Momento.Sdk.Internal;
 
 class Header
 {

--- a/Momento/Internal/JwtUtils.cs
+++ b/Momento/Internal/JwtUtils.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using JWT;
 using JWT.Serializers;
-using MomentoSdk.Exceptions;
+using Momento.Sdk.Exceptions;
 using Newtonsoft.Json;
 
-namespace MomentoSdk.Internal;
+namespace Momento.Sdk.Internal;
 
 public class JwtUtils
 {

--- a/Momento/Internal/ScsControlClient.cs
+++ b/Momento/Internal/ScsControlClient.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using Momento.Protos.ControlClient;
-using MomentoSdk.Exceptions;
-using MomentoSdk.Responses;
+using Momento.Sdk.Exceptions;
+using Momento.Sdk.Responses;
 
-namespace MomentoSdk.Internal;
+namespace Momento.Sdk.Internal;
 
 internal sealed class ScsControlClient : IDisposable
 {

--- a/Momento/Internal/ScsDataClient.cs
+++ b/Momento/Internal/ScsDataClient.cs
@@ -5,11 +5,11 @@ using System.Threading.Tasks;
 using Google.Protobuf;
 using Grpc.Core;
 using Momento.Protos.CacheClient;
-using MomentoSdk.Exceptions;
-using MomentoSdk.Internal.ExtensionMethods;
-using MomentoSdk.Responses;
+using Momento.Sdk.Exceptions;
+using Momento.Sdk.Internal.ExtensionMethods;
+using Momento.Sdk.Responses;
 
-namespace MomentoSdk.Internal;
+namespace Momento.Sdk.Internal;
 
 public class ScsDataClientBase : IDisposable
 {

--- a/Momento/Internal/Utils.cs
+++ b/Momento/Internal/Utils.cs
@@ -1,11 +1,11 @@
 using System;
-using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Google.Protobuf;
 
-namespace MomentoSdk.Internal
+namespace Momento.Sdk.Internal
 {
     /// <summary>
     /// Ad-hoc utility methods.

--- a/Momento/MomentoSigner.cs
+++ b/Momento/MomentoSigner.cs
@@ -2,10 +2,10 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Web;
 using Microsoft.IdentityModel.Tokens;
-using MomentoSdk.Exceptions;
-using MomentoSdk.Requests;
+using Momento.Sdk.Exceptions;
+using Momento.Sdk.Requests;
 
-namespace MomentoSdk;
+namespace Momento.Sdk;
 
 /// <summary>
 /// Manage presigned URLs on the Simple Cache Service.

--- a/Momento/Requests/SigningRequest.cs
+++ b/Momento/Requests/SigningRequest.cs
@@ -1,4 +1,4 @@
-﻿namespace MomentoSdk.Requests;
+﻿namespace Momento.Sdk.Requests;
 
 /// <summary>
 /// Type of operation to performed on the cache for the signed url.

--- a/Momento/Responses/CacheDeleteResponse.cs
+++ b/Momento/Responses/CacheDeleteResponse.cs
@@ -1,4 +1,4 @@
-﻿namespace MomentoSdk.Responses;
+﻿namespace Momento.Sdk.Responses;
 
 public class CacheDeleteResponse
 {

--- a/Momento/Responses/CacheGetBatchResponse.cs
+++ b/Momento/Responses/CacheGetBatchResponse.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
-namespace MomentoSdk.Responses;
+namespace Momento.Sdk.Responses;
 
 public class CacheGetBatchResponse
 {

--- a/Momento/Responses/CacheGetResponse.cs
+++ b/Momento/Responses/CacheGetResponse.cs
@@ -1,7 +1,7 @@
 ﻿using Google.Protobuf;
 using Momento.Protos.CacheClient;
 
-namespace MomentoSdk.Responses;
+namespace Momento.Sdk.Responses;
 
 public class CacheGetResponse
 {

--- a/Momento/Responses/CacheGetStatus.cs
+++ b/Momento/Responses/CacheGetStatus.cs
@@ -1,7 +1,7 @@
 ﻿using Momento.Protos.CacheClient;
-using MomentoSdk.Exceptions;
+using Momento.Sdk.Exceptions;
 
-namespace MomentoSdk.Responses;
+namespace Momento.Sdk.Responses;
 
 public enum CacheGetStatus
 {

--- a/Momento/Responses/CacheInfo.cs
+++ b/Momento/Responses/CacheInfo.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace MomentoSdk.Responses;
+namespace Momento.Sdk.Responses;
 
 public class CacheInfo : IEquatable<CacheInfo>
 {

--- a/Momento/Responses/CacheSetBatchResponse.cs
+++ b/Momento/Responses/CacheSetBatchResponse.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
-
-namespace MomentoSdk.Responses;
+namespace Momento.Sdk.Responses;
 
 public class CacheSetBatchResponse
 {

--- a/Momento/Responses/CacheSetResponse.cs
+++ b/Momento/Responses/CacheSetResponse.cs
@@ -1,4 +1,4 @@
-﻿namespace MomentoSdk.Responses;
+﻿namespace Momento.Sdk.Responses;
 
 public class CacheSetResponse
 {

--- a/Momento/Responses/CreateCacheResponse.cs
+++ b/Momento/Responses/CreateCacheResponse.cs
@@ -1,4 +1,4 @@
-﻿namespace MomentoSdk.Responses;
+﻿namespace Momento.Sdk.Responses;
 
 public class CreateCacheResponse
 {

--- a/Momento/Responses/DeleteCacheResponse.cs
+++ b/Momento/Responses/DeleteCacheResponse.cs
@@ -1,4 +1,4 @@
-﻿namespace MomentoSdk.Responses;
+﻿namespace Momento.Sdk.Responses;
 
 public class DeleteCacheResponse
 {

--- a/Momento/Responses/ListCachesResponse.cs
+++ b/Momento/Responses/ListCachesResponse.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using Momento.Protos.ControlClient;
 
-namespace MomentoSdk.Responses;
+namespace Momento.Sdk.Responses;
 
 public class ListCachesResponse
 {

--- a/Momento/SimpleCacheClient.cs
+++ b/Momento/SimpleCacheClient.cs
@@ -1,11 +1,11 @@
 ﻿using System;
-using System.Threading.Tasks;
-using MomentoSdk.Internal;
-using MomentoSdk.Responses;
-using MomentoSdk.Exceptions;
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using Momento.Sdk.Exceptions;
+using Momento.Sdk.Internal;
+using Momento.Sdk.Responses;
 
-namespace MomentoSdk;
+namespace Momento.Sdk;
 
 /// <summary>
 /// Client to perform control and data operations against the Simple Cache Service.

--- a/MomentoIntegrationTest/SimpleCacheDataTest.cs
+++ b/MomentoIntegrationTest/SimpleCacheDataTest.cs
@@ -200,7 +200,7 @@ public class SimpleCacheDataTest
         // Set very small timeout for dataClientOperationTimeoutMilliseconds
         using SimpleCacheClient simpleCacheClient = new SimpleCacheClient(authToken, DefaultTtlSeconds, 1);
         List<string> keys = new() { Utils.NewGuidString(), Utils.NewGuidString(), Utils.NewGuidString(), Utils.NewGuidString() };
-        await Assert.ThrowsAsync<MomentoSdk.Exceptions.TimeoutException>(async () => await simpleCacheClient.GetBatchAsync(cacheName, keys));
+        await Assert.ThrowsAsync<Momento.Sdk.Exceptions.TimeoutException>(async () => await simpleCacheClient.GetBatchAsync(cacheName, keys));
     }
 
     [Fact]

--- a/MomentoIntegrationTest/Usings.cs
+++ b/MomentoIntegrationTest/Usings.cs
@@ -1,6 +1,6 @@
-global using Xunit;
-global using MomentoSdk;
-global using Utils = MomentoSdk.Internal.Utils;
-global using MomentoSdk.Exceptions;
-global using MomentoSdk.Responses;
 global using System;
+global using Momento.Sdk;
+global using Momento.Sdk.Exceptions;
+global using Momento.Sdk.Responses;
+global using Xunit;
+global using Utils = Momento.Sdk.Internal.Utils;

--- a/MomentoTest/MomentoSignerTest.cs
+++ b/MomentoTest/MomentoSignerTest.cs
@@ -1,11 +1,11 @@
-﻿using Microsoft.IdentityModel.Tokens;
-using System;
+﻿using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Web;
+using Microsoft.IdentityModel.Tokens;
+using Momento.Sdk;
+using Momento.Sdk.Exceptions;
+using Momento.Sdk.Requests;
 using Xunit;
-using MomentoSdk;
-using MomentoSdk.Exceptions;
-using MomentoSdk.Requests;
 
 namespace MomentoTest;
 

--- a/MomentoTest/Responses/CacheGetResponseTest.cs
+++ b/MomentoTest/Responses/CacheGetResponseTest.cs
@@ -1,7 +1,7 @@
 ﻿using Google.Protobuf;
 using Momento.Protos.CacheClient;
-using MomentoSdk.Exceptions;
-using MomentoSdk.Responses;
+using Momento.Sdk.Exceptions;
+using Momento.Sdk.Responses;
 using Xunit;
 
 namespace MomentoTest.Responses;


### PR DESCRIPTION
Closes #104 

This PR renames the namespace `MomentoSdk` to `Momento.Sdk`. This is
consistent with C# best practices, with the package name on NuGet, and
with the assembly name.