### PR TITLE
fix: make truncate*ToSize nomenclature consistent with `ListPush*`

### DIFF
--- a/IncubatingIntegrationTest/ListTest.cs
+++ b/IncubatingIntegrationTest/ListTest.cs
@@ -75,9 +75,9 @@ public class ListTest : TestBase
     }
 
     [Fact]
-    public async Task ListPushFrontAsync_ValueIsByteArrayTruncateTailToSizeIsZero_ThrowsException()
+    public async Task ListPushFrontAsync_ValueIsByteArrayTruncateBackToSizeIsZero_ThrowsException()
     {
-        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await client.ListPushFrontAsync("myCache", "listName", new byte[] { 0x00 }, false, truncateTailToSize: 0));
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await client.ListPushFrontAsync("myCache", "listName", new byte[] { 0x00 }, false, truncateBackToSize: 0));
     }
 
     [Theory]
@@ -146,9 +146,9 @@ public class ListTest : TestBase
     }
 
     [Fact]
-    public async Task ListPushFrontAsync_ValueIsStringTruncateTailToSizeIsZero_ThrowsException()
+    public async Task ListPushFrontAsync_ValueIsStringTruncateBackToSizeIsZero_ThrowsException()
     {
-        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await client.ListPushFrontAsync("myCache", "listName", "value", false, truncateTailToSize: 0));
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await client.ListPushFrontAsync("myCache", "listName", "value", false, truncateBackToSize: 0));
     }
 
     [Theory]
@@ -217,9 +217,9 @@ public class ListTest : TestBase
     }
 
     [Fact]
-    public async Task ListPushBackAsync_ValueIsByteArrayTruncateHeadToSizeIsZero_ThrowsException()
+    public async Task ListPushBackAsync_ValueIsByteArrayTruncateFrontToSizeIsZero_ThrowsException()
     {
-        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await client.ListPushBackAsync("myCache", "listName", new byte[] { 0x00 }, false, truncateHeadToSize: 0));
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await client.ListPushBackAsync("myCache", "listName", new byte[] { 0x00 }, false, truncateFrontToSize: 0));
     }
 
     [Theory]
@@ -288,9 +288,9 @@ public class ListTest : TestBase
     }
 
     [Fact]
-    public async Task ListPushBackAsync_ValueIsStringTruncateHeadToSizeIsZero_ThrowsException()
+    public async Task ListPushBackAsync_ValueIsStringTruncateFrontToSizeIsZero_ThrowsException()
     {
-        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await client.ListPushBackAsync("myCache", "listName", "value", false, truncateHeadToSize: 0));
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await client.ListPushBackAsync("myCache", "listName", "value", false, truncateFrontToSize: 0));
     }
 
     [Theory]

--- a/Momento/Incubating/SimpleCacheClient.cs
+++ b/Momento/Incubating/SimpleCacheClient.cs
@@ -674,16 +674,16 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="value">The value to push to the front of the list.</param>
     /// <param name="refreshTtl">Update `listName`'s TTL if it already exists.</param>
     /// <param name="ttlSeconds">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <param name="truncateTailToSize">Ensure the list does not exceed this length. Remove excess from tail of list. Must be a positive number.</param>
+    /// <param name="truncateBackToSize">Ensure the list does not exceed this length. Remove excess from the end of the list. Must be a positive number.</param>
     /// <returns>Task representing the result of the push operation.</returns>
     /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` or `value` is `null`.</exception>
     /// <exception cref="ArgumentOutOfRangeException">`truncateTailToSize` is zero.</exception>
-    public async Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, byte[] value, bool refreshTtl, uint? ttlSeconds = null, uint? truncateTailToSize = null)
+    public async Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, byte[] value, bool refreshTtl, uint? ttlSeconds = null, uint? truncateBackToSize = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
         Utils.ArgumentNotNull(listName, nameof(listName));
         Utils.ArgumentNotNull(value, nameof(value));
-        Utils.ArgumentStrictlyPositive(truncateTailToSize, nameof(truncateTailToSize));
+        Utils.ArgumentStrictlyPositive(truncateBackToSize, nameof(truncateBackToSize));
 
         return await this.dataClient.ListPushFrontAsync(cacheName, listName, value, refreshTtl, ttlSeconds);
     }
@@ -700,16 +700,16 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="value">The value to push to the front of the list.</param>
     /// <param name="refreshTtl">Update `listName`'s TTL if it already exists.</param>
     /// <param name="ttlSeconds">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <param name="truncateTailToSize">Ensure the list does not exceed this length. Remove excess from tail of list. Must be a positive number.</param>
+    /// <param name="truncateBackToSize">Ensure the list does not exceed this length. Remove excess from the end of the list. Must be a positive number.</param>
     /// <returns>Task representing the result of the push operation.</returns>
     /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` or `value` is `null`.</exception>
     /// <exception cref="ArgumentOutOfRangeException">`truncateTailToSize` is zero.</exception>
-    public async Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, string value, bool refreshTtl, uint? ttlSeconds = null, uint? truncateTailToSize = null)
+    public async Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, string value, bool refreshTtl, uint? ttlSeconds = null, uint? truncateBackToSize = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
         Utils.ArgumentNotNull(listName, nameof(listName));
         Utils.ArgumentNotNull(value, nameof(value));
-        Utils.ArgumentStrictlyPositive(truncateTailToSize, nameof(truncateTailToSize));
+        Utils.ArgumentStrictlyPositive(truncateBackToSize, nameof(truncateBackToSize));
 
         return await this.dataClient.ListPushFrontAsync(cacheName, listName, value, refreshTtl, ttlSeconds);
     }
@@ -726,16 +726,16 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="value">The value to push to the back of the list.</param>
     /// <param name="refreshTtl">Update `listName`'s TTL if it already exists.</param>
     /// <param name="ttlSeconds">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <param name="truncateHeadToSize">Ensure the list does not exceed this length. Remove excess from head of list. Must be a positive number.</param>
+    /// <param name="truncateFrontToSize">Ensure the list does not exceed this length. Remove excess from the beginning of the list. Must be a positive number.</param>
     /// <returns>Task representing the result of the push operation.</returns>
     /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` or `value` is `null`.</exception>
     /// <exception cref="ArgumentOutOfRangeException">`truncateHeadToSize` is zero.</exception>
-    public async Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, byte[] value, bool refreshTtl, uint? ttlSeconds = null, uint? truncateHeadToSize = null)
+    public async Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, byte[] value, bool refreshTtl, uint? ttlSeconds = null, uint? truncateFrontToSize = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
         Utils.ArgumentNotNull(listName, nameof(listName));
         Utils.ArgumentNotNull(value, nameof(value));
-        Utils.ArgumentStrictlyPositive(truncateHeadToSize, nameof(truncateHeadToSize));
+        Utils.ArgumentStrictlyPositive(truncateFrontToSize, nameof(truncateFrontToSize));
 
         return await this.dataClient.ListPushBackAsync(cacheName, listName, value, refreshTtl, ttlSeconds);
     }
@@ -752,16 +752,16 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="value">The value to push to the back of the list.</param>
     /// <param name="refreshTtl">Update `listName`'s TTL if it already exists.</param>
     /// <param name="ttlSeconds">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <param name="truncateHeadToSize">Ensure the list does not exceed this length. Remove excess from head of list. Must be a positive number.</param>
+    /// <param name="truncateFrontToSize">Ensure the list does not exceed this length. Remove excess from the beginning of the list. Must be a positive number.</param>
     /// <returns>Task representing the result of the push operation.</returns>
     /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` or `value` is `null`.</exception>
     /// <exception cref="ArgumentOutOfRangeException">`truncateHeadToSize` is zero.</exception>
-    public async Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, string value, bool refreshTtl, uint? ttlSeconds = null, uint? truncateHeadToSize = null)
+    public async Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, string value, bool refreshTtl, uint? ttlSeconds = null, uint? truncateFrontToSize = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
         Utils.ArgumentNotNull(listName, nameof(listName));
         Utils.ArgumentNotNull(value, nameof(value));
-        Utils.ArgumentStrictlyPositive(truncateHeadToSize, nameof(truncateHeadToSize));
+        Utils.ArgumentStrictlyPositive(truncateFrontToSize, nameof(truncateFrontToSize));
 
         return await this.dataClient.ListPushBackAsync(cacheName, listName, value, refreshTtl, ttlSeconds);
     }

--- a/Momento/Incubating/SimpleCacheClient.cs
+++ b/Momento/Incubating/SimpleCacheClient.cs
@@ -663,7 +663,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     }
 
     /// <summary>
-    /// Push a value to the front of a list.
+    /// Push a value to the beginning of a list.
     ///
     /// Creates the list if it does not exist and sets the TTL.
     /// If the list already exists and `refreshTtl` is `true`, then update the
@@ -689,7 +689,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     }
 
     /// <summary>
-    /// Push a value to the front of a list.
+    /// Push a value to the beginning of a list.
     ///
     /// Creates the list if it does not exist and sets the TTL.
     /// If the list already exists and `refreshTtl` is `true`, then update the
@@ -715,7 +715,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     }
 
     /// <summary>
-    /// Push a value to the back of a list.
+    /// Push a value to the end of a list.
     ///
     /// Creates the list if it does not exist and sets the TTL.
     /// If the list already exists and `refreshTtl` is `true`, then update the
@@ -741,7 +741,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     }
 
     /// <summary>
-    /// Push a value to the back of a list.
+    /// Push a value to the end of a list.
     ///
     /// Creates the list if it does not exist and sets the TTL.
     /// If the list already exists and `refreshTtl` is `true`, then update the


### PR DESCRIPTION
For `ListPush` We use the nouns "Front" and "Back" to refer to the
beginning and end of the list respectively. In the previous commit, in the
context of truncate, we used the nouns "Head" and "Tail". That introduced 
extra vocabulary to refer to exactly the same concepts. This commit renames
"Head" and "Tail" to "Front" and "Back" for consistency.