### PR TITLE
chore: add dictionary set and fetch overloads

### DIFF
--- a/IncubatingIntegrationTest/DictionaryTest.cs
+++ b/IncubatingIntegrationTest/DictionaryTest.cs
@@ -14,7 +14,7 @@ public class DictionaryTest : TestBase
     [InlineData(null, "my-dictionary", new byte[] { 0x00 })]
     [InlineData("cache", null, new byte[] { 0x00 })]
     [InlineData("cache", "my-dictionary", null)]
-    public async Task DictionaryGetAsync_NullChecksByteArray_ThrowsException(string cacheName, string dictionaryName, byte[] field)
+    public async Task DictionaryGetAsync_NullChecksFieldIsByteArray_ThrowsException(string cacheName, string dictionaryName, byte[] field)
     {
         await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.DictionaryGetAsync(cacheName, dictionaryName, field));
     }
@@ -24,7 +24,7 @@ public class DictionaryTest : TestBase
     [InlineData("cache", null, new byte[] { 0x00 }, new byte[] { 0x00 })]
     [InlineData("cache", "my-dictionary", null, new byte[] { 0x00 })]
     [InlineData("cache", "my-dictionary", new byte[] { 0x00 }, null)]
-    public async Task DictionarySetAsync_NullChecksByteArray_ThrowsException(string cacheName, string dictionaryName, byte[] field, byte[] value)
+    public async Task DictionarySetAsync_NullChecksFieldIsByteArrayValueIsByteArray_ThrowsException(string cacheName, string dictionaryName, byte[] field, byte[] value)
     {
         await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false));
     }
@@ -67,7 +67,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionarySetGetAsync_FieldIsByteArray_NoRefreshTtl()
+    public async Task DictionarySetGetAsync_FieldIsByteArrayValueIsByteArray_NoRefreshTtl()
     {
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidByteArray();
@@ -84,7 +84,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionarySetGetAsync_FieldIsByteArray_RefreshTtl()
+    public async Task DictionarySetGetAsync_FieldIsByteArrayValueIsByteArray_RefreshTtl()
     {
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidByteArray();
@@ -103,7 +103,7 @@ public class DictionaryTest : TestBase
     [InlineData(null, "my-dictionary", "my-field")]
     [InlineData("cache", null, "my-field")]
     [InlineData("cache", "my-dictionary", null)]
-    public async Task DictionaryGetAsync_NullChecksString_ThrowsException(string cacheName, string dictionaryName, string field)
+    public async Task DictionaryGetAsync_NullChecksFieldIsString_ThrowsException(string cacheName, string dictionaryName, string field)
     {
         await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.DictionaryGetAsync(cacheName, dictionaryName, field));
     }
@@ -113,7 +113,7 @@ public class DictionaryTest : TestBase
     [InlineData("cache", null, "my-field", "my-value")]
     [InlineData("cache", "my-dictionary", null, "my-value")]
     [InlineData("cache", "my-dictionary", "my-field", null)]
-    public async Task DictionarySetAsync_NullChecksString_ThrowsException(string cacheName, string dictionaryName, string field, string value)
+    public async Task DictionarySetAsync_NullChecksFieldIsStringValueIsString_ThrowsException(string cacheName, string dictionaryName, string field, string value)
     {
         await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false));
     }
@@ -156,7 +156,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionarySetGetAsync_FieldIsString_NoRefreshTtl()
+    public async Task DictionarySetGetAsync_FieldIsStringValueIsString_NoRefreshTtl()
     {
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidString();
@@ -173,7 +173,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionarySetGetAsync_FieldIsString_RefreshTtl()
+    public async Task DictionarySetGetAsync_FieldIsStringValueIsString_RefreshTtl()
     {
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidString();
@@ -189,7 +189,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionarySetBatchAsync_NullChecksByteArray_ThrowsException()
+    public async Task DictionarySetBatchAsync_NullChecksFieldIsByteArrayValueIsByteArray_ThrowsException()
     {
         var dictionaryName = Utils.NewGuidString();
         var dictionary = new Dictionary<byte[], byte[]>();
@@ -224,7 +224,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionarySetBatchAsync_FieldsAreByteArray_NoRefreshTtl()
+    public async Task DictionarySetBatchAsync_FieldsAreByteArrayValuesAreByteArray_NoRefreshTtl()
     {
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidByteArray();
@@ -242,7 +242,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionarySetBatchAsync_FieldsAreByteArray_RefreshTtl()
+    public async Task DictionarySetBatchAsync_FieldsAreByteArrayValuesAreByteArray_RefreshTtl()
     {
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidByteArray();
@@ -259,7 +259,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionarySetBatchAsync_NullChecksStrings_ThrowsException()
+    public async Task DictionarySetBatchAsync_NullChecksFieldIsStringValueIsString_ThrowsException()
     {
         var dictionaryName = Utils.NewGuidString();
         var dictionary = new Dictionary<string, string>();
@@ -272,7 +272,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionarySetBatchAsync_FieldsAreStrings_HappyPath()
+    public async Task DictionarySetBatchAsync_FieldsAreString_HappyPath()
     {
         var dictionaryName = Utils.NewGuidString();
         var field1 = Utils.NewGuidString();
@@ -294,7 +294,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionarySetBatchAsync_FieldsAreStrings_NoRefreshTtl()
+    public async Task DictionarySetBatchAsync_FieldsAreStringValuesAreString_NoRefreshTtl()
     {
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidString();
@@ -312,7 +312,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionarySetBatchAsync_FieldsAreStrings_RefreshTtl()
+    public async Task DictionarySetBatchAsync_FieldsAreStringValuesAreString_RefreshTtl()
     {
         var dictionaryName = Utils.NewGuidString();
         var field = Utils.NewGuidString();
@@ -329,7 +329,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionaryGetBatchAsync_NullChecksByteArrayParams_ThrowsException()
+    public async Task DictionaryGetBatchAsync_NullChecksFieldsAreByteArray_ThrowsException()
     {
         var dictionaryName = Utils.NewGuidString();
         var testData = new byte[][][] { new byte[][] { Utils.NewGuidByteArray(), Utils.NewGuidByteArray() }, new byte[][] { Utils.NewGuidByteArray(), null! } };
@@ -387,7 +387,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionaryGetBatchAsync_NullChecksStringParams_ThrowsException()
+    public async Task DictionaryGetBatchAsync_NullChecksFieldsAreString_ThrowsException()
     {
         var dictionaryName = Utils.NewGuidString();
         var testData = new string[][] { new string[] { Utils.NewGuidString(), Utils.NewGuidString() }, new string[] { Utils.NewGuidString(), null! } };
@@ -404,7 +404,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionaryGetBatchAsync_FieldsAreStrings_HappyPath()
+    public async Task DictionaryGetBatchAsync_FieldsAreString_HappyPath()
     {
         var dictionaryName = Utils.NewGuidString();
         var field1 = Utils.NewGuidString();
@@ -438,8 +438,8 @@ public class DictionaryTest : TestBase
         var dictionaryName = Utils.NewGuidString();
         var response = await client.DictionaryFetchAsync(cacheName, dictionaryName);
         Assert.Equal(CacheGetStatus.MISS, response.Status);
-        Assert.Null(response.ByteArrayDictionary);
-        Assert.Null(response.StringDictionary());
+        Assert.Null(response.ByteArrayByteArrayDictionary);
+        Assert.Null(response.StringStringDictionary());
     }
 
     [Fact]
@@ -461,7 +461,7 @@ public class DictionaryTest : TestBase
         var fetchResponse = await client.DictionaryFetchAsync(cacheName, dictionaryName);
 
         Assert.Equal(CacheGetStatus.HIT, fetchResponse.Status);
-        Assert.Equal(fetchResponse.StringDictionary(), contentDictionary);
+        Assert.Equal(fetchResponse.StringStringDictionary(), contentDictionary);
     }
 
     [Fact]
@@ -485,12 +485,12 @@ public class DictionaryTest : TestBase
         Assert.Equal(CacheGetStatus.HIT, fetchResponse.Status);
 
         // Exercise byte array dictionary structural equality comparer
-        Assert.True(fetchResponse.ByteArrayDictionary!.ContainsKey(field1));
-        Assert.True(fetchResponse.ByteArrayDictionary!.ContainsKey(field2));
-        Assert.Equal(2, fetchResponse.ByteArrayDictionary!.Count);
+        Assert.True(fetchResponse.ByteArrayByteArrayDictionary!.ContainsKey(field1));
+        Assert.True(fetchResponse.ByteArrayByteArrayDictionary!.ContainsKey(field2));
+        Assert.Equal(2, fetchResponse.ByteArrayByteArrayDictionary!.Count);
 
         // Exercise DictionaryEquals extension
-        Assert.True(fetchResponse.ByteArrayDictionary!.DictionaryEquals(contentDictionary));
+        Assert.True(fetchResponse.ByteArrayByteArrayDictionary!.DictionaryEquals(contentDictionary));
     }
 
     [Theory]
@@ -527,7 +527,7 @@ public class DictionaryTest : TestBase
     [InlineData(null, "my-dictionary", new byte[] { 0x00 })]
     [InlineData("my-cache", null, new byte[] { 0x00 })]
     [InlineData("my-cache", "my-dictionary", null)]
-    public async Task DictionaryRemoveFieldAsync_NullChecksByte_ThrowsException(string cacheName, string dictionaryName, byte[] field)
+    public async Task DictionaryRemoveFieldAsync_NullChecksFieldIsByteArray_ThrowsException(string cacheName, string dictionaryName, byte[] field)
     {
         await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.DictionaryRemoveFieldAsync(cacheName, dictionaryName, field));
     }
@@ -536,7 +536,7 @@ public class DictionaryTest : TestBase
     [InlineData(null, "my-dictionary", "my-field")]
     [InlineData("my-cache", null, "my-field")]
     [InlineData("my-cache", "my-dictionary", null)]
-    public async Task DictionaryRemoveFieldAsync_NullChecksString_ThrowsException(string cacheName, string dictionaryName, string field)
+    public async Task DictionaryRemoveFieldAsync_NullChecksFieldIsString_ThrowsException(string cacheName, string dictionaryName, string field)
     {
         await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.DictionaryRemoveFieldAsync(cacheName, dictionaryName, field));
     }
@@ -586,7 +586,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionaryRemoveFieldsAsync_NullChecksByteArrayParams_ThrowsException()
+    public async Task DictionaryRemoveFieldsAsync_NullChecksFieldsAreByteArray_ThrowsException()
     {
         var dictionaryName = Utils.NewGuidString();
         var testData = new byte[][][] { new byte[][] { Utils.NewGuidByteArray(), Utils.NewGuidByteArray() }, new byte[][] { Utils.NewGuidByteArray(), null! } };
@@ -604,7 +604,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionaryRemoveFieldsAsync_ByteArrayParams_HappyPath()
+    public async Task DictionaryRemoveFieldsAsync_FieldsAreByteArray_HappyPath()
     {
         var dictionaryName = Utils.NewGuidString();
         var fields = new byte[][] { Utils.NewGuidByteArray(), Utils.NewGuidByteArray() };
@@ -623,7 +623,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionaryRemoveFieldsAsync_NullChecksStringParams_ThrowsException()
+    public async Task DictionaryRemoveFieldsAsync_NullChecksFieldsAreString_ThrowsException()
     {
         var dictionaryName = Utils.NewGuidString();
         var testData = new string[][] { new string[] { Utils.NewGuidString(), Utils.NewGuidString() }, new string[] { Utils.NewGuidString(), null! } };
@@ -640,7 +640,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionaryRemoveFieldsAsync_StringParams_HappyPath()
+    public async Task DictionaryRemoveFieldsAsync_FieldAreString_HappyPath()
     {
         var dictionaryName = Utils.NewGuidString();
         var fields = new string[] { Utils.NewGuidString(), Utils.NewGuidString() };

--- a/IncubatingIntegrationTest/DictionaryTest.cs
+++ b/IncubatingIntegrationTest/DictionaryTest.cs
@@ -383,6 +383,7 @@ public class DictionaryTest : TestBase
         Assert.Equal(CacheGetStatus.HIT, response.Status);
         Assert.Equal(value, response.String());
     }
+
     [Fact]
     public async Task DictionarySetBatchAsync_NullChecksFieldsAreStringValuesAreByteArray_ThrowsException()
     {
@@ -568,7 +569,7 @@ public class DictionaryTest : TestBase
     }
 
     [Fact]
-    public async Task DictionaryFetchAsync_HasContentString_HappyPath()
+    public async Task DictionaryFetchAsync_HasContentStringString_HappyPath()
     {
         var dictionaryName = Utils.NewGuidString();
         var field1 = Utils.NewGuidString();
@@ -587,10 +588,38 @@ public class DictionaryTest : TestBase
 
         Assert.Equal(CacheGetStatus.HIT, fetchResponse.Status);
         Assert.Equal(fetchResponse.StringStringDictionary(), contentDictionary);
+
+        // Test field caching behavior
+        Assert.Same(fetchResponse.StringStringDictionary(), fetchResponse.StringStringDictionary());
     }
 
     [Fact]
-    public async Task DictionaryFetchAsync_HasContentByteArray_HappyPath()
+    public async Task DictionaryFetchAsync_HasContentStringByteArray_HappyPath()
+    {
+        var dictionaryName = Utils.NewGuidString();
+        var field1 = Utils.NewGuidString();
+        var value1 = Utils.NewGuidByteArray();
+        var field2 = Utils.NewGuidString();
+        var value2 = Utils.NewGuidByteArray();
+        var contentDictionary = new Dictionary<string, byte[]>() {
+            {field1, value1},
+            {field2, value2}
+        };
+
+        await client.DictionarySetAsync(cacheName, dictionaryName, field1, value1, true, ttlSeconds: 10);
+        await client.DictionarySetAsync(cacheName, dictionaryName, field2, value2, true, ttlSeconds: 10);
+
+        var fetchResponse = await client.DictionaryFetchAsync(cacheName, dictionaryName);
+
+        Assert.Equal(CacheGetStatus.HIT, fetchResponse.Status);
+        Assert.Equal(fetchResponse.StringByteArrayDictionary(), contentDictionary);
+
+        // Test field caching behavior
+        Assert.Same(fetchResponse.StringByteArrayDictionary(), fetchResponse.StringByteArrayDictionary());
+    }
+
+    [Fact]
+    public async Task DictionaryFetchAsync_HasContentByteArrayByteArray_HappyPath()
     {
         var dictionaryName = Utils.NewGuidString();
         var field1 = Utils.NewGuidByteArray();
@@ -616,6 +645,9 @@ public class DictionaryTest : TestBase
 
         // Exercise DictionaryEquals extension
         Assert.True(fetchResponse.ByteArrayByteArrayDictionary!.DictionaryEquals(contentDictionary));
+
+        // Test field caching behavior
+        Assert.Same(fetchResponse.ByteArrayByteArrayDictionary, fetchResponse.ByteArrayByteArrayDictionary);
     }
 
     [Theory]

--- a/Momento/Incubating/Internal/ScsDataClient.cs
+++ b/Momento/Incubating/Internal/ScsDataClient.cs
@@ -64,6 +64,12 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return await SendDictionarySetBatchAsync(cacheName, dictionaryName, protoItems, refreshTtl, ttlSeconds);
     }
 
+    public async Task<CacheDictionarySetBatchResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, byte[]>> items, bool refreshTtl, uint? ttlSeconds = null)
+    {
+        var protoItems = items.Select(kv => new _DictionaryFieldValuePair() { Field = kv.Key.ToByteString(), Value = kv.Value.ToByteString() });
+        return await SendDictionarySetBatchAsync(cacheName, dictionaryName, protoItems, refreshTtl, ttlSeconds);
+    }
+
     public async Task<CacheDictionarySetBatchResponse> SendDictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<_DictionaryFieldValuePair> items, bool refreshTtl, uint? ttlSeconds = null)
     {
         _DictionarySetRequest request = new()

--- a/Momento/Incubating/Internal/ScsDataClient.cs
+++ b/Momento/Incubating/Internal/ScsDataClient.cs
@@ -20,6 +20,7 @@ internal sealed class ScsDataClient : ScsDataClientBase
 
     private _DictionaryFieldValuePair[] ToSingletonFieldValuePair(byte[] field, byte[] value) => new _DictionaryFieldValuePair[] { new _DictionaryFieldValuePair() { Field = field.ToByteString(), Value = value.ToByteString() } };
     private _DictionaryFieldValuePair[] ToSingletonFieldValuePair(string field, string value) => new _DictionaryFieldValuePair[] { new _DictionaryFieldValuePair() { Field = field.ToByteString(), Value = value.ToByteString() } };
+    private _DictionaryFieldValuePair[] ToSingletonFieldValuePair(string field, byte[] value) => new _DictionaryFieldValuePair[] { new _DictionaryFieldValuePair() { Field = field.ToByteString(), Value = value.ToByteString() } };
 
     public async Task<CacheDictionarySetResponse> DictionarySetAsync(string cacheName, string dictionaryName, byte[] field, byte[] value, bool refreshTtl, uint? ttlSeconds = null)
     {
@@ -28,6 +29,12 @@ internal sealed class ScsDataClient : ScsDataClientBase
     }
 
     public async Task<CacheDictionarySetResponse> DictionarySetAsync(string cacheName, string dictionaryName, string field, string value, bool refreshTtl, uint? ttlSeconds = null)
+    {
+        await SendDictionarySetBatchAsync(cacheName, dictionaryName, ToSingletonFieldValuePair(field, value), refreshTtl, ttlSeconds);
+        return new CacheDictionarySetResponse();
+    }
+
+    public async Task<CacheDictionarySetResponse> DictionarySetAsync(string cacheName, string dictionaryName, string field, byte[] value, bool refreshTtl, uint? ttlSeconds = null)
     {
         await SendDictionarySetBatchAsync(cacheName, dictionaryName, ToSingletonFieldValuePair(field, value), refreshTtl, ttlSeconds);
         return new CacheDictionarySetResponse();

--- a/Momento/Incubating/README.md
+++ b/Momento/Incubating/README.md
@@ -16,12 +16,22 @@ class Driver
         using var client = SimpleCacheClientFactory.CreateClient(authToken: "YOUR-AUTH-TOKEN", defaultTtlSeconds: 60);
         var cacheName = "my-cache";
 
+public static class Driver
+{
+    public async static Task Main()
+    {
+        var authToken = System.Environment.GetEnvironmentVariable("TEST_AUTH_TOKEN")!;
+        //using var client = new SimpleCacheClient(authToken, 60);
+        var cacheName = "my-example-cache";
+
+        using var client = Momento.Sdk.Incubating.SimpleCacheClientFactory.CreateClient(authToken, 60);
+
         // Set a value
-        client.DictionarySet(cacheName: cacheName, dictionaryName: "my-dictionary",
-            field: "my-key", value: "my-value", ttlSeconds: 60, refreshTtl: false);
+        await client.DictionarySetAsync(cacheName: cacheName, dictionaryName: "my-dictionary",
+            field: "my-key", value: "my-value", refreshTtl: false, ttlSeconds: 60);
 
         // Set multiple values
-        client.DictionarySetMulti(
+        await client.DictionarySetBatchAsync(
             cacheName: cacheName,
             dictionaryName: "my-dictionary",
             new Dictionary<string, string>() {
@@ -31,7 +41,7 @@ class Driver
             refreshTtl: false);
 
         // Get a value
-        var getResponse = client.DictionaryGet(
+        var getResponse = await client.DictionaryGetAsync(
             cacheName: cacheName,
             dictionaryName: "my-dictionary",
             field: "key1");
@@ -39,20 +49,20 @@ class Driver
         string value = getResponse.String()!; // "value1"
 
         // Get multiple values
-        var getMultiResponse = client.DictionaryGetMulti(
+        var getBatchResponse = await client.DictionaryGetBatchAsync(
             cacheName: cacheName,
             dictionaryName: "my-dictionary",
-            "key1", "key2", "key3", "key4");
-        var manyStatus = getMultiResponse.Status; // [HIT, HIT, HIT, MISS]
-        var values = getMultiResponse.Strings(); // ["value1", "value2", "value3", null]
-        var responses = getMultiResponse.Responses; // individual responses
+            new string[] { "key1", "key2", "key3", "key4" });
+        var manyStatus = getBatchResponse.Status; // [HIT, HIT, HIT, MISS]
+        var values = getBatchResponse.Strings(); // ["value1", "value2", "value3", null]
+        var responses = getBatchResponse.Responses; // individual responses
 
         // Get the whole dictionary
-        var getAllResponse = client.DictionaryGetAll(
+        var fetchResponse = await client.DictionaryFetchAsync(
             cacheName: cacheName,
             dictionaryName: "my-dictionary");
-        status = getAllResponse.Status;
-        var dictionary = getAllResponse.StringDictionary()!;
+        status = fetchResponse.Status;
+        var dictionary = fetchResponse.StringStringDictionary()!;
         value = dictionary["key1"]; // == "value1"
     }
 }

--- a/Momento/Incubating/Responses/CacheDictionaryFetchResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictionaryFetchResponse.cs
@@ -12,15 +12,15 @@ public class CacheDictionaryFetchResponse
 {
     public CacheGetStatus Status { get; private set; }
     private readonly RepeatedField<_DictionaryFieldValuePair>? items;
-    private readonly Lazy<Dictionary<byte[], byte[]>?> _byteArrayDictionary;
-    private readonly Lazy<Dictionary<string, string>?> _stringDictionary;
+    private readonly Lazy<Dictionary<byte[], byte[]>?> _byteArrayByteArrayDictionary;
+    private readonly Lazy<Dictionary<string, string>?> _stringStringDictionary;
 
     public CacheDictionaryFetchResponse(_DictionaryFetchResponse response)
     {
         Status = (response.DictionaryCase == _DictionaryFetchResponse.DictionaryOneofCase.Found) ? CacheGetStatus.HIT : CacheGetStatus.MISS;
         items = (Status == CacheGetStatus.HIT) ? response.Found.Items : null;
 
-        _byteArrayDictionary = new(() =>
+        _byteArrayByteArrayDictionary = new(() =>
         {
             if (items == null)
             {
@@ -31,7 +31,7 @@ public class CacheDictionaryFetchResponse
                 Utils.ByteArrayComparer);
         });
 
-        _stringDictionary = new(() =>
+        _stringStringDictionary = new(() =>
         {
             if (items == null)
             {
@@ -42,7 +42,7 @@ public class CacheDictionaryFetchResponse
         });
     }
 
-    public Dictionary<byte[], byte[]>? ByteArrayDictionary { get => _byteArrayDictionary.Value; }
+    public Dictionary<byte[], byte[]>? ByteArrayByteArrayDictionary { get => _byteArrayByteArrayDictionary.Value; }
 
-    public Dictionary<string, string>? StringDictionary() => _stringDictionary.Value;
+    public Dictionary<string, string>? StringStringDictionary() => _stringStringDictionary.Value;
 }

--- a/Momento/Incubating/Responses/CacheDictionaryFetchResponse.cs
+++ b/Momento/Incubating/Responses/CacheDictionaryFetchResponse.cs
@@ -14,6 +14,7 @@ public class CacheDictionaryFetchResponse
     private readonly RepeatedField<_DictionaryFieldValuePair>? items;
     private readonly Lazy<Dictionary<byte[], byte[]>?> _byteArrayByteArrayDictionary;
     private readonly Lazy<Dictionary<string, string>?> _stringStringDictionary;
+    private readonly Lazy<Dictionary<string, byte[]>?> _stringByteArrayDictionary;
 
     public CacheDictionaryFetchResponse(_DictionaryFetchResponse response)
     {
@@ -40,9 +41,20 @@ public class CacheDictionaryFetchResponse
             return new Dictionary<string, string>(
                 items.Select(kv => new KeyValuePair<string, string>(kv.Field.ToStringUtf8(), kv.Value.ToStringUtf8())));
         });
+        _stringByteArrayDictionary = new(() =>
+        {
+            if (items == null)
+            {
+                return null;
+            }
+            return new Dictionary<string, byte[]>(
+                items.Select(kv => new KeyValuePair<string, byte[]>(kv.Field.ToStringUtf8(), kv.Value.ToByteArray())));
+        });
     }
 
     public Dictionary<byte[], byte[]>? ByteArrayByteArrayDictionary { get => _byteArrayByteArrayDictionary.Value; }
 
     public Dictionary<string, string>? StringStringDictionary() => _stringStringDictionary.Value;
+
+    public Dictionary<string, byte[]>? StringByteArrayDictionary() => _stringByteArrayDictionary.Value;
 }

--- a/Momento/Incubating/SimpleCacheClient.cs
+++ b/Momento/Incubating/SimpleCacheClient.cs
@@ -170,6 +170,31 @@ public class SimpleCacheClient : ISimpleCacheClient
     }
 
     /// <summary>
+    /// Set the dictionary field to a value with a given time to live (TTL) seconds.
+    ///
+    /// Creates the dictionary if it does not exist and sets the TTL.
+    /// If the dictionary already exists and `refreshTtl` is `true`, then update the
+    /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
+    /// <param name="dictionaryName">The dictionary to set.</param>
+    /// <param name="field">The field in the dictionary to set.</param>
+    /// <param name="value">The value to be stored.</param>
+    /// <param name="refreshTtl">Update the dictionary TTL if the dictionary already exists.</param>
+    /// <param name="ttlSeconds">TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
+    /// <returns>Task representing the result of the cache operation.</returns>
+    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `field`, `value` is `null`.</exception>
+    public async Task<CacheDictionarySetResponse> DictionarySetAsync(string cacheName, string dictionaryName, string field, byte[] value, bool refreshTtl, uint? ttlSeconds = null)
+    {
+        Utils.ArgumentNotNull(cacheName, nameof(cacheName));
+        Utils.ArgumentNotNull(dictionaryName, nameof(dictionaryName));
+        Utils.ArgumentNotNull(field, nameof(field));
+        Utils.ArgumentNotNull(value, nameof(value));
+
+        return await this.dataClient.DictionarySetAsync(cacheName, dictionaryName, field, value, refreshTtl, ttlSeconds);
+    }
+
+    /// <summary>
     /// Get the cache value stored for the given dictionary and field.
     /// </summary>
     /// <param name="cacheName">Name of the cache to perform the lookup in.</param>

--- a/Momento/Incubating/SimpleCacheClient.cs
+++ b/Momento/Incubating/SimpleCacheClient.cs
@@ -277,6 +277,30 @@ public class SimpleCacheClient : ISimpleCacheClient
     }
 
     /// <summary>
+    /// Set several dictionary field-value pairs in the cache.
+    ///
+    /// Creates the dictionary if it does not exist and sets the TTL.
+    /// If the dictionary already exists and `refreshTtl` is `true`, then update the
+    /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
+    /// <param name="dictionaryName">The dictionary to set.</param>
+    /// <param name="items">The field-value pairs in the dictionary to set.</param>
+    /// <param name="refreshTtl">Update the dictionary TTL if the dictionary already exists.</param>
+    /// <param name="ttlSeconds">TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
+    /// <returns>Task representing the result of the cache operation.</returns>
+    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `items` is `null`.</exception>
+    public async Task<CacheDictionarySetBatchResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, byte[]>> items, bool refreshTtl, uint? ttlSeconds = null)
+    {
+        Utils.ArgumentNotNull(cacheName, nameof(cacheName));
+        Utils.ArgumentNotNull(dictionaryName, nameof(dictionaryName));
+        Utils.ArgumentNotNull(items, nameof(items));
+        Utils.KeysAndValuesNotNull(items, nameof(items));
+
+        return await this.dataClient.DictionarySetBatchAsync(cacheName, dictionaryName, items, refreshTtl, ttlSeconds);
+    }
+
+    /// <summary>
     /// Get several values from a dictionary.
     /// </summary>
     /// <param name="cacheName">Name of the cache to perform the lookup in.</param>


### PR DESCRIPTION
Add overloads for `DictionarySet` and `DictionarySetBatch` to accept `string` fields and `byte[]` values. Also support marshalling  `DictionaryFetch` results to `Dictionary<string, byte[]>`.

Closes #119 