### PR TITLE
chore: remove methods with variadic args

### DIFF
--- a/IncubatingIntegrationTest/DictionaryTest.cs
+++ b/IncubatingIntegrationTest/DictionaryTest.cs
@@ -91,8 +91,6 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidByteArray();
 
         await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttlSeconds: 1);
-        await Task.Delay(100);
-
         await client.DictionarySetAsync(cacheName, dictionaryName, field, value, true, ttlSeconds: 10);
         await Task.Delay(1000);
 
@@ -182,8 +180,6 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidString();
 
         await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttlSeconds: 1);
-        await Task.Delay(100);
-
         await client.DictionarySetAsync(cacheName, dictionaryName, field, value, true, ttlSeconds: 10);
         await Task.Delay(1000);
 
@@ -254,8 +250,6 @@ public class DictionaryTest : TestBase
         var content = new Dictionary<byte[], byte[]>() { { field, value } };
 
         await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttlSeconds: 1);
-        await Task.Delay(100);
-
         await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, true, ttlSeconds: 10);
         await Task.Delay(1000);
 
@@ -326,8 +320,6 @@ public class DictionaryTest : TestBase
         var content = new Dictionary<string, string>() { { field, value } };
 
         await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttlSeconds: 1);
-        await Task.Delay(100);
-
         await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, true, ttlSeconds: 10);
         await Task.Delay(1000);
 

--- a/IncubatingIntegrationTest/DictionaryTest.cs
+++ b/IncubatingIntegrationTest/DictionaryTest.cs
@@ -367,15 +367,12 @@ public class DictionaryTest : TestBase
         await client.DictionarySetAsync(cacheName, dictionaryName, field1, value1, false, 10);
         await client.DictionarySetAsync(cacheName, dictionaryName, field2, value2, false, 10);
 
-        var response1 = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, field1, field2, field3);
-        var response2 = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, new byte[][] { field1, field2, field3 });
+        var response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, new byte[][] { field1, field2, field3 });
 
         var status = new CacheGetStatus[] { CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS };
         var values = new byte[]?[] { value1, value2, null };
-        Assert.Equal(status, response1.Status);
-        Assert.Equal(status, response2.Status);
-        Assert.Equal(values, response1.ByteArrays);
-        Assert.Equal(values, response2.ByteArrays);
+        Assert.Equal(status, response.Status);
+        Assert.Equal(values, response.ByteArrays);
     }
 
     [Fact]
@@ -386,7 +383,7 @@ public class DictionaryTest : TestBase
         var field2 = Utils.NewGuidByteArray();
         var field3 = Utils.NewGuidByteArray();
 
-        var response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, field1, field2, field3);
+        var response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, new byte[][] { field1, field2, field3 });
 
         var status = new CacheGetStatus[] { CacheGetStatus.MISS, CacheGetStatus.MISS, CacheGetStatus.MISS };
         var byteArrays = new byte[]?[] { null, null, null };
@@ -427,15 +424,12 @@ public class DictionaryTest : TestBase
         await client.DictionarySetAsync(cacheName, dictionaryName, field1, value1, false, 10);
         await client.DictionarySetAsync(cacheName, dictionaryName, field2, value2, false, 10);
 
-        var response1 = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, field1, field2, field3);
-        var response2 = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, new string[] { field1, field2, field3 });
+        var response = await client.DictionaryGetBatchAsync(cacheName, dictionaryName, new string[] { field1, field2, field3 });
 
         var status = new CacheGetStatus[] { CacheGetStatus.HIT, CacheGetStatus.HIT, CacheGetStatus.MISS };
         var values = new string?[] { value1, value2, null };
-        Assert.Equal(status, response1.Status);
-        Assert.Equal(status, response2.Status);
-        Assert.Equal(values, response1.Strings());
-        Assert.Equal(values, response2.Strings());
+        Assert.Equal(status, response.Status);
+        Assert.Equal(values, response.Strings());
     }
 
     [Theory]
@@ -624,19 +618,7 @@ public class DictionaryTest : TestBase
         var fields = new byte[][] { Utils.NewGuidByteArray(), Utils.NewGuidByteArray() };
         var otherField = Utils.NewGuidByteArray();
 
-        // Test variadic args
-        await client.DictionarySetAsync(cacheName, dictionaryName, fields[0], Utils.NewGuidByteArray(), false);
-        await client.DictionarySetAsync(cacheName, dictionaryName, fields[1], Utils.NewGuidByteArray(), false);
-        await client.DictionarySetAsync(cacheName, dictionaryName, otherField, Utils.NewGuidByteArray(), false);
-
-
-        await client.DictionaryRemoveFieldsAsync(cacheName, dictionaryName, fields[0], fields[1]);
-        Assert.Equal(CacheGetStatus.MISS, (await client.DictionaryGetAsync(cacheName, dictionaryName, fields[0])).Status);
-        Assert.Equal(CacheGetStatus.MISS, (await client.DictionaryGetAsync(cacheName, dictionaryName, fields[1])).Status);
-        Assert.Equal(CacheGetStatus.HIT, (await client.DictionaryGetAsync(cacheName, dictionaryName, otherField)).Status);
-
         // Test enumerable
-        dictionaryName = Utils.NewGuidString();
         await client.DictionarySetAsync(cacheName, dictionaryName, fields[0], Utils.NewGuidByteArray(), false);
         await client.DictionarySetAsync(cacheName, dictionaryName, fields[1], Utils.NewGuidByteArray(), false);
         await client.DictionarySetAsync(cacheName, dictionaryName, otherField, Utils.NewGuidByteArray(), false);
@@ -672,19 +654,7 @@ public class DictionaryTest : TestBase
         var fields = new string[] { Utils.NewGuidString(), Utils.NewGuidString() };
         var otherField = Utils.NewGuidString();
 
-        // Test variadic args
-        await client.DictionarySetAsync(cacheName, dictionaryName, fields[0], Utils.NewGuidString(), false);
-        await client.DictionarySetAsync(cacheName, dictionaryName, fields[1], Utils.NewGuidString(), false);
-        await client.DictionarySetAsync(cacheName, dictionaryName, otherField, Utils.NewGuidString(), false);
-
-
-        await client.DictionaryRemoveFieldsAsync(cacheName, dictionaryName, fields[0], fields[1]);
-        Assert.Equal(CacheGetStatus.MISS, (await client.DictionaryGetAsync(cacheName, dictionaryName, fields[0])).Status);
-        Assert.Equal(CacheGetStatus.MISS, (await client.DictionaryGetAsync(cacheName, dictionaryName, fields[1])).Status);
-        Assert.Equal(CacheGetStatus.HIT, (await client.DictionaryGetAsync(cacheName, dictionaryName, otherField)).Status);
-
         // Test enumerable
-        dictionaryName = Utils.NewGuidString();
         await client.DictionarySetAsync(cacheName, dictionaryName, fields[0], Utils.NewGuidString(), false);
         await client.DictionarySetAsync(cacheName, dictionaryName, fields[1], Utils.NewGuidString(), false);
         await client.DictionarySetAsync(cacheName, dictionaryName, otherField, Utils.NewGuidString(), false);

--- a/IncubatingIntegrationTest/ListTest.cs
+++ b/IncubatingIntegrationTest/ListTest.cs
@@ -66,8 +66,6 @@ public class ListTest : TestBase
         var value = Utils.NewGuidByteArray();
 
         await client.ListPushFrontAsync(cacheName, listName, value, false, ttlSeconds: 1);
-        await Task.Delay(100);
-
         await client.ListPushFrontAsync(cacheName, listName, value, true, ttlSeconds: 10);
         await Task.Delay(1000);
 
@@ -133,8 +131,6 @@ public class ListTest : TestBase
         var value = Utils.NewGuidString();
 
         await client.ListPushFrontAsync(cacheName, listName, value, false, ttlSeconds: 1);
-        await Task.Delay(100);
-
         await client.ListPushFrontAsync(cacheName, listName, value, true, ttlSeconds: 10);
         await Task.Delay(1000);
 
@@ -200,8 +196,6 @@ public class ListTest : TestBase
         var value = Utils.NewGuidByteArray();
 
         await client.ListPushBackAsync(cacheName, listName, value, false, ttlSeconds: 1);
-        await Task.Delay(100);
-
         await client.ListPushBackAsync(cacheName, listName, value, true, ttlSeconds: 10);
         await Task.Delay(1000);
 
@@ -267,8 +261,6 @@ public class ListTest : TestBase
         var value = Utils.NewGuidString();
 
         await client.ListPushBackAsync(cacheName, listName, value, false, ttlSeconds: 1);
-        await Task.Delay(100);
-
         await client.ListPushBackAsync(cacheName, listName, value, true, ttlSeconds: 10);
         await Task.Delay(1000);
 

--- a/IncubatingIntegrationTest/SetTest.cs
+++ b/IncubatingIntegrationTest/SetTest.cs
@@ -57,8 +57,6 @@ public class SetTest : TestBase
         var element = Utils.NewGuidByteArray();
 
         await client.SetAddAsync(cacheName, setName, element, false, ttlSeconds: 1);
-        await Task.Delay(100);
-
         await client.SetAddAsync(cacheName, setName, element, true, ttlSeconds: 10);
         await Task.Delay(1000);
 
@@ -115,8 +113,6 @@ public class SetTest : TestBase
         var element = Utils.NewGuidString();
 
         await client.SetAddAsync(cacheName, setName, element, false, ttlSeconds: 1);
-        await Task.Delay(100);
-
         await client.SetAddAsync(cacheName, setName, element, true, ttlSeconds: 10);
         await Task.Delay(1000);
 
@@ -182,8 +178,6 @@ public class SetTest : TestBase
         var content = new List<byte[]>() { element };
 
         await client.SetAddBatchAsync(cacheName, setName, content, false, ttlSeconds: 1);
-        await Task.Delay(100);
-
         await client.SetAddBatchAsync(cacheName, setName, content, true, ttlSeconds: 10);
         await Task.Delay(1000);
 
@@ -252,8 +246,6 @@ public class SetTest : TestBase
         var content = new List<string>() { element };
 
         await client.SetAddBatchAsync(cacheName, setName, content, false, ttlSeconds: 1);
-        await Task.Delay(100);
-
         await client.SetAddBatchAsync(cacheName, setName, content, true, ttlSeconds: 10);
         await Task.Delay(1000);
 

--- a/IncubatingIntegrationTest/SetTest.cs
+++ b/IncubatingIntegrationTest/SetTest.cs
@@ -136,66 +136,6 @@ public class SetTest : TestBase
 
         set.Add(null!);
         await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAddBatchAsync(cacheName, setName, set, false));
-
-        // Variadic args
-        var byteArray = Utils.NewGuidByteArray();
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAddBatchAsync(null!, setName, false, ttlSeconds: null, byteArray));
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAddBatchAsync(cacheName, null!, false, ttlSeconds: null, byteArray));
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAddBatchAsync(cacheName, setName, false, ttlSeconds: null, (byte[])null!));
-    }
-
-    [Fact]
-    public async Task SetAddBatchAsync_ElementsAreByteArrayParams_HappyPath()
-    {
-        var setName = Utils.NewGuidString();
-        var element1 = Utils.NewGuidByteArray();
-        var element2 = Utils.NewGuidByteArray();
-
-        await client.SetAddBatchAsync(cacheName, setName, false, 10, element1, element2);
-
-        var fetchResponse = await client.SetFetchAsync(cacheName, setName);
-        Assert.Equal(CacheGetStatus.HIT, fetchResponse.Status);
-
-        var set = fetchResponse.ByteArraySet;
-        Assert.Equal(2, set!.Count);
-        Assert.Contains(element1, set);
-        Assert.Contains(element2, set);
-    }
-
-    [Fact]
-    public async Task SetAddBatchAsync_ElementsAreByteArrayParams_NoRefreshTtl()
-    {
-        var setName = Utils.NewGuidString();
-        var element = Utils.NewGuidByteArray();
-
-        await client.SetAddBatchAsync(cacheName, setName, false, ttlSeconds: 5, element);
-        await Task.Delay(100);
-
-        await client.SetAddBatchAsync(cacheName, setName, false, ttlSeconds: 10, element);
-        await Task.Delay(4900);
-
-        var response = await client.SetFetchAsync(cacheName, setName);
-        Assert.Equal(CacheGetStatus.MISS, response.Status);
-    }
-
-    [Fact]
-    public async Task SetAddBatchAsync_ElementsAreByteArrayParams_RefreshTtl()
-    {
-        var setName = Utils.NewGuidString();
-        var element = Utils.NewGuidByteArray();
-
-        await client.SetAddBatchAsync(cacheName, setName, false, ttlSeconds: 1, element);
-        await Task.Delay(100);
-
-        await client.SetAddBatchAsync(cacheName, setName, true, ttlSeconds: 10, element);
-        await Task.Delay(1000);
-
-        var response = await client.SetFetchAsync(cacheName, setName);
-        Assert.Equal(CacheGetStatus.HIT, response.Status);
-
-        var set = response.ByteArraySet;
-        Assert.Single(set);
-        Assert.Contains(element, set);
     }
 
     [Fact]
@@ -266,66 +206,6 @@ public class SetTest : TestBase
 
         set.Add(null!);
         await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAddBatchAsync(cacheName, setName, set, false));
-
-        // Variadic args
-        var str = Utils.NewGuidString();
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAddBatchAsync(null!, setName, false, ttlSeconds: null, str));
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAddBatchAsync(cacheName, null!, false, ttlSeconds: null, str));
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SetAddBatchAsync(cacheName, setName, false, ttlSeconds: null, (string)null!));
-    }
-
-    [Fact]
-    public async Task SetAddBatchAsync_ElementsAreStringParams_HappyPath()
-    {
-        var setName = Utils.NewGuidString();
-        var element1 = Utils.NewGuidString();
-        var element2 = Utils.NewGuidString();
-
-        await client.SetAddBatchAsync(cacheName, setName, false, 10, element1, element2);
-
-        var fetchResponse = await client.SetFetchAsync(cacheName, setName);
-        Assert.Equal(CacheGetStatus.HIT, fetchResponse.Status);
-
-        var set = fetchResponse.StringSet();
-        Assert.Equal(2, set!.Count);
-        Assert.Contains(element1, set);
-        Assert.Contains(element2, set);
-    }
-
-    [Fact]
-    public async Task SetAddBatchAsync_ElementsAreStringParams_NoRefreshTtl()
-    {
-        var setName = Utils.NewGuidString();
-        var element = Utils.NewGuidString();
-
-        await client.SetAddBatchAsync(cacheName, setName, false, ttlSeconds: 5, element);
-        await Task.Delay(100);
-
-        await client.SetAddBatchAsync(cacheName, setName, false, ttlSeconds: 10, element);
-        await Task.Delay(4900);
-
-        var response = await client.SetFetchAsync(cacheName, setName);
-        Assert.Equal(CacheGetStatus.MISS, response.Status);
-    }
-
-    [Fact]
-    public async Task SetAddBatchAsync_ElementsAreStringParams_RefreshTtl()
-    {
-        var setName = Utils.NewGuidString();
-        var element = Utils.NewGuidString();
-
-        await client.SetAddBatchAsync(cacheName, setName, false, ttlSeconds: 1, element);
-        await Task.Delay(100);
-
-        await client.SetAddBatchAsync(cacheName, setName, true, ttlSeconds: 10, element);
-        await Task.Delay(1000);
-
-        var response = await client.SetFetchAsync(cacheName, setName);
-        Assert.Equal(CacheGetStatus.HIT, response.Status);
-
-        var set = response.StringSet();
-        Assert.Single(set);
-        Assert.Contains(element, set);
     }
 
     [Fact]
@@ -407,7 +287,7 @@ public class SetTest : TestBase
     public async Task SetFetchAsync_UsesCachedByteArraySet_HappyPath()
     {
         var setName = Utils.NewGuidString();
-        await client.SetAddBatchAsync(cacheName, setName, false, null, Utils.NewGuidString(), Utils.NewGuidString());
+        await client.SetAddBatchAsync(cacheName, setName, new string[] { Utils.NewGuidString(), Utils.NewGuidString() }, false);
         var response = await client.SetFetchAsync(cacheName, setName);
 
         var set1 = response.ByteArraySet;
@@ -419,7 +299,7 @@ public class SetTest : TestBase
     public async Task SetFetchAsync_UsesCachedStringSet_HappyPath()
     {
         var setName = Utils.NewGuidString();
-        await client.SetAddBatchAsync(cacheName, setName, false, null, Utils.NewGuidString(), Utils.NewGuidString());
+        await client.SetAddBatchAsync(cacheName, setName, new string[] { Utils.NewGuidString(), Utils.NewGuidString() }, false);
         var response = await client.SetFetchAsync(cacheName, setName);
 
         var set1 = response.StringSet();

--- a/Momento/ISimpleCacheClient.cs
+++ b/Momento/ISimpleCacheClient.cs
@@ -112,22 +112,6 @@ public interface ISimpleCacheClient : IDisposable
     public Task<CacheGetBatchResponse> GetBatchAsync(string cacheName, IEnumerable<string> keys);
 
     /// <summary>
-    /// Gets multiple values from the cache.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-    /// <param name="keys">The keys to get.</param>
-    /// <returns>Task object representing the statuses of the get operation and the associated values.</returns>
-    public Task<CacheGetBatchResponse> GetBatchAsync(string cacheName, params byte[][] keys);
-
-    /// <summary>
-    /// Gets multiple values from the cache.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-    /// <param name="keys">The keys to get.</param>
-    /// <returns>Task object representing the statuses of the get operation and the associated values.</returns>
-    public Task<CacheGetBatchResponse> GetBatchAsync(string cacheName, params string[] keys);
-
-    /// <summary>
     /// Sets multiple items in the cache. Overwrites existing items.
     /// </summary>
     /// <param name="cacheName">Name of the cache to store the items in.</param>

--- a/Momento/Incubating/Internal/ScsDataClient.cs
+++ b/Momento/Incubating/Internal/ScsDataClient.cs
@@ -78,18 +78,6 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheDictionarySetBatchResponse();
     }
 
-    public async Task<CacheDictionaryGetBatchResponse> DictionaryGetBatchAsync(string cacheName, string dictionaryName, params byte[][] fields)
-    {
-        var response = await SendDictionaryGetBatchAsync(cacheName, dictionaryName, fields.Select(field => field.ToByteString()));
-        return new CacheDictionaryGetBatchResponse(response, fields.Length);
-    }
-
-    public async Task<CacheDictionaryGetBatchResponse> DictionaryGetBatchAsync(string cacheName, string dictionaryName, params string[] fields)
-    {
-        var response = await SendDictionaryGetBatchAsync(cacheName, dictionaryName, fields.ToEnumerableByteString());
-        return new CacheDictionaryGetBatchResponse(response, fields.Length);
-    }
-
     public async Task<CacheDictionaryGetBatchResponse> DictionaryGetBatchAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields)
     {
         var response = await SendDictionaryGetBatchAsync(cacheName, dictionaryName, fields.ToEnumerableByteString());
@@ -178,16 +166,6 @@ internal sealed class ScsDataClient : ScsDataClientBase
             throw CacheExceptionMapper.Convert(e);
         }
         return new CacheDictionaryRemoveFieldResponse();
-    }
-
-    public async Task<CacheDictionaryRemoveFieldsResponse> DictionaryRemoveFieldsAsync(string cacheName, string dictionaryName, params byte[][] fields)
-    {
-        return await DictionaryRemoveFieldsAsync(cacheName, dictionaryName, fields.ToEnumerableByteString());
-    }
-
-    public async Task<CacheDictionaryRemoveFieldsResponse> DictionaryRemoveFieldsAsync(string cacheName, string dictionaryName, params string[] fields)
-    {
-        return await DictionaryRemoveFieldsAsync(cacheName, dictionaryName, fields.ToEnumerableByteString());
     }
 
     public async Task<CacheDictionaryRemoveFieldsResponse> DictionaryRemoveFieldsAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields)

--- a/Momento/Incubating/SimpleCacheClient.cs
+++ b/Momento/Incubating/SimpleCacheClient.cs
@@ -108,18 +108,6 @@ public class SimpleCacheClient : ISimpleCacheClient
     }
 
     /// <inheritdoc />
-    public async Task<CacheGetBatchResponse> GetBatchAsync(string cacheName, params byte[][] keys)
-    {
-        return await this.simpleCacheClient.GetBatchAsync(cacheName, keys);
-    }
-
-    /// <inheritdoc />
-    public async Task<CacheGetBatchResponse> GetBatchAsync(string cacheName, params string[] keys)
-    {
-        return await this.simpleCacheClient.GetBatchAsync(cacheName, keys);
-    }
-
-    /// <inheritdoc />
     public async Task<CacheSetBatchResponse> SetBatchAsync(string cacheName, IEnumerable<KeyValuePair<byte[], byte[]>> items, uint? ttlSeconds = null)
     {
         return await this.simpleCacheClient.SetBatchAsync(cacheName, items, ttlSeconds);
@@ -271,42 +259,6 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="fields">The fields in the dictionary to lookup.</param>
     /// <returns>Task representing the status and associated value for each field.</returns>
     /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `fields` is `null`.</exception>
-    public async Task<CacheDictionaryGetBatchResponse> DictionaryGetBatchAsync(string cacheName, string dictionaryName, params byte[][] fields)
-    {
-        Utils.ArgumentNotNull(cacheName, nameof(cacheName));
-        Utils.ArgumentNotNull(dictionaryName, nameof(dictionaryName));
-        Utils.ArgumentNotNull(fields, nameof(fields));
-        Utils.ElementsNotNull(fields, nameof(fields));
-
-        return await this.dataClient.DictionaryGetBatchAsync(cacheName, dictionaryName, fields);
-    }
-
-    /// <summary>
-    /// Get several values from a dictionary.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-    /// <param name="dictionaryName">The dictionary to lookup.</param>
-    /// <param name="fields">The fields in the dictionary to lookup.</param>
-    /// <returns>Task representing the status and associated value for each field.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `fields` is `null`.</exception>
-    public async Task<CacheDictionaryGetBatchResponse> DictionaryGetBatchAsync(string cacheName, string dictionaryName, params string[] fields)
-    {
-        Utils.ArgumentNotNull(cacheName, nameof(cacheName));
-        Utils.ArgumentNotNull(dictionaryName, nameof(dictionaryName));
-        Utils.ArgumentNotNull(fields, nameof(fields));
-        Utils.ElementsNotNull(fields, nameof(fields));
-
-        return await this.dataClient.DictionaryGetBatchAsync(cacheName, dictionaryName, fields);
-    }
-
-    /// <summary>
-    /// Get several values from a dictionary.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-    /// <param name="dictionaryName">The dictionary to lookup.</param>
-    /// <param name="fields">The fields in the dictionary to lookup.</param>
-    /// <returns>Task representing the status and associated value for each field.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `fields` is `null`.</exception>
     public async Task<CacheDictionaryGetBatchResponse> DictionaryGetBatchAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -415,46 +367,6 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="fields">Name of the fields to remove from the dictionary.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
     /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `fields` is `null`.</exception>
-    public async Task<CacheDictionaryRemoveFieldsResponse> DictionaryRemoveFieldsAsync(string cacheName, string dictionaryName, params byte[][] fields)
-    {
-        Utils.ArgumentNotNull(cacheName, nameof(cacheName));
-        Utils.ArgumentNotNull(dictionaryName, nameof(dictionaryName));
-        Utils.ArgumentNotNull(fields, nameof(fields));
-        Utils.ElementsNotNull(fields, nameof(fields));
-
-        return await this.dataClient.DictionaryRemoveFieldsAsync(cacheName, dictionaryName, fields);
-    }
-
-    /// <summary>
-    /// Remove fields from a dictionary.
-    ///
-    /// Performs a no-op if `dictionaryName` or a particular field does not exist.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to lookup the dictionary in.</param>
-    /// <param name="dictionaryName">Name of the dictionary to remove the field from.</param>
-    /// <param name="fields">Name of the fields to remove from the dictionary.</param>
-    /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `fields` is `null`.</exception>
-    public async Task<CacheDictionaryRemoveFieldsResponse> DictionaryRemoveFieldsAsync(string cacheName, string dictionaryName, params string[] fields)
-    {
-        Utils.ArgumentNotNull(cacheName, nameof(cacheName));
-        Utils.ArgumentNotNull(dictionaryName, nameof(dictionaryName));
-        Utils.ArgumentNotNull(fields, nameof(fields));
-        Utils.ElementsNotNull(fields, nameof(fields));
-
-        return await this.dataClient.DictionaryRemoveFieldsAsync(cacheName, dictionaryName, fields);
-    }
-
-    /// <summary>
-    /// Remove fields from a dictionary.
-    ///
-    /// Performs a no-op if `dictionaryName` or a particular field does not exist.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to lookup the dictionary in.</param>
-    /// <param name="dictionaryName">Name of the dictionary to remove the field from.</param>
-    /// <param name="fields">Name of the fields to remove from the dictionary.</param>
-    /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `fields` is `null`.</exception>
     public async Task<CacheDictionaryRemoveFieldsResponse> DictionaryRemoveFieldsAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -535,60 +447,6 @@ public class SimpleCacheClient : ISimpleCacheClient
         Utils.ArgumentNotNull(element, nameof(element));
 
         return await this.dataClient.SetAddAsync(cacheName, setName, element, refreshTtl, ttlSeconds);
-    }
-
-    /// <summary>
-    /// Add several elements to a set in the cache.
-    ///
-    /// After this operation, the set will contain the union
-    /// of the elements passed in and the elements of the set.
-    ///
-    /// Creates the set if it does not exist and sets the TTL.
-    /// If the set already exists and `refreshTtl` is `true`, then update the
-    /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to store the set in.</param>
-    /// <param name="setName">The set to add elements to.</param>
-    /// <param name="refreshTtl">Update `setName`'s TTL if it already exists.</param>
-    /// <param name="ttlSeconds">TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <param name="elements">The data to add to the set.</param>
-    /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `elements` is `null`.</exception>
-    public async Task<CacheSetAddBatchResponse> SetAddBatchAsync(string cacheName, string setName, bool refreshTtl, uint? ttlSeconds = null, params byte[][] elements)
-    {
-        Utils.ArgumentNotNull(cacheName, nameof(cacheName));
-        Utils.ArgumentNotNull(setName, nameof(setName));
-        Utils.ArgumentNotNull(elements, nameof(elements));
-        Utils.ElementsNotNull(elements, nameof(elements));
-
-        return await this.dataClient.SetAddBatchAsync(cacheName, setName, elements, refreshTtl, ttlSeconds);
-    }
-
-    /// <summary>
-    /// Add several elements to a set in the cache.
-    ///
-    /// After this operation, the set will contain the union
-    /// of the elements passed in and the elements of the set.
-    ///
-    /// Creates the set if it does not exist and sets the TTL.
-    /// If the set already exists and `refreshTtl` is `true`, then update the
-    /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to store the set in.</param>
-    /// <param name="setName">The set to add elements to.</param>
-    /// <param name="refreshTtl">Update `setName`'s TTL if it already exists.</param>
-    /// <param name="ttlSeconds">TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <param name="elements">The data to add to the set.</param>
-    /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `elements` is `null`.</exception>
-    public async Task<CacheSetAddBatchResponse> SetAddBatchAsync(string cacheName, string setName, bool refreshTtl, uint? ttlSeconds = null, params string[] elements)
-    {
-        Utils.ArgumentNotNull(cacheName, nameof(cacheName));
-        Utils.ArgumentNotNull(setName, nameof(setName));
-        Utils.ArgumentNotNull(elements, nameof(elements));
-        Utils.ElementsNotNull(elements, nameof(elements));
-
-        return await this.dataClient.SetAddBatchAsync(cacheName, setName, elements, refreshTtl, ttlSeconds);
     }
 
     /// <summary>
@@ -813,7 +671,6 @@ public class SimpleCacheClient : ISimpleCacheClient
 
         return await this.dataClient.ListFetchAsync(cacheName, listName);
     }
-
 
     /// <inheritdoc />
     public void Dispose()

--- a/Momento/SimpleCacheClient.cs
+++ b/Momento/SimpleCacheClient.cs
@@ -139,26 +139,6 @@ public class SimpleCacheClient : ISimpleCacheClient
     }
 
     /// <inheritdoc />
-    public async Task<CacheGetBatchResponse> GetBatchAsync(string cacheName, params byte[][] keys)
-    {
-        Utils.ArgumentNotNull(cacheName, nameof(cacheName));
-        Utils.ArgumentNotNull(keys, nameof(keys));
-        Utils.ElementsNotNull(keys, nameof(keys));
-
-        return await this.dataClient.GetBatchAsync(cacheName, keys);
-    }
-
-    /// <inheritdoc />
-    public async Task<CacheGetBatchResponse> GetBatchAsync(string cacheName, params string[] keys)
-    {
-        Utils.ArgumentNotNull(cacheName, nameof(cacheName));
-        Utils.ArgumentNotNull(keys, nameof(keys));
-        Utils.ElementsNotNull(keys, nameof(keys));
-
-        return await this.dataClient.GetBatchAsync(cacheName, keys);
-    }
-
-    /// <inheritdoc />
     public async Task<CacheSetBatchResponse> SetBatchAsync(string cacheName, IEnumerable<KeyValuePair<byte[], byte[]>> items, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));

--- a/MomentoIntegrationTest/SimpleCacheDataTest.cs
+++ b/MomentoIntegrationTest/SimpleCacheDataTest.cs
@@ -125,8 +125,6 @@ public class SimpleCacheDataTest
 
         var badList = new List<byte[]>(new byte[][] { Utils.NewGuidByteArray(), null! });
         await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetBatchAsync("cache", badList));
-
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetBatchAsync("cache", Utils.NewGuidByteArray(), null!));
     }
 
     [Fact]
@@ -149,23 +147,6 @@ public class SimpleCacheDataTest
     }
 
     [Fact]
-    public async Task GetBatchAsync_KeysAreByteArray_HappyPath2()
-    {
-        string key1 = Utils.NewGuidString();
-        string value1 = Utils.NewGuidString();
-        string key2 = Utils.NewGuidString();
-        string value2 = Utils.NewGuidString();
-        await client.SetAsync(cacheName, key1, value1);
-        await client.SetAsync(cacheName, key2, value2);
-
-        CacheGetBatchResponse result = await client.GetBatchAsync(cacheName, key1, key2);
-        string? stringResult1 = result.Strings().ToList()[0];
-        string? stringResult2 = result.Strings().ToList()[1];
-        Assert.Equal(value1, stringResult1);
-        Assert.Equal(value2, stringResult2);
-    }
-
-    [Fact]
     public async Task GetBatchAsync_NullCheckString_ThrowsException()
     {
         await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetBatchAsync(null!, new List<string>()));
@@ -173,8 +154,6 @@ public class SimpleCacheDataTest
 
         List<string> strings = new(new string[] { "key1", "key2", null! });
         await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetBatchAsync("cache", strings));
-
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.GetBatchAsync("cache", "key1", "key2", null!));
     }
 
     [Fact]


### PR DESCRIPTION
This PR removes methods with variadic args. These overloads are
undesirable for a few reasons:
(1) They add considerable surface area to SDK.

(2) Because the arguments (cache keys/values) are variable length,
they go at the end of the method signature. This breaks the pattern
where the cache keys/values go after the cache name.

(3) Mixed support across languages. We want to add the most common
case first. In most languages, the common case is not variable length
arguments as opposed to lists.