### PR TITLE
feat: add stub parameter to `ListPush` to truncate after size.

### DIFF
--- a/IncubatingIntegrationTest/ListTest.cs
+++ b/IncubatingIntegrationTest/ListTest.cs
@@ -74,6 +74,12 @@ public class ListTest : TestBase
         Assert.Equal(2, response.ByteArrayList!.Count);
     }
 
+    [Fact]
+    public async Task ListPushFrontAsync_ValueIsByteArrayTruncateTailToSizeIsZero_ThrowsException()
+    {
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await client.ListPushFrontAsync("myCache", "listName", new byte[] { 0x00 }, false, truncateTailToSize: 0));
+    }
+
     [Theory]
     [InlineData(null, "my-list", "my-value")]
     [InlineData("cache", null, "my-value")]
@@ -137,6 +143,12 @@ public class ListTest : TestBase
         var response = await client.ListFetchAsync(cacheName, listName);
         Assert.Equal(CacheGetStatus.HIT, response.Status);
         Assert.Equal(2, response.StringList()!.Count);
+    }
+
+    [Fact]
+    public async Task ListPushFrontAsync_ValueIsStringTruncateTailToSizeIsZero_ThrowsException()
+    {
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await client.ListPushFrontAsync("myCache", "listName", "value", false, truncateTailToSize: 0));
     }
 
     [Theory]
@@ -204,6 +216,12 @@ public class ListTest : TestBase
         Assert.Equal(2, response.ByteArrayList!.Count);
     }
 
+    [Fact]
+    public async Task ListPushBackAsync_ValueIsByteArrayTruncateHeadToSizeIsZero_ThrowsException()
+    {
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await client.ListPushBackAsync("myCache", "listName", new byte[] { 0x00 }, false, truncateHeadToSize: 0));
+    }
+
     [Theory]
     [InlineData(null, "my-list", "my-value")]
     [InlineData("cache", null, "my-value")]
@@ -267,6 +285,12 @@ public class ListTest : TestBase
         var response = await client.ListFetchAsync(cacheName, listName);
         Assert.Equal(CacheGetStatus.HIT, response.Status);
         Assert.Equal(2, response.StringList()!.Count);
+    }
+
+    [Fact]
+    public async Task ListPushBackAsync_ValueIsStringTruncateHeadToSizeIsZero_ThrowsException()
+    {
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await client.ListPushBackAsync("myCache", "listName", "value", false, truncateHeadToSize: 0));
     }
 
     [Theory]

--- a/Momento/Incubating/SimpleCacheClient.cs
+++ b/Momento/Incubating/SimpleCacheClient.cs
@@ -674,13 +674,16 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="value">The value to push to the front of the list.</param>
     /// <param name="refreshTtl">Update `listName`'s TTL if it already exists.</param>
     /// <param name="ttlSeconds">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
+    /// <param name="truncateTailToSize">Ensure the list does not exceed this length. Remove excess from tail of list. Must be a positive number.</param>
     /// <returns>Task representing the result of the push operation.</returns>
     /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` or `value` is `null`.</exception>
-    public async Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, byte[] value, bool refreshTtl, uint? ttlSeconds = null)
+    /// <exception cref="ArgumentOutOfRangeException">`truncateTailToSize` is zero.</exception>
+    public async Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, byte[] value, bool refreshTtl, uint? ttlSeconds = null, uint? truncateTailToSize = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
         Utils.ArgumentNotNull(listName, nameof(listName));
         Utils.ArgumentNotNull(value, nameof(value));
+        Utils.ArgumentStrictlyPositive(truncateTailToSize, nameof(truncateTailToSize));
 
         return await this.dataClient.ListPushFrontAsync(cacheName, listName, value, refreshTtl, ttlSeconds);
     }
@@ -697,13 +700,16 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="value">The value to push to the front of the list.</param>
     /// <param name="refreshTtl">Update `listName`'s TTL if it already exists.</param>
     /// <param name="ttlSeconds">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
+    /// <param name="truncateTailToSize">Ensure the list does not exceed this length. Remove excess from tail of list. Must be a positive number.</param>
     /// <returns>Task representing the result of the push operation.</returns>
     /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` or `value` is `null`.</exception>
-    public async Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, string value, bool refreshTtl, uint? ttlSeconds = null)
+    /// <exception cref="ArgumentOutOfRangeException">`truncateTailToSize` is zero.</exception>
+    public async Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, string value, bool refreshTtl, uint? ttlSeconds = null, uint? truncateTailToSize = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
         Utils.ArgumentNotNull(listName, nameof(listName));
         Utils.ArgumentNotNull(value, nameof(value));
+        Utils.ArgumentStrictlyPositive(truncateTailToSize, nameof(truncateTailToSize));
 
         return await this.dataClient.ListPushFrontAsync(cacheName, listName, value, refreshTtl, ttlSeconds);
     }
@@ -720,13 +726,16 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="value">The value to push to the back of the list.</param>
     /// <param name="refreshTtl">Update `listName`'s TTL if it already exists.</param>
     /// <param name="ttlSeconds">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
+    /// <param name="truncateHeadToSize">Ensure the list does not exceed this length. Remove excess from head of list. Must be a positive number.</param>
     /// <returns>Task representing the result of the push operation.</returns>
     /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` or `value` is `null`.</exception>
-    public async Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, byte[] value, bool refreshTtl, uint? ttlSeconds = null)
+    /// <exception cref="ArgumentOutOfRangeException">`truncateHeadToSize` is zero.</exception>
+    public async Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, byte[] value, bool refreshTtl, uint? ttlSeconds = null, uint? truncateHeadToSize = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
         Utils.ArgumentNotNull(listName, nameof(listName));
         Utils.ArgumentNotNull(value, nameof(value));
+        Utils.ArgumentStrictlyPositive(truncateHeadToSize, nameof(truncateHeadToSize));
 
         return await this.dataClient.ListPushBackAsync(cacheName, listName, value, refreshTtl, ttlSeconds);
     }
@@ -743,13 +752,16 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="value">The value to push to the back of the list.</param>
     /// <param name="refreshTtl">Update `listName`'s TTL if it already exists.</param>
     /// <param name="ttlSeconds">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
+    /// <param name="truncateHeadToSize">Ensure the list does not exceed this length. Remove excess from head of list. Must be a positive number.</param>
     /// <returns>Task representing the result of the push operation.</returns>
     /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` or `value` is `null`.</exception>
-    public async Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, string value, bool refreshTtl, uint? ttlSeconds = null)
+    /// <exception cref="ArgumentOutOfRangeException">`truncateHeadToSize` is zero.</exception>
+    public async Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, string value, bool refreshTtl, uint? ttlSeconds = null, uint? truncateHeadToSize = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
         Utils.ArgumentNotNull(listName, nameof(listName));
         Utils.ArgumentNotNull(value, nameof(value));
+        Utils.ArgumentStrictlyPositive(truncateHeadToSize, nameof(truncateHeadToSize));
 
         return await this.dataClient.ListPushBackAsync(cacheName, listName, value, refreshTtl, ttlSeconds);
     }

--- a/Momento/Internal/Utils.cs
+++ b/Momento/Internal/Utils.cs
@@ -77,6 +77,20 @@ namespace Momento.Sdk.Internal
         }
 
         /// <summary>
+        /// Throw an exception if the argument is zero.
+        /// </summary>
+        /// <param name="argument">The integer to zero test.</param>
+        /// <param name="paramName">Name of the integer to propagate to the exception.</param>
+        /// <exception cref="ArgumentOutOfRangeException">`argument` is zero.</exception>
+        public static void ArgumentStrictlyPositive(uint? argument, string paramName)
+        {
+            if (argument == 0)
+            {
+                throw new ArgumentOutOfRangeException(paramName, "Number must be strictly positive.");
+            }
+        }
+
+        /// <summary>
         /// Defines methods to support comparing containers of reference items by their
         /// contents (structure) instead of by reference.
         /// </summary>


### PR DESCRIPTION
Add an optional `truncateTailToSize` (`truncateHeadToSize`) to `LishPushFront` (`ListPushBack`). This argument will trigger the list to be trimmed on the opposite end of the push if the size exceeds the specified value. This PR adds the argument to the method signatures as well as checks that it is strictly positive. A future PR will make this functional.

Progress towards #122 .