### PR TITLE
fix: relax integration test timings

### DIFF
--- a/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/DictionaryTest.cs
@@ -90,9 +90,9 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidByteArray();
         var value = Utils.NewGuidByteArray();
 
-        await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttlSeconds: 1);
+        await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttlSeconds: 2);
         await client.DictionarySetAsync(cacheName, dictionaryName, field, value, true, ttlSeconds: 10);
-        await Task.Delay(1000);
+        await Task.Delay(2000);
 
         var response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
         Assert.Equal(CacheGetStatus.HIT, response.Status);
@@ -179,9 +179,9 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttlSeconds: 1);
+        await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttlSeconds: 2);
         await client.DictionarySetAsync(cacheName, dictionaryName, field, value, true, ttlSeconds: 10);
-        await Task.Delay(1000);
+        await Task.Delay(2000);
 
         var response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
         Assert.Equal(CacheGetStatus.HIT, response.Status);
@@ -235,9 +235,9 @@ public class DictionaryTest : TestBase
         var field = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttlSeconds: 1);
+        await client.DictionarySetAsync(cacheName, dictionaryName, field, value, false, ttlSeconds: 2);
         await client.DictionarySetAsync(cacheName, dictionaryName, field, value, true, ttlSeconds: 10);
-        await Task.Delay(1000);
+        await Task.Delay(2000);
 
         var response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
         Assert.Equal(CacheGetStatus.HIT, response.Status);
@@ -305,9 +305,9 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidByteArray();
         var content = new Dictionary<byte[], byte[]>() { { field, value } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttlSeconds: 1);
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttlSeconds: 2);
         await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, true, ttlSeconds: 10);
-        await Task.Delay(1000);
+        await Task.Delay(2000);
 
         var response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
         Assert.Equal(CacheGetStatus.HIT, response.Status);
@@ -375,9 +375,9 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidString();
         var content = new Dictionary<string, string>() { { field, value } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttlSeconds: 1);
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttlSeconds: 2);
         await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, true, ttlSeconds: 10);
-        await Task.Delay(1000);
+        await Task.Delay(2000);
 
         var response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
         Assert.Equal(CacheGetStatus.HIT, response.Status);
@@ -445,9 +445,9 @@ public class DictionaryTest : TestBase
         var value = Utils.NewGuidByteArray();
         var content = new Dictionary<string, byte[]>() { { field, value } };
 
-        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttlSeconds: 1);
+        await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, false, ttlSeconds: 2);
         await client.DictionarySetBatchAsync(cacheName, dictionaryName, content, true, ttlSeconds: 10);
-        await Task.Delay(1000);
+        await Task.Delay(2000);
 
         var response = await client.DictionaryGetAsync(cacheName, dictionaryName, field);
         Assert.Equal(CacheGetStatus.HIT, response.Status);

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
@@ -65,9 +65,9 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        await client.ListPushFrontAsync(cacheName, listName, value, false, ttlSeconds: 1);
+        await client.ListPushFrontAsync(cacheName, listName, value, false, ttlSeconds: 2);
         await client.ListPushFrontAsync(cacheName, listName, value, true, ttlSeconds: 10);
-        await Task.Delay(1000);
+        await Task.Delay(2000);
 
         var response = await client.ListFetchAsync(cacheName, listName);
         Assert.Equal(CacheGetStatus.HIT, response.Status);
@@ -136,9 +136,9 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        await client.ListPushFrontAsync(cacheName, listName, value, false, ttlSeconds: 1);
+        await client.ListPushFrontAsync(cacheName, listName, value, false, ttlSeconds: 2);
         await client.ListPushFrontAsync(cacheName, listName, value, true, ttlSeconds: 10);
-        await Task.Delay(1000);
+        await Task.Delay(2000);
 
         var response = await client.ListFetchAsync(cacheName, listName);
         Assert.Equal(CacheGetStatus.HIT, response.Status);
@@ -207,9 +207,9 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidByteArray();
 
-        await client.ListPushBackAsync(cacheName, listName, value, false, ttlSeconds: 1);
+        await client.ListPushBackAsync(cacheName, listName, value, false, ttlSeconds: 2);
         await client.ListPushBackAsync(cacheName, listName, value, true, ttlSeconds: 10);
-        await Task.Delay(1000);
+        await Task.Delay(2000);
 
         var response = await client.ListFetchAsync(cacheName, listName);
         Assert.Equal(CacheGetStatus.HIT, response.Status);
@@ -278,9 +278,9 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value = Utils.NewGuidString();
 
-        await client.ListPushBackAsync(cacheName, listName, value, false, ttlSeconds: 1);
+        await client.ListPushBackAsync(cacheName, listName, value, false, ttlSeconds: 2);
         await client.ListPushBackAsync(cacheName, listName, value, true, ttlSeconds: 10);
-        await Task.Delay(1000);
+        await Task.Delay(2000);
 
         var response = await client.ListFetchAsync(cacheName, listName);
         Assert.Equal(CacheGetStatus.HIT, response.Status);

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/SetTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/SetTest.cs
@@ -56,9 +56,9 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidByteArray();
 
-        await client.SetAddAsync(cacheName, setName, element, false, ttlSeconds: 1);
+        await client.SetAddAsync(cacheName, setName, element, false, ttlSeconds: 2);
         await client.SetAddAsync(cacheName, setName, element, true, ttlSeconds: 10);
-        await Task.Delay(1000);
+        await Task.Delay(2000);
 
         var response = await client.SetFetchAsync(cacheName, setName);
         Assert.Equal(CacheGetStatus.HIT, response.Status);
@@ -112,9 +112,9 @@ public class SetTest : TestBase
         var setName = Utils.NewGuidString();
         var element = Utils.NewGuidString();
 
-        await client.SetAddAsync(cacheName, setName, element, false, ttlSeconds: 1);
+        await client.SetAddAsync(cacheName, setName, element, false, ttlSeconds: 2);
         await client.SetAddAsync(cacheName, setName, element, true, ttlSeconds: 10);
-        await Task.Delay(1000);
+        await Task.Delay(2000);
 
         var response = await client.SetFetchAsync(cacheName, setName);
         Assert.Equal(CacheGetStatus.HIT, response.Status);
@@ -177,9 +177,9 @@ public class SetTest : TestBase
         var element = Utils.NewGuidByteArray();
         var content = new List<byte[]>() { element };
 
-        await client.SetAddBatchAsync(cacheName, setName, content, false, ttlSeconds: 1);
+        await client.SetAddBatchAsync(cacheName, setName, content, false, ttlSeconds: 2);
         await client.SetAddBatchAsync(cacheName, setName, content, true, ttlSeconds: 10);
-        await Task.Delay(1000);
+        await Task.Delay(2000);
 
         var response = await client.SetFetchAsync(cacheName, setName);
         Assert.Equal(CacheGetStatus.HIT, response.Status);
@@ -245,9 +245,9 @@ public class SetTest : TestBase
         var element = Utils.NewGuidString();
         var content = new List<string>() { element };
 
-        await client.SetAddBatchAsync(cacheName, setName, content, false, ttlSeconds: 1);
+        await client.SetAddBatchAsync(cacheName, setName, content, false, ttlSeconds: 2);
         await client.SetAddBatchAsync(cacheName, setName, content, true, ttlSeconds: 10);
-        await Task.Delay(1000);
+        await Task.Delay(2000);
 
         var response = await client.SetFetchAsync(cacheName, setName);
         Assert.Equal(CacheGetStatus.HIT, response.Status);


### PR DESCRIPTION
The `RefreshTtl` integration tests rely on delays to exercise the
feature. The TTLs before are too tight for the CI/CD server env, and cause
intermittent failures due to network latencies as opposed to the
feature under test not working. This change relaxes the timings to
account for latencies.