### PR TITLE
docs: use documentation tags where appropriate

### DIFF
--- a/src/Momento.Sdk/ISimpleCacheClient.cs
+++ b/src/Momento.Sdk/ISimpleCacheClient.cs
@@ -59,40 +59,16 @@ public interface ISimpleCacheClient : IDisposable
     /// <returns>Task object representing the result of the delete operation.</returns>
     public Task<CacheDeleteResponse> DeleteAsync(string cacheName, byte[] key);
 
-    /// <summary>
-    /// Set the value in cache with a given time to live (TTL) seconds.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to store the item in.</param>
-    /// <param name="key">The key to set.</param>
-    /// <param name="value">The value to be stored.</param>
-    /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <returns>Task object representing the result of the set operation.</returns>
+    /// <inheritdoc cref="SetAsync(string, byte[], byte[], uint?)" />
     public Task<CacheSetResponse> SetAsync(string cacheName, string key, string value, uint? ttlSeconds = null);
 
-    /// <summary>
-    /// Get the cache value stored for the given key.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-    /// <param name="key">The key to lookup.</param>
-    /// <returns>Task object representing containing the status of the get operation and the associated value.</returns>
+    /// <inheritdoc cref="GetAsync(string, byte[])" />
     public Task<CacheGetResponse> GetAsync(string cacheName, string key);
 
-    /// <summary>
-    /// Remove the key from the cache.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to delete the key from.</param>
-    /// <param name="key">The key to delete.</param>
-    /// <returns>Task object representing the result of the delete operation.</returns>
+    /// <inheritdoc cref="DeleteAsync(string, byte[])" />
     public Task<CacheDeleteResponse> DeleteAsync(string cacheName, string key);
 
-    /// <summary>
-    /// Set the value in cache with a given time to live (TTL) seconds.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to store the item in.</param>
-    /// <param name="key">The key to set.</param>
-    /// <param name="value">The value to be stored.</param>
-    /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <returns>Task object representing the result of the set operation.</returns>
+    /// <inheritdoc cref="SetAsync(string, byte[], byte[], uint?)" />
     public Task<CacheSetResponse> SetAsync(string cacheName, string key, byte[] value, uint? ttlSeconds = null);
 
     /// <summary>
@@ -103,12 +79,7 @@ public interface ISimpleCacheClient : IDisposable
     /// <returns>Task object representing the statuses of the get operation and the associated values.</returns>
     public Task<CacheGetBatchResponse> GetBatchAsync(string cacheName, IEnumerable<byte[]> keys);
 
-    /// <summary>
-    /// Gets multiple values from the cache.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-    /// <param name="keys">The keys to get.</param>
-    /// <returns>Task object representing the statuses of the get operation and the associated values.</returns>
+    /// <inheritdoc cref="GetBatchAsync(string, IEnumerable{byte[]})" />
     public Task<CacheGetBatchResponse> GetBatchAsync(string cacheName, IEnumerable<string> keys);
 
     /// <summary>
@@ -120,12 +91,6 @@ public interface ISimpleCacheClient : IDisposable
     /// <returns>Task object representing the result of the set operation.</returns>
     public Task<CacheSetBatchResponse> SetBatchAsync(string cacheName, IEnumerable<KeyValuePair<byte[], byte[]>> items, uint? ttlSeconds = null);
 
-    /// <summary>
-    /// Sets multiple items in the cache. Overwrites existing items.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to store the items in.</param>
-    /// <param name="items">The items to set.</param>
-    /// <param name="ttlSeconds">TTL for the item in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <returns>Task object representing the result of the set operation.</returns>
+    /// <inheritdoc cref="SetBatchAsync(string, IEnumerable{KeyValuePair{byte[], byte[]}}, uint?)" />
     public Task<CacheSetBatchResponse> SetBatchAsync(string cacheName, IEnumerable<KeyValuePair<string, string>> items, uint? ttlSeconds = null);
 }

--- a/src/Momento.Sdk/ISimpleCacheClient.cs
+++ b/src/Momento.Sdk/ISimpleCacheClient.cs
@@ -59,16 +59,16 @@ public interface ISimpleCacheClient : IDisposable
     /// <returns>Task object representing the result of the delete operation.</returns>
     public Task<CacheDeleteResponse> DeleteAsync(string cacheName, byte[] key);
 
-    /// <inheritdoc cref="SetAsync(string, byte[], byte[], uint?)" />
+    /// <inheritdoc cref="SetAsync(string, byte[], byte[], uint?)"/>
     public Task<CacheSetResponse> SetAsync(string cacheName, string key, string value, uint? ttlSeconds = null);
 
-    /// <inheritdoc cref="GetAsync(string, byte[])" />
+    /// <inheritdoc cref="GetAsync(string, byte[])"/>
     public Task<CacheGetResponse> GetAsync(string cacheName, string key);
 
-    /// <inheritdoc cref="DeleteAsync(string, byte[])" />
+    /// <inheritdoc cref="DeleteAsync(string, byte[])"/>
     public Task<CacheDeleteResponse> DeleteAsync(string cacheName, string key);
 
-    /// <inheritdoc cref="SetAsync(string, byte[], byte[], uint?)" />
+    /// <inheritdoc cref="SetAsync(string, byte[], byte[], uint?)"/>
     public Task<CacheSetResponse> SetAsync(string cacheName, string key, byte[] value, uint? ttlSeconds = null);
 
     /// <summary>
@@ -79,7 +79,7 @@ public interface ISimpleCacheClient : IDisposable
     /// <returns>Task object representing the statuses of the get operation and the associated values.</returns>
     public Task<CacheGetBatchResponse> GetBatchAsync(string cacheName, IEnumerable<byte[]> keys);
 
-    /// <inheritdoc cref="GetBatchAsync(string, IEnumerable{byte[]})" />
+    /// <inheritdoc cref="GetBatchAsync(string, IEnumerable{byte[]})"/>
     public Task<CacheGetBatchResponse> GetBatchAsync(string cacheName, IEnumerable<string> keys);
 
     /// <summary>
@@ -91,6 +91,6 @@ public interface ISimpleCacheClient : IDisposable
     /// <returns>Task object representing the result of the set operation.</returns>
     public Task<CacheSetBatchResponse> SetBatchAsync(string cacheName, IEnumerable<KeyValuePair<byte[], byte[]>> items, uint? ttlSeconds = null);
 
-    /// <inheritdoc cref="SetBatchAsync(string, IEnumerable{KeyValuePair{byte[], byte[]}}, uint?)" />
+    /// <inheritdoc cref="SetBatchAsync(string, IEnumerable{KeyValuePair{byte[], byte[]}}, uint?)"/>
     public Task<CacheSetBatchResponse> SetBatchAsync(string cacheName, IEnumerable<KeyValuePair<string, string>> items, uint? ttlSeconds = null);
 }

--- a/src/Momento.Sdk/Incubating/SimpleCacheClient.cs
+++ b/src/Momento.Sdk/Incubating/SimpleCacheClient.cs
@@ -123,8 +123,8 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// Set the dictionary field to a value with a given time to live (TTL) seconds.
     ///
     /// Creates the dictionary if it does not exist and sets the TTL.
-    /// If the dictionary already exists and `refreshTtl` is <see langword="true"/>, then update the
-    /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
+    /// If the dictionary already exists and <paramref name="refreshTtl"/> is <see langword="true"/>, then update the
+    /// TTL to <paramref name="ttlSeconds"/>, otherwise leave the TTL unchanged.
     /// </summary>
     /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
     /// <param name="dictionaryName">The dictionary to set.</param>
@@ -133,7 +133,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="refreshTtl">Update the dictionary TTL if the dictionary already exists.</param>
     /// <param name="ttlSeconds">TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `field`, `value` is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Any of <paramref name="cacheName"/>, <paramref name="dictionaryName"/>, <paramref name="field"/>, <paramref name="value"/> is <see langword="null"/>.</exception>
     public async Task<CacheDictionarySetResponse> DictionarySetAsync(string cacheName, string dictionaryName, byte[] field, byte[] value, bool refreshTtl, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -173,7 +173,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="dictionaryName">The dictionary to lookup.</param>
     /// <param name="field">The field in the dictionary to lookup.</param>
     /// <returns>Task representing the status of the get operation and the associated value.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `field` is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Any of <paramref name="cacheName"/>, <paramref name="dictionaryName"/>, <paramref name="field"/> is <see langword="null"/>.</exception>
     public async Task<CacheDictionaryGetResponse> DictionaryGetAsync(string cacheName, string dictionaryName, byte[] field)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -197,8 +197,8 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// Set several dictionary field-value pairs in the cache.
     ///
     /// Creates the dictionary if it does not exist and sets the TTL.
-    /// If the dictionary already exists and `refreshTtl` is <see langword="true"/>, then update the
-    /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
+    /// If the dictionary already exists and <paramref name="refreshTtl"/> is <see langword="true"/>, then update the
+    /// TTL to <paramref name="ttlSeconds"/>, otherwise leave the TTL unchanged.
     /// </summary>
     /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
     /// <param name="dictionaryName">The dictionary to set.</param>
@@ -206,7 +206,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="refreshTtl">Update the dictionary TTL if the dictionary already exists.</param>
     /// <param name="ttlSeconds">TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `items` is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Any of <paramref name="cacheName"/>, <paramref name="dictionaryName"/>, <paramref name="items"/> is <see langword="null"/>.</exception>
     public async Task<CacheDictionarySetBatchResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<byte[], byte[]>> items, bool refreshTtl, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -246,7 +246,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="dictionaryName">The dictionary to lookup.</param>
     /// <param name="fields">The fields in the dictionary to lookup.</param>
     /// <returns>Task representing the status and associated value for each field.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `fields` is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Any of <paramref name="cacheName"/>, <paramref name="dictionaryName"/>, <paramref name="fields"/> is <see langword="null"/>.</exception>
     public async Task<CacheDictionaryGetBatchResponse> DictionaryGetBatchAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -274,7 +274,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
     /// <param name="dictionaryName">The dictionary to fetch.</param>
     /// <returns>Task representing with the status of the fetch operation and the associated dictionary.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName` is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Any of <paramref name="cacheName"/>, <paramref name="dictionaryName"/> is <see langword="null"/>.</exception>
     public async Task<CacheDictionaryFetchResponse> DictionaryFetchAsync(string cacheName, string dictionaryName)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -286,12 +286,12 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <summary>
     /// Remove the dictionary from the cache.
     ///
-    /// Performs a no-op if `dictionaryName` does not exist.
+    /// Performs a no-op if <paramref name="dictionaryName"/> does not exist.
     /// </summary>
     /// <param name="cacheName">Name of the cache to delete the dictionary from.</param>
     /// <param name="dictionaryName">Name of the dictionary to delete.</param>
     /// <returns>Task representing the result of the delete operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `dictionaryName` is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Any of <paramref name="cacheName"/> or <paramref name="dictionaryName"/> is <see langword="null"/>.</exception>
     public async Task<CacheDictionaryDeleteResponse> DictionaryDeleteAsync(string cacheName, string dictionaryName)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -303,13 +303,13 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <summary>
     /// Remove a field from a dictionary.
     ///
-    /// Performs a no-op if `dictionaryName` or `field` does not exist.
+    /// Performs a no-op if <paramref name="dictionaryName"/> or <paramref name="field"/> does not exist.
     /// </summary>
     /// <param name="cacheName">Name of the cache to lookup the dictionary in.</param>
     /// <param name="dictionaryName">Name of the dictionary to remove the field from.</param>
     /// <param name="field">Name of the field to remove from the dictionary.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `field` is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Any of <paramref name="cacheName"/>, <paramref name="dictionaryName"/>, <paramref name="field"/> is <see langword="null"/>.</exception>
     public async Task<CacheDictionaryRemoveFieldResponse> DictionaryRemoveFieldAsync(string cacheName, string dictionaryName, byte[] field)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -332,13 +332,13 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <summary>
     /// Remove fields from a dictionary.
     ///
-    /// Performs a no-op if `dictionaryName` or a particular field does not exist.
+    /// Performs a no-op if <paramref name="dictionaryName"/> or a particular field does not exist.
     /// </summary>
     /// <param name="cacheName">Name of the cache to lookup the dictionary in.</param>
     /// <param name="dictionaryName">Name of the dictionary to remove the field from.</param>
     /// <param name="fields">Name of the fields to remove from the dictionary.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `fields` is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Any of <paramref name="cacheName"/>, <paramref name="dictionaryName"/>, <paramref name="fields"/> is <see langword="null"/>.</exception>
     public async Task<CacheDictionaryRemoveFieldsResponse> DictionaryRemoveFieldsAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -367,16 +367,16 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// of the element passed in and the elements of the set.
     ///
     /// Creates the set if it does not exist and sets the TTL.
-    /// If the set already exists and `refreshTtl` is <see langword="true"/>, then update the
-    /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
+    /// If the set already exists and <paramref name="refreshTtl"/> is <see langword="true"/>, then update the
+    /// TTL to <paramref name="ttlSeconds"/>, otherwise leave the TTL unchanged.
     /// </summary>
     /// <param name="cacheName">Name of the cache to store the set in.</param>
     /// <param name="setName">The set to add the element to.</param>
     /// <param name="element">The data to add to the set.</param>
-    /// <param name="refreshTtl">Update `setName`'s TTL if it already exists.</param>
+    /// <param name="refreshTtl">Update <paramref name="setName"/>'s TTL if it already exists.</param>
     /// <param name="ttlSeconds">TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `element` is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Any of <paramref name="cacheName"/>, <paramref name="setName"/>, <paramref name="element"/> is <see langword="null"/>.</exception>
     public async Task<CacheSetAddResponse> SetAddAsync(string cacheName, string setName, byte[] element, bool refreshTtl, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -403,16 +403,16 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// of the elements passed in and the elements of the set.
     ///
     /// Creates the set if it does not exist and sets the TTL.
-    /// If the set already exists and `refreshTtl` is <see langword="true"/>, then update the
-    /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
+    /// If the set already exists and <paramref name="refreshTtl"/> is <see langword="true"/>, then update the
+    /// TTL to <paramref name="ttlSeconds"/>, otherwise leave the TTL unchanged.
     /// </summary>
     /// <param name="cacheName">Name of the cache to store the set in.</param>
     /// <param name="setName">The set to add elements to.</param>
     /// <param name="elements">The data to add to the set.</param>
-    /// <param name="refreshTtl">Update `setName`'s TTL if it already exists.</param>
+    /// <param name="refreshTtl">Update <paramref name="setName"/>'s TTL if it already exists.</param>
     /// <param name="ttlSeconds">TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `elements` is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Any of <paramref name="cacheName"/>, <paramref name="setName"/>, <paramref name="elements"/> is <see langword="null"/>.</exception>
     public async Task<CacheSetAddBatchResponse> SetAddBatchAsync(string cacheName, string setName, IEnumerable<byte[]> elements, bool refreshTtl, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -437,13 +437,13 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <summary>
     /// Remove an element from a set.
     ///
-    /// Performs a no-op if `setName` or `element` does not exist.
+    /// Performs a no-op if <paramref name="setName"/> or <paramref name="element"/> does not exist.
     /// </summary>
     /// <param name="cacheName">Name of the cache to lookup the set in.</param>
     /// <param name="setName">The set to remove the element from.</param>
     /// <param name="element">The data to remove from the set.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `element` is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Any of <paramref name="cacheName"/>, <paramref name="setName"/>, <paramref name="element"/> is <see langword="null"/>.</exception>
     public async Task<CacheSetRemoveElementResponse> SetRemoveElementAsync(string cacheName, string setName, byte[] element)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -466,13 +466,13 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <summary>
     /// Remove elements from a set.
     ///
-    /// Performs a no-op if `setName` or any of `elements` do not exist.
+    /// Performs a no-op if <paramref name="setName"/> or any of <paramref name="elements"/> do not exist.
     /// </summary>
     /// <param name="cacheName">Name of the cache to lookup the set in.</param>
     /// <param name="setName">The set to remove the elements from.</param>
     /// <param name="elements">The data to remove from the set.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `elements` is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Any of <paramref name="cacheName"/>, <paramref name="setName"/>, <paramref name="elements"/> is <see langword="null"/>.</exception>
     public async Task<CacheSetRemoveElementsResponse> SetRemoveElementsAsync(string cacheName, string setName, IEnumerable<byte[]> elements)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -500,7 +500,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
     /// <param name="setName">The set to fetch.</param>
     /// <returns>Task representing with the status of the fetch operation and the associated set.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `setName` is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Any of <paramref name="cacheName"/> or <paramref name="setName"/> is <see langword="null"/>.</exception>
     public async Task<CacheSetFetchResponse> SetFetchAsync(string cacheName, string setName)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -512,12 +512,12 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <summary>
     /// Remove the set from the cache.
     ///
-    /// Performs a no-op if `setName` does not exist.
+    /// Performs a no-op if <paramref name="setName"/> does not exist.
     /// </summary>
     /// <param name="cacheName">Name of the cache to delete the set from.</param>
     /// <param name="setName">Name of the set to delete.</param>
     /// <returns>Task representing the result of the delete operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `setName` is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Any of <paramref name="cacheName"/> or <paramref name="setName"/> is <see langword="null"/>.</exception>
     public async Task<CacheSetDeleteResponse> SetDeleteAsync(string cacheName, string setName)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -530,18 +530,18 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// Push a value to the beginning of a list.
     ///
     /// Creates the list if it does not exist and sets the TTL.
-    /// If the list already exists and `refreshTtl` is <see langword="true"/>, then update the
-    /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
+    /// If the list already exists and <paramref name="refreshTtl"/> is <see langword="true"/>, then update the
+    /// TTL to <paramref name="ttlSeconds"/>, otherwise leave the TTL unchanged.
     /// </summary>
     /// <param name="cacheName">Name of the cache to store the list in.</param>
     /// <param name="listName">The list to push the value on.</param>
     /// <param name="value">The value to push to the front of the list.</param>
-    /// <param name="refreshTtl">Update `listName`'s TTL if it already exists.</param>
+    /// <param name="refreshTtl">Update <paramref name="listName"/>'s TTL if it already exists.</param>
     /// <param name="ttlSeconds">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <param name="truncateBackToSize">Ensure the list does not exceed this length. Remove excess from the end of the list. Must be a positive number.</param>
     /// <returns>Task representing the result of the push operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` or `value` is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">`truncateTailToSize` is zero.</exception>
+    /// <exception cref="ArgumentNullException">Any of <paramref name="cacheName"/> or <paramref name="listName"/> or <paramref name="value"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="truncateTailToSize"/> is zero.</exception>
     public async Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, byte[] value, bool refreshTtl, uint? ttlSeconds = null, uint? truncateBackToSize = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -567,18 +567,18 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// Push a value to the end of a list.
     ///
     /// Creates the list if it does not exist and sets the TTL.
-    /// If the list already exists and `refreshTtl` is <see langword="true"/>, then update the
-    /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
+    /// If the list already exists and <paramref name="refreshTtl"/> is <see langword="true"/>, then update the
+    /// TTL to <paramref name="ttlSeconds"/>, otherwise leave the TTL unchanged.
     /// </summary>
     /// <param name="cacheName">Name of the cache to store the list in.</param>
     /// <param name="listName">The list to push the value on.</param>
     /// <param name="value">The value to push to the back of the list.</param>
-    /// <param name="refreshTtl">Update `listName`'s TTL if it already exists.</param>
+    /// <param name="refreshTtl">Update <paramref name="listName"/>'s TTL if it already exists.</param>
     /// <param name="ttlSeconds">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <param name="truncateFrontToSize">Ensure the list does not exceed this length. Remove excess from the beginning of the list. Must be a positive number.</param>
     /// <returns>Task representing the result of the push operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` or `value` is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">`truncateHeadToSize` is zero.</exception>
+    /// <exception cref="ArgumentNullException">Any of <paramref name="cacheName"/> or <paramref name="listName"/> or <paramref name="value"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="truncateHeadToSize"/> is zero.</exception>
     public async Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, byte[] value, bool refreshTtl, uint? ttlSeconds = null, uint? truncateFrontToSize = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -606,7 +606,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="cacheName">Name of the cache to read the list from.</param>
     /// <param name="listName">The list to pop from.</param>
     /// <returns>Task representing the status and associated value for the pop operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Any of <paramref name="cacheName"/> or <paramref name="listName"/> is <see langword="null"/>.</exception>
     public async Task<CacheListPopFrontResponse> ListPopFrontAsync(string cacheName, string listName)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -621,7 +621,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="cacheName">Name of the cache to read the list from.</param>
     /// <param name="listName">The list to pop from.</param>
     /// <returns>Task representing the status and associated value for the pop operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Any of <paramref name="cacheName"/> or <paramref name="listName"/> is <see langword="null"/>.</exception>
     public async Task<CacheListPopBackResponse> ListPopBackAsync(string cacheName, string listName)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -636,7 +636,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
     /// <param name="listName">The list to fetch.</param>
     /// <returns>Task representing with the status of the fetch operation and the associated list.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentNullException">Any of <paramref name="cacheName"/> or <paramref name="listName"/> is <see langword="null"/>.</exception>
     public async Task<CacheListFetchResponse> ListFetchAsync(string cacheName, string listName)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));

--- a/src/Momento.Sdk/Incubating/SimpleCacheClient.cs
+++ b/src/Momento.Sdk/Incubating/SimpleCacheClient.cs
@@ -197,7 +197,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <summary>
     /// Set several dictionary field-value pairs in the cache.
     /// </summary>
-    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], bool, uint?)" path="/remark"/>
+    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], bool, uint?)" path="remark"/>
     /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
     /// <param name="dictionaryName">The dictionary to set.</param>
     /// <param name="items">The field-value pairs in the dictionary to set.</param>
@@ -364,7 +364,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// After this operation, the set will contain the union
     /// of the element passed in and the elements of the set.
     /// </summary>
-    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], bool, uint?)" path="/remark"/>
+    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], bool, uint?)" path="remark"/>
     /// <param name="cacheName">Name of the cache to store the set in.</param>
     /// <param name="setName">The set to add the element to.</param>
     /// <param name="element">The data to add to the set.</param>
@@ -397,7 +397,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// After this operation, the set will contain the union
     /// of the elements passed in and the elements of the set.
     /// </summary>
-    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], bool, uint?)" path="/remark"/>
+    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], bool, uint?)" path="remark"/>
     /// <param name="cacheName">Name of the cache to store the set in.</param>
     /// <param name="setName">The set to add elements to.</param>
     /// <param name="elements">The data to add to the set.</param>
@@ -521,7 +521,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <summary>
     /// Push a value to the beginning of a list.
     /// </summary>
-    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], bool, uint?)" path="/remark"/>
+    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], bool, uint?)" path="remark"/>
     /// <param name="cacheName">Name of the cache to store the list in.</param>
     /// <param name="listName">The list to push the value on.</param>
     /// <param name="value">The value to push to the front of the list.</param>
@@ -555,7 +555,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <summary>
     /// Push a value to the end of a list.
     /// </summary>
-    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], bool, uint?)" path="/remark"/>
+    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], bool, uint?)" path="remark"/>
     /// <param name="cacheName">Name of the cache to store the list in.</param>
     /// <param name="listName">The list to push the value on.</param>
     /// <param name="value">The value to push to the back of the list.</param>

--- a/src/Momento.Sdk/Incubating/SimpleCacheClient.cs
+++ b/src/Momento.Sdk/Incubating/SimpleCacheClient.cs
@@ -530,7 +530,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="truncateBackToSize">Ensure the list does not exceed this length. Remove excess from the end of the list. Must be a positive number.</param>
     /// <returns>Task representing the result of the push operation.</returns>
     /// <exception cref="ArgumentNullException">Any of <paramref name="cacheName"/> or <paramref name="listName"/> or <paramref name="value"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentOutOfRangeException"><paramref name="truncateTailToSize"/> is zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="truncateBackToSize"/> is zero.</exception>
     public async Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, byte[] value, bool refreshTtl, uint? ttlSeconds = null, uint? truncateBackToSize = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -564,7 +564,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="truncateFrontToSize">Ensure the list does not exceed this length. Remove excess from the beginning of the list. Must be a positive number.</param>
     /// <returns>Task representing the result of the push operation.</returns>
     /// <exception cref="ArgumentNullException">Any of <paramref name="cacheName"/> or <paramref name="listName"/> or <paramref name="value"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentOutOfRangeException"><paramref name="truncateHeadToSize"/> is zero.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="truncateFrontToSize"/> is zero.</exception>
     public async Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, byte[] value, bool refreshTtl, uint? ttlSeconds = null, uint? truncateFrontToSize = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));

--- a/src/Momento.Sdk/Incubating/SimpleCacheClient.cs
+++ b/src/Momento.Sdk/Incubating/SimpleCacheClient.cs
@@ -123,7 +123,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// Set the dictionary field to a value with a given time to live (TTL) seconds.
     ///
     /// Creates the dictionary if it does not exist and sets the TTL.
-    /// If the dictionary already exists and `refreshTtl` is <see langword="true" />, then update the
+    /// If the dictionary already exists and `refreshTtl` is <see langword="true"/>, then update the
     /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
     /// </summary>
     /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
@@ -133,7 +133,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="refreshTtl">Update the dictionary TTL if the dictionary already exists.</param>
     /// <param name="ttlSeconds">TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `field`, `value` is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `field`, `value` is <see langword="null"/>.</exception>
     public async Task<CacheDictionarySetResponse> DictionarySetAsync(string cacheName, string dictionaryName, byte[] field, byte[] value, bool refreshTtl, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -144,7 +144,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionarySetAsync(cacheName, dictionaryName, field, value, refreshTtl, ttlSeconds);
     }
 
-    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], bool, uint?)" />
+    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], bool, uint?)"/>
     public async Task<CacheDictionarySetResponse> DictionarySetAsync(string cacheName, string dictionaryName, string field, string value, bool refreshTtl, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -155,7 +155,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionarySetAsync(cacheName, dictionaryName, field, value, refreshTtl, ttlSeconds);
     }
 
-    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], bool, uint?)" />
+    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], bool, uint?)"/>
     public async Task<CacheDictionarySetResponse> DictionarySetAsync(string cacheName, string dictionaryName, string field, byte[] value, bool refreshTtl, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -173,7 +173,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="dictionaryName">The dictionary to lookup.</param>
     /// <param name="field">The field in the dictionary to lookup.</param>
     /// <returns>Task representing the status of the get operation and the associated value.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `field` is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `field` is <see langword="null"/>.</exception>
     public async Task<CacheDictionaryGetResponse> DictionaryGetAsync(string cacheName, string dictionaryName, byte[] field)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -183,7 +183,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionaryGetAsync(cacheName, dictionaryName, field);
     }
 
-    /// <inheritdoc cref="DictionaryGetAsync(string, string, byte[])" />
+    /// <inheritdoc cref="DictionaryGetAsync(string, string, byte[])"/>
     public async Task<CacheDictionaryGetResponse> DictionaryGetAsync(string cacheName, string dictionaryName, string field)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -197,7 +197,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// Set several dictionary field-value pairs in the cache.
     ///
     /// Creates the dictionary if it does not exist and sets the TTL.
-    /// If the dictionary already exists and `refreshTtl` is <see langword="true" />, then update the
+    /// If the dictionary already exists and `refreshTtl` is <see langword="true"/>, then update the
     /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
     /// </summary>
     /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
@@ -206,7 +206,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="refreshTtl">Update the dictionary TTL if the dictionary already exists.</param>
     /// <param name="ttlSeconds">TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `items` is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `items` is <see langword="null"/>.</exception>
     public async Task<CacheDictionarySetBatchResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<byte[], byte[]>> items, bool refreshTtl, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -217,7 +217,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionarySetBatchAsync(cacheName, dictionaryName, items, refreshTtl, ttlSeconds);
     }
 
-    /// <inheritdoc cref="DictionarySetBatchAsync(string, string, IEnumerable{KeyValuePair{byte[], byte[]}}, bool, uint?)" />
+    /// <inheritdoc cref="DictionarySetBatchAsync(string, string, IEnumerable{KeyValuePair{byte[], byte[]}}, bool, uint?)"/>
     public async Task<CacheDictionarySetBatchResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, string>> items, bool refreshTtl, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -228,7 +228,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionarySetBatchAsync(cacheName, dictionaryName, items, refreshTtl, ttlSeconds);
     }
 
-    /// <inheritdoc cref="DictionarySetBatchAsync(string, string, IEnumerable{KeyValuePair{byte[], byte[]}}, bool, uint?)" />
+    /// <inheritdoc cref="DictionarySetBatchAsync(string, string, IEnumerable{KeyValuePair{byte[], byte[]}}, bool, uint?)"/>
     public async Task<CacheDictionarySetBatchResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, byte[]>> items, bool refreshTtl, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -246,7 +246,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="dictionaryName">The dictionary to lookup.</param>
     /// <param name="fields">The fields in the dictionary to lookup.</param>
     /// <returns>Task representing the status and associated value for each field.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `fields` is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `fields` is <see langword="null"/>.</exception>
     public async Task<CacheDictionaryGetBatchResponse> DictionaryGetBatchAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -257,7 +257,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionaryGetBatchAsync(cacheName, dictionaryName, fields);
     }
 
-    /// <inheritdoc cref="DictionaryGetBatchAsync(string, string, IEnumerable{byte[]})" />
+    /// <inheritdoc cref="DictionaryGetBatchAsync(string, string, IEnumerable{byte[]})"/>
     public async Task<CacheDictionaryGetBatchResponse> DictionaryGetBatchAsync(string cacheName, string dictionaryName, IEnumerable<string> fields)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -274,7 +274,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
     /// <param name="dictionaryName">The dictionary to fetch.</param>
     /// <returns>Task representing with the status of the fetch operation and the associated dictionary.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName` is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName` is <see langword="null"/>.</exception>
     public async Task<CacheDictionaryFetchResponse> DictionaryFetchAsync(string cacheName, string dictionaryName)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -291,7 +291,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="cacheName">Name of the cache to delete the dictionary from.</param>
     /// <param name="dictionaryName">Name of the dictionary to delete.</param>
     /// <returns>Task representing the result of the delete operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `dictionaryName` is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName` or `dictionaryName` is <see langword="null"/>.</exception>
     public async Task<CacheDictionaryDeleteResponse> DictionaryDeleteAsync(string cacheName, string dictionaryName)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -309,7 +309,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="dictionaryName">Name of the dictionary to remove the field from.</param>
     /// <param name="field">Name of the field to remove from the dictionary.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `field` is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `field` is <see langword="null"/>.</exception>
     public async Task<CacheDictionaryRemoveFieldResponse> DictionaryRemoveFieldAsync(string cacheName, string dictionaryName, byte[] field)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -319,7 +319,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionaryRemoveFieldAsync(cacheName, dictionaryName, field);
     }
 
-    /// <inheritdoc cref="DictionaryRemoveFieldAsync(string, string, byte[])" />
+    /// <inheritdoc cref="DictionaryRemoveFieldAsync(string, string, byte[])"/>
     public async Task<CacheDictionaryRemoveFieldResponse> DictionaryRemoveFieldAsync(string cacheName, string dictionaryName, string field)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -338,7 +338,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="dictionaryName">Name of the dictionary to remove the field from.</param>
     /// <param name="fields">Name of the fields to remove from the dictionary.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `fields` is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `fields` is <see langword="null"/>.</exception>
     public async Task<CacheDictionaryRemoveFieldsResponse> DictionaryRemoveFieldsAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -349,7 +349,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionaryRemoveFieldsAsync(cacheName, dictionaryName, fields);
     }
 
-    /// <inheritdoc cref="DictionaryRemoveFieldsAsync(string, string, IEnumerable{byte[]})" />
+    /// <inheritdoc cref="DictionaryRemoveFieldsAsync(string, string, IEnumerable{byte[]})"/>
     public async Task<CacheDictionaryRemoveFieldsResponse> DictionaryRemoveFieldsAsync(string cacheName, string dictionaryName, IEnumerable<string> fields)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -367,7 +367,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// of the element passed in and the elements of the set.
     ///
     /// Creates the set if it does not exist and sets the TTL.
-    /// If the set already exists and `refreshTtl` is <see langword="true" />, then update the
+    /// If the set already exists and `refreshTtl` is <see langword="true"/>, then update the
     /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
     /// </summary>
     /// <param name="cacheName">Name of the cache to store the set in.</param>
@@ -376,7 +376,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="refreshTtl">Update `setName`'s TTL if it already exists.</param>
     /// <param name="ttlSeconds">TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `element` is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `element` is <see langword="null"/>.</exception>
     public async Task<CacheSetAddResponse> SetAddAsync(string cacheName, string setName, byte[] element, bool refreshTtl, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -386,7 +386,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.SetAddAsync(cacheName, setName, element, refreshTtl, ttlSeconds);
     }
 
-    /// <inheritdoc cref="SetAddAsync(string, string, byte[], bool, uint?)" />
+    /// <inheritdoc cref="SetAddAsync(string, string, byte[], bool, uint?)"/>
     public async Task<CacheSetAddResponse> SetAddAsync(string cacheName, string setName, string element, bool refreshTtl, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -403,7 +403,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// of the elements passed in and the elements of the set.
     ///
     /// Creates the set if it does not exist and sets the TTL.
-    /// If the set already exists and `refreshTtl` is <see langword="true" />, then update the
+    /// If the set already exists and `refreshTtl` is <see langword="true"/>, then update the
     /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
     /// </summary>
     /// <param name="cacheName">Name of the cache to store the set in.</param>
@@ -412,7 +412,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="refreshTtl">Update `setName`'s TTL if it already exists.</param>
     /// <param name="ttlSeconds">TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `elements` is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `elements` is <see langword="null"/>.</exception>
     public async Task<CacheSetAddBatchResponse> SetAddBatchAsync(string cacheName, string setName, IEnumerable<byte[]> elements, bool refreshTtl, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -423,7 +423,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.SetAddBatchAsync(cacheName, setName, elements, refreshTtl, ttlSeconds);
     }
 
-    /// <inheritdoc cref="SetAddBatchAsync(string, string, IEnumerable{byte[]}, bool, uint?)" />
+    /// <inheritdoc cref="SetAddBatchAsync(string, string, IEnumerable{byte[]}, bool, uint?)"/>
     public async Task<CacheSetAddBatchResponse> SetAddBatchAsync(string cacheName, string setName, IEnumerable<string> elements, bool refreshTtl, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -443,7 +443,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="setName">The set to remove the element from.</param>
     /// <param name="element">The data to remove from the set.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `element` is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `element` is <see langword="null"/>.</exception>
     public async Task<CacheSetRemoveElementResponse> SetRemoveElementAsync(string cacheName, string setName, byte[] element)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -453,7 +453,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.SetRemoveElementAsync(cacheName, setName, element);
     }
 
-    /// <inheritdoc cref="SetRemoveElementAsync(string, string, byte[])" />
+    /// <inheritdoc cref="SetRemoveElementAsync(string, string, byte[])"/>
     public async Task<CacheSetRemoveElementResponse> SetRemoveElementAsync(string cacheName, string setName, string element)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -472,7 +472,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="setName">The set to remove the elements from.</param>
     /// <param name="elements">The data to remove from the set.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `elements` is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `elements` is <see langword="null"/>.</exception>
     public async Task<CacheSetRemoveElementsResponse> SetRemoveElementsAsync(string cacheName, string setName, IEnumerable<byte[]> elements)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -483,7 +483,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.SetRemoveElementsAsync(cacheName, setName, elements);
     }
 
-    /// <inheritdoc cref="SetRemoveElementsAsync(string, string, IEnumerable{byte[]})" />
+    /// <inheritdoc cref="SetRemoveElementsAsync(string, string, IEnumerable{byte[]})"/>
     public async Task<CacheSetRemoveElementsResponse> SetRemoveElementsAsync(string cacheName, string setName, IEnumerable<string> elements)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -500,7 +500,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
     /// <param name="setName">The set to fetch.</param>
     /// <returns>Task representing with the status of the fetch operation and the associated set.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `setName` is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName` or `setName` is <see langword="null"/>.</exception>
     public async Task<CacheSetFetchResponse> SetFetchAsync(string cacheName, string setName)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -517,7 +517,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="cacheName">Name of the cache to delete the set from.</param>
     /// <param name="setName">Name of the set to delete.</param>
     /// <returns>Task representing the result of the delete operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `setName` is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName` or `setName` is <see langword="null"/>.</exception>
     public async Task<CacheSetDeleteResponse> SetDeleteAsync(string cacheName, string setName)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -530,7 +530,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// Push a value to the beginning of a list.
     ///
     /// Creates the list if it does not exist and sets the TTL.
-    /// If the list already exists and `refreshTtl` is <see langword="true" />, then update the
+    /// If the list already exists and `refreshTtl` is <see langword="true"/>, then update the
     /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
     /// </summary>
     /// <param name="cacheName">Name of the cache to store the list in.</param>
@@ -540,7 +540,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="ttlSeconds">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <param name="truncateBackToSize">Ensure the list does not exceed this length. Remove excess from the end of the list. Must be a positive number.</param>
     /// <returns>Task representing the result of the push operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` or `value` is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` or `value` is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentOutOfRangeException">`truncateTailToSize` is zero.</exception>
     public async Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, byte[] value, bool refreshTtl, uint? ttlSeconds = null, uint? truncateBackToSize = null)
     {
@@ -552,7 +552,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.ListPushFrontAsync(cacheName, listName, value, refreshTtl, ttlSeconds);
     }
 
-    /// <inheritdoc cref="ListPushFrontAsync(string, string, byte[], bool, uint?, uint?)" />
+    /// <inheritdoc cref="ListPushFrontAsync(string, string, byte[], bool, uint?, uint?)"/>
     public async Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, string value, bool refreshTtl, uint? ttlSeconds = null, uint? truncateBackToSize = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -567,7 +567,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// Push a value to the end of a list.
     ///
     /// Creates the list if it does not exist and sets the TTL.
-    /// If the list already exists and `refreshTtl` is <see langword="true" />, then update the
+    /// If the list already exists and `refreshTtl` is <see langword="true"/>, then update the
     /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
     /// </summary>
     /// <param name="cacheName">Name of the cache to store the list in.</param>
@@ -577,7 +577,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="ttlSeconds">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <param name="truncateFrontToSize">Ensure the list does not exceed this length. Remove excess from the beginning of the list. Must be a positive number.</param>
     /// <returns>Task representing the result of the push operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` or `value` is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` or `value` is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentOutOfRangeException">`truncateHeadToSize` is zero.</exception>
     public async Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, byte[] value, bool refreshTtl, uint? ttlSeconds = null, uint? truncateFrontToSize = null)
     {
@@ -589,7 +589,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.ListPushBackAsync(cacheName, listName, value, refreshTtl, ttlSeconds);
     }
 
-    /// <inheritdoc cref="ListPushBackAsync(string, string, byte[], bool, uint?, uint?)" />
+    /// <inheritdoc cref="ListPushBackAsync(string, string, byte[], bool, uint?, uint?)"/>
     public async Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, string value, bool refreshTtl, uint? ttlSeconds = null, uint? truncateFrontToSize = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -606,7 +606,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="cacheName">Name of the cache to read the list from.</param>
     /// <param name="listName">The list to pop from.</param>
     /// <returns>Task representing the status and associated value for the pop operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` is <see langword="null"/>.</exception>
     public async Task<CacheListPopFrontResponse> ListPopFrontAsync(string cacheName, string listName)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -621,7 +621,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="cacheName">Name of the cache to read the list from.</param>
     /// <param name="listName">The list to pop from.</param>
     /// <returns>Task representing the status and associated value for the pop operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` is <see langword="null"/>.</exception>
     public async Task<CacheListPopBackResponse> ListPopBackAsync(string cacheName, string listName)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -636,7 +636,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
     /// <param name="listName">The list to fetch.</param>
     /// <returns>Task representing with the status of the fetch operation and the associated list.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` is <see langword="null"/>.</exception>
     public async Task<CacheListFetchResponse> ListFetchAsync(string cacheName, string listName)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));

--- a/src/Momento.Sdk/Incubating/SimpleCacheClient.cs
+++ b/src/Momento.Sdk/Incubating/SimpleCacheClient.cs
@@ -144,21 +144,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionarySetAsync(cacheName, dictionaryName, field, value, refreshTtl, ttlSeconds);
     }
 
-    /// <summary>
-    /// Set the dictionary field to a value with a given time to live (TTL) seconds.
-    ///
-    /// Creates the dictionary if it does not exist and sets the TTL.
-    /// If the dictionary already exists and `refreshTtl` is `true`, then update the
-    /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
-    /// <param name="dictionaryName">The dictionary to set.</param>
-    /// <param name="field">The field in the dictionary to set.</param>
-    /// <param name="value">The value to be stored.</param>
-    /// <param name="refreshTtl">Update the dictionary TTL if the dictionary already exists.</param>
-    /// <param name="ttlSeconds">TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `field`, `value` is `null`.</exception>
+    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], bool, uint?)" />
     public async Task<CacheDictionarySetResponse> DictionarySetAsync(string cacheName, string dictionaryName, string field, string value, bool refreshTtl, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -169,21 +155,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionarySetAsync(cacheName, dictionaryName, field, value, refreshTtl, ttlSeconds);
     }
 
-    /// <summary>
-    /// Set the dictionary field to a value with a given time to live (TTL) seconds.
-    ///
-    /// Creates the dictionary if it does not exist and sets the TTL.
-    /// If the dictionary already exists and `refreshTtl` is `true`, then update the
-    /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
-    /// <param name="dictionaryName">The dictionary to set.</param>
-    /// <param name="field">The field in the dictionary to set.</param>
-    /// <param name="value">The value to be stored.</param>
-    /// <param name="refreshTtl">Update the dictionary TTL if the dictionary already exists.</param>
-    /// <param name="ttlSeconds">TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `field`, `value` is `null`.</exception>
+    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], bool, uint?)" />
     public async Task<CacheDictionarySetResponse> DictionarySetAsync(string cacheName, string dictionaryName, string field, byte[] value, bool refreshTtl, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -211,14 +183,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionaryGetAsync(cacheName, dictionaryName, field);
     }
 
-    /// <summary>
-    /// Get the cache value stored for the given dictionary and field.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-    /// <param name="dictionaryName">The dictionary to lookup.</param>
-    /// <param name="field">The field in the dictionary to lookup.</param>
-    /// <returns>Task representing the status of the get operation and the associated value.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `field` is `null`.</exception>
+    /// <inheritdoc cref="DictionaryGetAsync(string, string, byte[])" />
     public async Task<CacheDictionaryGetResponse> DictionaryGetAsync(string cacheName, string dictionaryName, string field)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -252,20 +217,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionarySetBatchAsync(cacheName, dictionaryName, items, refreshTtl, ttlSeconds);
     }
 
-    /// <summary>
-    /// Set several dictionary field-value pairs in the cache.
-    ///
-    /// Creates the dictionary if it does not exist and sets the TTL.
-    /// If the dictionary already exists and `refreshTtl` is `true`, then update the
-    /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
-    /// <param name="dictionaryName">The dictionary to set.</param>
-    /// <param name="items">The field-value pairs in the dictionary to set.</param>
-    /// <param name="refreshTtl">Update the dictionary TTL if the dictionary already exists.</param>
-    /// <param name="ttlSeconds">TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `items` is `null`.</exception>
+    /// <inheritdoc cref="DictionarySetBatchAsync(string, string, IEnumerable{KeyValuePair{byte[], byte[]}}, bool, uint?)" />
     public async Task<CacheDictionarySetBatchResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, string>> items, bool refreshTtl, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -276,20 +228,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionarySetBatchAsync(cacheName, dictionaryName, items, refreshTtl, ttlSeconds);
     }
 
-    /// <summary>
-    /// Set several dictionary field-value pairs in the cache.
-    ///
-    /// Creates the dictionary if it does not exist and sets the TTL.
-    /// If the dictionary already exists and `refreshTtl` is `true`, then update the
-    /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
-    /// <param name="dictionaryName">The dictionary to set.</param>
-    /// <param name="items">The field-value pairs in the dictionary to set.</param>
-    /// <param name="refreshTtl">Update the dictionary TTL if the dictionary already exists.</param>
-    /// <param name="ttlSeconds">TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `items` is `null`.</exception>
+    /// <inheritdoc cref="DictionarySetBatchAsync(string, string, IEnumerable{KeyValuePair{byte[], byte[]}}, bool, uint?)" />
     public async Task<CacheDictionarySetBatchResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<string, byte[]>> items, bool refreshTtl, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -318,14 +257,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionaryGetBatchAsync(cacheName, dictionaryName, fields);
     }
 
-    /// <summary>
-    /// Get several values from a dictionary.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
-    /// <param name="dictionaryName">The dictionary to lookup.</param>
-    /// <param name="fields">The fields in the dictionary to lookup.</param>
-    /// <returns>Task representing the status and associated value for each field.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `fields` is `null`.</exception>
+    /// <inheritdoc cref="DictionaryGetBatchAsync(string, string, IEnumerable{byte[]})" />
     public async Task<CacheDictionaryGetBatchResponse> DictionaryGetBatchAsync(string cacheName, string dictionaryName, IEnumerable<string> fields)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -387,16 +319,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionaryRemoveFieldAsync(cacheName, dictionaryName, field);
     }
 
-    /// <summary>
-    /// Remove a field from a dictionary.
-    ///
-    /// Performs a no-op if `dictionaryName` or `field` does not exist.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to lookup the dictionary in.</param>
-    /// <param name="dictionaryName">Name of the dictionary to remove the field from.</param>
-    /// <param name="field">Name of the field to remove from the dictionary.</param>
-    /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `field` is `null`.</exception>
+    /// <inheritdoc cref="DictionaryRemoveFieldAsync(string, string, byte[])" />
     public async Task<CacheDictionaryRemoveFieldResponse> DictionaryRemoveFieldAsync(string cacheName, string dictionaryName, string field)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -426,16 +349,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.DictionaryRemoveFieldsAsync(cacheName, dictionaryName, fields);
     }
 
-    /// <summary>
-    /// Remove fields from a dictionary.
-    ///
-    /// Performs a no-op if `dictionaryName` or a particular field does not exist.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to lookup the dictionary in.</param>
-    /// <param name="dictionaryName">Name of the dictionary to remove the field from.</param>
-    /// <param name="fields">Name of the fields to remove from the dictionary.</param>
-    /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `fields` is `null`.</exception>
+    /// <inheritdoc cref="DictionaryRemoveFieldsAsync(string, string, IEnumerable{byte[]})" />
     public async Task<CacheDictionaryRemoveFieldsResponse> DictionaryRemoveFieldsAsync(string cacheName, string dictionaryName, IEnumerable<string> fields)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -472,23 +386,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.SetAddAsync(cacheName, setName, element, refreshTtl, ttlSeconds);
     }
 
-    /// <summary>
-    /// Add an element to a set in the cache.
-    ///
-    /// After this operation, the set will contain the union
-    /// of the element passed in and the elements of the set.
-    ///
-    /// Creates the set if it does not exist and sets the TTL.
-    /// If the set already exists and `refreshTtl` is `true`, then update the
-    /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to store the set in.</param>
-    /// <param name="setName">The set to add the element to.</param>
-    /// <param name="element">The data to add to the set.</param>
-    /// <param name="refreshTtl">Update `setName`'s TTL if it already exists.</param>
-    /// <param name="ttlSeconds">TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `element` is `null`.</exception>
+    /// <inheritdoc cref="SetAddAsync(string, string, byte[], bool, uint?)" />
     public async Task<CacheSetAddResponse> SetAddAsync(string cacheName, string setName, string element, bool refreshTtl, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -525,23 +423,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.SetAddBatchAsync(cacheName, setName, elements, refreshTtl, ttlSeconds);
     }
 
-    /// <summary>
-    /// Add several elements to a set in the cache.
-    ///
-    /// After this operation, the set will contain the union
-    /// of the elements passed in and the elements of the set.
-    ///
-    /// Creates the set if it does not exist and sets the TTL.
-    /// If the set already exists and `refreshTtl` is `true`, then update the
-    /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to store the set in.</param>
-    /// <param name="setName">The set to add elements to.</param>
-    /// <param name="elements">The data to add to the set.</param>
-    /// <param name="refreshTtl">Update `setName`'s TTL if it already exists.</param>
-    /// <param name="ttlSeconds">TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `elements` is `null`.</exception>
+    /// <inheritdoc cref="SetAddBatchAsync(string, string, IEnumerable{byte[]}, bool, uint?)" />
     public async Task<CacheSetAddBatchResponse> SetAddBatchAsync(string cacheName, string setName, IEnumerable<string> elements, bool refreshTtl, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -571,16 +453,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.SetRemoveElementAsync(cacheName, setName, element);
     }
 
-    /// <summary>
-    /// Remove an element from a set.
-    ///
-    /// Performs a no-op if `setName` or `element` does not exist.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to lookup the set in.</param>
-    /// <param name="setName">The set to remove the element from.</param>
-    /// <param name="element">The data to remove from the set.</param>
-    /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `element` is `null`.</exception>
+    /// <inheritdoc cref="SetRemoveElementAsync(string, string, byte[])" />
     public async Task<CacheSetRemoveElementResponse> SetRemoveElementAsync(string cacheName, string setName, string element)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -610,16 +483,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.SetRemoveElementsAsync(cacheName, setName, elements);
     }
 
-    /// <summary>
-    /// Remove elements from a set.
-    ///
-    /// Performs a no-op if `setName` or any of `elements` do not exist.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to lookup the set in.</param>
-    /// <param name="setName">The set to remove the elements from.</param>
-    /// <param name="elements">The data to remove from the set.</param>
-    /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `elements` is `null`.</exception>
+    /// <inheritdoc cref="SetRemoveElementsAsync(string, string, IEnumerable{byte[]})" />
     public async Task<CacheSetRemoveElementsResponse> SetRemoveElementsAsync(string cacheName, string setName, IEnumerable<string> elements)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -688,22 +552,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.ListPushFrontAsync(cacheName, listName, value, refreshTtl, ttlSeconds);
     }
 
-    /// <summary>
-    /// Push a value to the beginning of a list.
-    ///
-    /// Creates the list if it does not exist and sets the TTL.
-    /// If the list already exists and `refreshTtl` is `true`, then update the
-    /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to store the list in.</param>
-    /// <param name="listName">The list to push the value on.</param>
-    /// <param name="value">The value to push to the front of the list.</param>
-    /// <param name="refreshTtl">Update `listName`'s TTL if it already exists.</param>
-    /// <param name="ttlSeconds">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <param name="truncateBackToSize">Ensure the list does not exceed this length. Remove excess from the end of the list. Must be a positive number.</param>
-    /// <returns>Task representing the result of the push operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` or `value` is `null`.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">`truncateTailToSize` is zero.</exception>
+    /// <inheritdoc cref="ListPushFrontAsync(string, string, byte[], bool, uint?, uint?)" />
     public async Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, string value, bool refreshTtl, uint? ttlSeconds = null, uint? truncateBackToSize = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -740,22 +589,7 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.ListPushBackAsync(cacheName, listName, value, refreshTtl, ttlSeconds);
     }
 
-    /// <summary>
-    /// Push a value to the end of a list.
-    ///
-    /// Creates the list if it does not exist and sets the TTL.
-    /// If the list already exists and `refreshTtl` is `true`, then update the
-    /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
-    /// </summary>
-    /// <param name="cacheName">Name of the cache to store the list in.</param>
-    /// <param name="listName">The list to push the value on.</param>
-    /// <param name="value">The value to push to the back of the list.</param>
-    /// <param name="refreshTtl">Update `listName`'s TTL if it already exists.</param>
-    /// <param name="ttlSeconds">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
-    /// <param name="truncateFrontToSize">Ensure the list does not exceed this length. Remove excess from the beginning of the list. Must be a positive number.</param>
-    /// <returns>Task representing the result of the push operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` or `value` is `null`.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">`truncateHeadToSize` is zero.</exception>
+    /// <inheritdoc cref="ListPushBackAsync(string, string, byte[], bool, uint?, uint?)" />
     public async Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, string value, bool refreshTtl, uint? ttlSeconds = null, uint? truncateFrontToSize = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));

--- a/src/Momento.Sdk/Incubating/SimpleCacheClient.cs
+++ b/src/Momento.Sdk/Incubating/SimpleCacheClient.cs
@@ -123,7 +123,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// Set the dictionary field to a value with a given time to live (TTL) seconds.
     ///
     /// Creates the dictionary if it does not exist and sets the TTL.
-    /// If the dictionary already exists and `refreshTtl` is `true`, then update the
+    /// If the dictionary already exists and `refreshTtl` is <see langword="true" />, then update the
     /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
     /// </summary>
     /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
@@ -133,7 +133,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="refreshTtl">Update the dictionary TTL if the dictionary already exists.</param>
     /// <param name="ttlSeconds">TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `field`, `value` is `null`.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `field`, `value` is <see langword="null" />.</exception>
     public async Task<CacheDictionarySetResponse> DictionarySetAsync(string cacheName, string dictionaryName, byte[] field, byte[] value, bool refreshTtl, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -173,7 +173,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="dictionaryName">The dictionary to lookup.</param>
     /// <param name="field">The field in the dictionary to lookup.</param>
     /// <returns>Task representing the status of the get operation and the associated value.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `field` is `null`.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `field` is <see langword="null" />.</exception>
     public async Task<CacheDictionaryGetResponse> DictionaryGetAsync(string cacheName, string dictionaryName, byte[] field)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -197,7 +197,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// Set several dictionary field-value pairs in the cache.
     ///
     /// Creates the dictionary if it does not exist and sets the TTL.
-    /// If the dictionary already exists and `refreshTtl` is `true`, then update the
+    /// If the dictionary already exists and `refreshTtl` is <see langword="true" />, then update the
     /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
     /// </summary>
     /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
@@ -206,7 +206,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="refreshTtl">Update the dictionary TTL if the dictionary already exists.</param>
     /// <param name="ttlSeconds">TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `items` is `null`.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `items` is <see langword="null" />.</exception>
     public async Task<CacheDictionarySetBatchResponse> DictionarySetBatchAsync(string cacheName, string dictionaryName, IEnumerable<KeyValuePair<byte[], byte[]>> items, bool refreshTtl, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -246,7 +246,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="dictionaryName">The dictionary to lookup.</param>
     /// <param name="fields">The fields in the dictionary to lookup.</param>
     /// <returns>Task representing the status and associated value for each field.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `fields` is `null`.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `fields` is <see langword="null" />.</exception>
     public async Task<CacheDictionaryGetBatchResponse> DictionaryGetBatchAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -274,7 +274,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
     /// <param name="dictionaryName">The dictionary to fetch.</param>
     /// <returns>Task representing with the status of the fetch operation and the associated dictionary.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName` is `null`.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName` is <see langword="null" />.</exception>
     public async Task<CacheDictionaryFetchResponse> DictionaryFetchAsync(string cacheName, string dictionaryName)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -291,7 +291,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="cacheName">Name of the cache to delete the dictionary from.</param>
     /// <param name="dictionaryName">Name of the dictionary to delete.</param>
     /// <returns>Task representing the result of the delete operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `dictionaryName` is `null`.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName` or `dictionaryName` is <see langword="null" />.</exception>
     public async Task<CacheDictionaryDeleteResponse> DictionaryDeleteAsync(string cacheName, string dictionaryName)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -309,7 +309,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="dictionaryName">Name of the dictionary to remove the field from.</param>
     /// <param name="field">Name of the field to remove from the dictionary.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `field` is `null`.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `field` is <see langword="null" />.</exception>
     public async Task<CacheDictionaryRemoveFieldResponse> DictionaryRemoveFieldAsync(string cacheName, string dictionaryName, byte[] field)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -338,7 +338,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="dictionaryName">Name of the dictionary to remove the field from.</param>
     /// <param name="fields">Name of the fields to remove from the dictionary.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `fields` is `null`.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName`, `dictionaryName`, `fields` is <see langword="null" />.</exception>
     public async Task<CacheDictionaryRemoveFieldsResponse> DictionaryRemoveFieldsAsync(string cacheName, string dictionaryName, IEnumerable<byte[]> fields)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -367,7 +367,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// of the element passed in and the elements of the set.
     ///
     /// Creates the set if it does not exist and sets the TTL.
-    /// If the set already exists and `refreshTtl` is `true`, then update the
+    /// If the set already exists and `refreshTtl` is <see langword="true" />, then update the
     /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
     /// </summary>
     /// <param name="cacheName">Name of the cache to store the set in.</param>
@@ -376,7 +376,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="refreshTtl">Update `setName`'s TTL if it already exists.</param>
     /// <param name="ttlSeconds">TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `element` is `null`.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `element` is <see langword="null" />.</exception>
     public async Task<CacheSetAddResponse> SetAddAsync(string cacheName, string setName, byte[] element, bool refreshTtl, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -403,7 +403,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// of the elements passed in and the elements of the set.
     ///
     /// Creates the set if it does not exist and sets the TTL.
-    /// If the set already exists and `refreshTtl` is `true`, then update the
+    /// If the set already exists and `refreshTtl` is <see langword="true" />, then update the
     /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
     /// </summary>
     /// <param name="cacheName">Name of the cache to store the set in.</param>
@@ -412,7 +412,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="refreshTtl">Update `setName`'s TTL if it already exists.</param>
     /// <param name="ttlSeconds">TTL for the set in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `elements` is `null`.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `elements` is <see langword="null" />.</exception>
     public async Task<CacheSetAddBatchResponse> SetAddBatchAsync(string cacheName, string setName, IEnumerable<byte[]> elements, bool refreshTtl, uint? ttlSeconds = null)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -443,7 +443,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="setName">The set to remove the element from.</param>
     /// <param name="element">The data to remove from the set.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `element` is `null`.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `element` is <see langword="null" />.</exception>
     public async Task<CacheSetRemoveElementResponse> SetRemoveElementAsync(string cacheName, string setName, byte[] element)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -472,7 +472,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="setName">The set to remove the elements from.</param>
     /// <param name="elements">The data to remove from the set.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `elements` is `null`.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName`, `setName`, `elements` is <see langword="null" />.</exception>
     public async Task<CacheSetRemoveElementsResponse> SetRemoveElementsAsync(string cacheName, string setName, IEnumerable<byte[]> elements)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -500,7 +500,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
     /// <param name="setName">The set to fetch.</param>
     /// <returns>Task representing with the status of the fetch operation and the associated set.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `setName` is `null`.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName` or `setName` is <see langword="null" />.</exception>
     public async Task<CacheSetFetchResponse> SetFetchAsync(string cacheName, string setName)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -517,7 +517,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="cacheName">Name of the cache to delete the set from.</param>
     /// <param name="setName">Name of the set to delete.</param>
     /// <returns>Task representing the result of the delete operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `setName` is `null`.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName` or `setName` is <see langword="null" />.</exception>
     public async Task<CacheSetDeleteResponse> SetDeleteAsync(string cacheName, string setName)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -530,7 +530,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// Push a value to the beginning of a list.
     ///
     /// Creates the list if it does not exist and sets the TTL.
-    /// If the list already exists and `refreshTtl` is `true`, then update the
+    /// If the list already exists and `refreshTtl` is <see langword="true" />, then update the
     /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
     /// </summary>
     /// <param name="cacheName">Name of the cache to store the list in.</param>
@@ -540,7 +540,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="ttlSeconds">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <param name="truncateBackToSize">Ensure the list does not exceed this length. Remove excess from the end of the list. Must be a positive number.</param>
     /// <returns>Task representing the result of the push operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` or `value` is `null`.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` or `value` is <see langword="null" />.</exception>
     /// <exception cref="ArgumentOutOfRangeException">`truncateTailToSize` is zero.</exception>
     public async Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, byte[] value, bool refreshTtl, uint? ttlSeconds = null, uint? truncateBackToSize = null)
     {
@@ -567,7 +567,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// Push a value to the end of a list.
     ///
     /// Creates the list if it does not exist and sets the TTL.
-    /// If the list already exists and `refreshTtl` is `true`, then update the
+    /// If the list already exists and `refreshTtl` is <see langword="true" />, then update the
     /// TTL to `ttlSeconds`, otherwise leave the TTL unchanged.
     /// </summary>
     /// <param name="cacheName">Name of the cache to store the list in.</param>
@@ -577,7 +577,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="ttlSeconds">TTL for the list in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.</param>
     /// <param name="truncateFrontToSize">Ensure the list does not exceed this length. Remove excess from the beginning of the list. Must be a positive number.</param>
     /// <returns>Task representing the result of the push operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` or `value` is `null`.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` or `value` is <see langword="null" />.</exception>
     /// <exception cref="ArgumentOutOfRangeException">`truncateHeadToSize` is zero.</exception>
     public async Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, byte[] value, bool refreshTtl, uint? ttlSeconds = null, uint? truncateFrontToSize = null)
     {
@@ -606,7 +606,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="cacheName">Name of the cache to read the list from.</param>
     /// <param name="listName">The list to pop from.</param>
     /// <returns>Task representing the status and associated value for the pop operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` is `null`.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` is <see langword="null" />.</exception>
     public async Task<CacheListPopFrontResponse> ListPopFrontAsync(string cacheName, string listName)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -621,7 +621,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="cacheName">Name of the cache to read the list from.</param>
     /// <param name="listName">The list to pop from.</param>
     /// <returns>Task representing the status and associated value for the pop operation.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` is `null`.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` is <see langword="null" />.</exception>
     public async Task<CacheListPopBackResponse> ListPopBackAsync(string cacheName, string listName)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
@@ -636,7 +636,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
     /// <param name="listName">The list to fetch.</param>
     /// <returns>Task representing with the status of the fetch operation and the associated list.</returns>
-    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` is `null`.</exception>
+    /// <exception cref="ArgumentNullException">Any of `cacheName` or `listName` is <see langword="null" />.</exception>
     public async Task<CacheListFetchResponse> ListFetchAsync(string cacheName, string listName)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));

--- a/src/Momento.Sdk/Incubating/SimpleCacheClient.cs
+++ b/src/Momento.Sdk/Incubating/SimpleCacheClient.cs
@@ -121,11 +121,12 @@ public class SimpleCacheClient : ISimpleCacheClient
 
     /// <summary>
     /// Set the dictionary field to a value with a given time to live (TTL) seconds.
-    ///
-    /// Creates the dictionary if it does not exist and sets the TTL.
-    /// If the dictionary already exists and <paramref name="refreshTtl"/> is <see langword="true"/>, then update the
-    /// TTL to <paramref name="ttlSeconds"/>, otherwise leave the TTL unchanged.
     /// </summary>
+    /// <remark>
+    /// Creates the data structure if it does not exist and sets the TTL.
+    /// If the data structure already exists and <paramref name="refreshTtl"/> is <see langword="true"/>,
+    /// then update the TTL to <paramref name="ttlSeconds"/>, otherwise leave the TTL unchanged.
+    /// </remark>
     /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
     /// <param name="dictionaryName">The dictionary to set.</param>
     /// <param name="field">The field in the dictionary to set.</param>
@@ -195,11 +196,8 @@ public class SimpleCacheClient : ISimpleCacheClient
 
     /// <summary>
     /// Set several dictionary field-value pairs in the cache.
-    ///
-    /// Creates the dictionary if it does not exist and sets the TTL.
-    /// If the dictionary already exists and <paramref name="refreshTtl"/> is <see langword="true"/>, then update the
-    /// TTL to <paramref name="ttlSeconds"/>, otherwise leave the TTL unchanged.
     /// </summary>
+    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], bool, uint?)" path="/remark"/>
     /// <param name="cacheName">Name of the cache to store the dictionary in.</param>
     /// <param name="dictionaryName">The dictionary to set.</param>
     /// <param name="items">The field-value pairs in the dictionary to set.</param>
@@ -365,11 +363,8 @@ public class SimpleCacheClient : ISimpleCacheClient
     ///
     /// After this operation, the set will contain the union
     /// of the element passed in and the elements of the set.
-    ///
-    /// Creates the set if it does not exist and sets the TTL.
-    /// If the set already exists and <paramref name="refreshTtl"/> is <see langword="true"/>, then update the
-    /// TTL to <paramref name="ttlSeconds"/>, otherwise leave the TTL unchanged.
     /// </summary>
+    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], bool, uint?)" path="/remark"/>
     /// <param name="cacheName">Name of the cache to store the set in.</param>
     /// <param name="setName">The set to add the element to.</param>
     /// <param name="element">The data to add to the set.</param>
@@ -401,11 +396,8 @@ public class SimpleCacheClient : ISimpleCacheClient
     ///
     /// After this operation, the set will contain the union
     /// of the elements passed in and the elements of the set.
-    ///
-    /// Creates the set if it does not exist and sets the TTL.
-    /// If the set already exists and <paramref name="refreshTtl"/> is <see langword="true"/>, then update the
-    /// TTL to <paramref name="ttlSeconds"/>, otherwise leave the TTL unchanged.
     /// </summary>
+    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], bool, uint?)" path="/remark"/>
     /// <param name="cacheName">Name of the cache to store the set in.</param>
     /// <param name="setName">The set to add elements to.</param>
     /// <param name="elements">The data to add to the set.</param>
@@ -528,11 +520,8 @@ public class SimpleCacheClient : ISimpleCacheClient
 
     /// <summary>
     /// Push a value to the beginning of a list.
-    ///
-    /// Creates the list if it does not exist and sets the TTL.
-    /// If the list already exists and <paramref name="refreshTtl"/> is <see langword="true"/>, then update the
-    /// TTL to <paramref name="ttlSeconds"/>, otherwise leave the TTL unchanged.
     /// </summary>
+    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], bool, uint?)" path="/remark"/>
     /// <param name="cacheName">Name of the cache to store the list in.</param>
     /// <param name="listName">The list to push the value on.</param>
     /// <param name="value">The value to push to the front of the list.</param>
@@ -565,11 +554,8 @@ public class SimpleCacheClient : ISimpleCacheClient
 
     /// <summary>
     /// Push a value to the end of a list.
-    ///
-    /// Creates the list if it does not exist and sets the TTL.
-    /// If the list already exists and <paramref name="refreshTtl"/> is <see langword="true"/>, then update the
-    /// TTL to <paramref name="ttlSeconds"/>, otherwise leave the TTL unchanged.
     /// </summary>
+    /// <inheritdoc cref="DictionarySetAsync(string, string, byte[], byte[], bool, uint?)" path="/remark"/>
     /// <param name="cacheName">Name of the cache to store the list in.</param>
     /// <param name="listName">The list to push the value on.</param>
     /// <param name="value">The value to push to the back of the list.</param>

--- a/src/Momento.Sdk/Internal/Utils.cs
+++ b/src/Momento.Sdk/Internal/Utils.cs
@@ -119,27 +119,27 @@ namespace Momento.Sdk.Internal
         public static class ToByteStringExtensions
         {
             /// <summary>
-            /// Convert a byte array to a `ByteString`
+            /// Convert a byte array to a <see cref="ByteString"/>
             /// </summary>
             /// <param name="byteArray">The byte array to convert.</param>
-            /// <returns>The byte array as a `ByteString`</returns>
+            /// <returns>The byte array as a <see cref="ByteString"/></returns>
             public static ByteString ToByteString(this byte[] byteArray)
             {
                 return ByteString.CopyFrom(byteArray);
             }
 
             /// <summary>
-            /// Convert a UTF-8 string to a `ByteString`.
+            /// Convert a UTF-8 string to a <see cref="ByteString"/>.
             /// </summary>
             /// <param name="str">The string to convert.</param>
-            /// <returns>The string as a `ByteString`.</returns>
+            /// <returns>The string as a <see cref="ByteString"/>.</returns>
             public static ByteString ToByteString(this string str)
             {
                 return ByteString.CopyFromUtf8(str);
             }
 
             /// <summary>
-            /// Convert a byte array to a singleton `ByteString` array
+            /// Convert a byte array to a singleton <see cref="ByteString"/> array
             /// </summary>
             /// <param name="byteArray">The byte array to convert.</param>
             /// <returns>A length one array containing the converted byte array.</returns>
@@ -149,7 +149,7 @@ namespace Momento.Sdk.Internal
             }
 
             /// <summary>
-            /// Convert a UTF-8 string to a singleton `ByteString` array.
+            /// Convert a UTF-8 string to a singleton <see cref="ByteString"/> array.
             /// </summary>
             /// <param name="str">The string to convert.</param>
             /// <returns>A length one array containing the converted string.</returns>
@@ -162,7 +162,7 @@ namespace Momento.Sdk.Internal
             /// Convert an enumerable of byte arrays to <code>IEnumerable&lt;ByteString&gt;</code>
             /// </summary>
             /// <param name="enumerable">The enumerable to convert.</param>
-            /// <returns>An enumerable over `ByteString`s.</returns>
+            /// <returns>An enumerable over <see cref="ByteString"/>s.</returns>
             public static IEnumerable<ByteString> ToEnumerableByteString(this IEnumerable<byte[]> enumerable)
             {
                 return enumerable.Select(item => item.ToByteString());
@@ -178,8 +178,8 @@ namespace Momento.Sdk.Internal
         public static class ByteArrayDictionaryExtensions
         {
             /// <summary>
-            /// DWIM equality implementation for dictionaries. cf `SetEquals`.
-            /// https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.hashset-1.setequals?view=net-6.0
+            /// DWIM equality implementation for dictionaries, cf <see href="https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.hashset-1.setequals?view=net-6.0">SetEquals</see>.
+            /// 
             ///
             /// Tests whether the dictionaries contain the same content as opposed to the same
             /// references.

--- a/src/Momento.Sdk/Internal/Utils.cs
+++ b/src/Momento.Sdk/Internal/Utils.cs
@@ -36,7 +36,7 @@ namespace Momento.Sdk.Internal
         /// </summary>
         /// <param name="argument">The instance to check for <see langword="null"/>.</param>
         /// <param name="paramName">The name of the object to propagate to the exception.</param>
-        /// <exception cref="ArgumentNullException">`argument` is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="argument"/> is <see langword="null"/>.</exception>
         public static void ArgumentNotNull(object? argument, string paramName)
         {
             if (argument == null)
@@ -52,7 +52,7 @@ namespace Momento.Sdk.Internal
         /// <typeparam name="TValue">Value type.</typeparam>
         /// <param name="argument">Enumerable to check for <see langword="null"/> keys/values.</param>
         /// <param name="paramName">Name of the enumerable to propagate to the exception.</param>
-        /// <exception cref="ArgumentNullException">Any of `argument` keys or values is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">Any of <paramref name="argument"/> keys or values is <see langword="null"/>.</exception>
         public static void KeysAndValuesNotNull<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> argument, string paramName)
         {
             if (argument.Any(kv => kv.Key == null || kv.Value == null))
@@ -67,7 +67,7 @@ namespace Momento.Sdk.Internal
         /// <typeparam name="T">Enumerable element type.</typeparam>
         /// <param name="argument">Enumerable to check for <see langword="null"/> elements.</param>
         /// <param name="paramName">Name of the eumerable to propagate to the exception.</param>
-        /// <exception cref="ArgumentNullException">Any of `argument` elements is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentNullException">Any of <paramref name="argument"/> elements is <see langword="null"/>.</exception>
         public static void ElementsNotNull<T>(IEnumerable<T> argument, string paramName)
         {
             if (argument.Any(value => value == null))
@@ -81,7 +81,7 @@ namespace Momento.Sdk.Internal
         /// </summary>
         /// <param name="argument">The integer to zero test.</param>
         /// <param name="paramName">Name of the integer to propagate to the exception.</param>
-        /// <exception cref="ArgumentOutOfRangeException">`argument` is zero.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="argument"/> is zero.</exception>
         public static void ArgumentStrictlyPositive(uint? argument, string paramName)
         {
             if (argument == 0)

--- a/src/Momento.Sdk/Internal/Utils.cs
+++ b/src/Momento.Sdk/Internal/Utils.cs
@@ -32,11 +32,11 @@ namespace Momento.Sdk.Internal
         public static byte[] Utf8ToByteArray(string s) => Encoding.UTF8.GetBytes(s);
 
         /// <summary>
-        /// Throw an exception if the argument is null.
+        /// Throw an exception if the argument is <see langword="null" />.
         /// </summary>
-        /// <param name="argument">The instance to check for null.</param>
+        /// <param name="argument">The instance to check for <see langword="null" />.</param>
         /// <param name="paramName">The name of the object to propagate to the exception.</param>
-        /// <exception cref="ArgumentNullException">`argument` is `null`.</exception>
+        /// <exception cref="ArgumentNullException">`argument` is <see langword="null" />.</exception>
         public static void ArgumentNotNull(object? argument, string paramName)
         {
             if (argument == null)
@@ -46,13 +46,13 @@ namespace Momento.Sdk.Internal
         }
 
         /// <summary>
-        /// Throw an exception if any of the keys or values is null.
+        /// Throw an exception if any of the keys or values is <see langword="null" />.
         /// </summary>
         /// <typeparam name="TKey">Key type.</typeparam>
         /// <typeparam name="TValue">Value type.</typeparam>
-        /// <param name="argument">Enumerable to check for null keys/values.</param>
+        /// <param name="argument">Enumerable to check for <see langword="null" /> keys/values.</param>
         /// <param name="paramName">Name of the enumerable to propagate to the exception.</param>
-        /// <exception cref="ArgumentNullException">Any of `argument` keys or values is `null`.</exception>
+        /// <exception cref="ArgumentNullException">Any of `argument` keys or values is <see langword="null" />.</exception>
         public static void KeysAndValuesNotNull<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> argument, string paramName)
         {
             if (argument.Any(kv => kv.Key == null || kv.Value == null))
@@ -62,12 +62,12 @@ namespace Momento.Sdk.Internal
         }
 
         /// <summary>
-        /// Throw an exception if any of the elements of the enumerable is null.
+        /// Throw an exception if any of the elements of the enumerable is <see langword="null" />.
         /// </summary>
         /// <typeparam name="T">Enumerable element type.</typeparam>
-        /// <param name="argument">Enumerable to check for null elements.</param>
+        /// <param name="argument">Enumerable to check for <see langword="null" /> elements.</param>
         /// <param name="paramName">Name of the eumerable to propagate to the exception.</param>
-        /// <exception cref="ArgumentNullException">Any of `argument` elements is `null`.</exception>
+        /// <exception cref="ArgumentNullException">Any of `argument` elements is <see langword="null" />.</exception>
         public static void ElementsNotNull<T>(IEnumerable<T> argument, string paramName)
         {
             if (argument.Any(value => value == null))
@@ -168,11 +168,7 @@ namespace Momento.Sdk.Internal
                 return enumerable.Select(item => item.ToByteString());
             }
 
-            /// <summary>
-            /// Convert an enumerable of strings to <code>IEnumerable&lt;ByteString&gt;</code>
-            /// </summary>
-            /// <param name="enumerable">The enumerable to convert.</param>
-            /// <returns>An enumerable over `ByteString`s.</returns>
+            /// <inheritdoc cref="ToEnumerableByteString(IEnumerable{byte[]})" />
             public static IEnumerable<ByteString> ToEnumerableByteString(this IEnumerable<string> enumerable)
             {
                 return enumerable.Select(item => item.ToByteString());
@@ -190,7 +186,7 @@ namespace Momento.Sdk.Internal
             /// </summary>
             /// <param name="dictionary">LHS to compare</param>
             /// <param name="other">RHS to compare</param>
-            /// <returns>`true` if the dictionaries contain the same content.</returns>
+            /// <returns><see langword="true" /> if the dictionaries contain the same content.</returns>
             public static bool DictionaryEquals(this Dictionary<byte[], byte[]> dictionary, Dictionary<byte[], byte[]> other)
             {
                 if (dictionary == null && other == null)

--- a/src/Momento.Sdk/Internal/Utils.cs
+++ b/src/Momento.Sdk/Internal/Utils.cs
@@ -32,11 +32,11 @@ namespace Momento.Sdk.Internal
         public static byte[] Utf8ToByteArray(string s) => Encoding.UTF8.GetBytes(s);
 
         /// <summary>
-        /// Throw an exception if the argument is <see langword="null" />.
+        /// Throw an exception if the argument is <see langword="null"/>.
         /// </summary>
-        /// <param name="argument">The instance to check for <see langword="null" />.</param>
+        /// <param name="argument">The instance to check for <see langword="null"/>.</param>
         /// <param name="paramName">The name of the object to propagate to the exception.</param>
-        /// <exception cref="ArgumentNullException">`argument` is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">`argument` is <see langword="null"/>.</exception>
         public static void ArgumentNotNull(object? argument, string paramName)
         {
             if (argument == null)
@@ -46,13 +46,13 @@ namespace Momento.Sdk.Internal
         }
 
         /// <summary>
-        /// Throw an exception if any of the keys or values is <see langword="null" />.
+        /// Throw an exception if any of the keys or values is <see langword="null"/>.
         /// </summary>
         /// <typeparam name="TKey">Key type.</typeparam>
         /// <typeparam name="TValue">Value type.</typeparam>
-        /// <param name="argument">Enumerable to check for <see langword="null" /> keys/values.</param>
+        /// <param name="argument">Enumerable to check for <see langword="null"/> keys/values.</param>
         /// <param name="paramName">Name of the enumerable to propagate to the exception.</param>
-        /// <exception cref="ArgumentNullException">Any of `argument` keys or values is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Any of `argument` keys or values is <see langword="null"/>.</exception>
         public static void KeysAndValuesNotNull<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> argument, string paramName)
         {
             if (argument.Any(kv => kv.Key == null || kv.Value == null))
@@ -62,12 +62,12 @@ namespace Momento.Sdk.Internal
         }
 
         /// <summary>
-        /// Throw an exception if any of the elements of the enumerable is <see langword="null" />.
+        /// Throw an exception if any of the elements of the enumerable is <see langword="null"/>.
         /// </summary>
         /// <typeparam name="T">Enumerable element type.</typeparam>
-        /// <param name="argument">Enumerable to check for <see langword="null" /> elements.</param>
+        /// <param name="argument">Enumerable to check for <see langword="null"/> elements.</param>
         /// <param name="paramName">Name of the eumerable to propagate to the exception.</param>
-        /// <exception cref="ArgumentNullException">Any of `argument` elements is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentNullException">Any of `argument` elements is <see langword="null"/>.</exception>
         public static void ElementsNotNull<T>(IEnumerable<T> argument, string paramName)
         {
             if (argument.Any(value => value == null))
@@ -168,7 +168,7 @@ namespace Momento.Sdk.Internal
                 return enumerable.Select(item => item.ToByteString());
             }
 
-            /// <inheritdoc cref="ToEnumerableByteString(IEnumerable{byte[]})" />
+            /// <inheritdoc cref="ToEnumerableByteString(IEnumerable{byte[]})"/>
             public static IEnumerable<ByteString> ToEnumerableByteString(this IEnumerable<string> enumerable)
             {
                 return enumerable.Select(item => item.ToByteString());
@@ -186,7 +186,7 @@ namespace Momento.Sdk.Internal
             /// </summary>
             /// <param name="dictionary">LHS to compare</param>
             /// <param name="other">RHS to compare</param>
-            /// <returns><see langword="true" /> if the dictionaries contain the same content.</returns>
+            /// <returns><see langword="true"/> if the dictionaries contain the same content.</returns>
             public static bool DictionaryEquals(this Dictionary<byte[], byte[]> dictionary, Dictionary<byte[], byte[]> other)
             {
                 if (dictionary == null && other == null)

--- a/src/Momento.Sdk/Internal/Utils.cs
+++ b/src/Momento.Sdk/Internal/Utils.cs
@@ -159,7 +159,7 @@ namespace Momento.Sdk.Internal
             }
 
             /// <summary>
-            /// Convert an enumerable of byte arrays to <code>IEnumerable&lt;ByteString&gt;</code>
+            /// Convert an enumerable of byte arrays to <see cref="IEnumerable{ByteString}"/>
             /// </summary>
             /// <param name="enumerable">The enumerable to convert.</param>
             /// <returns>An enumerable over <see cref="ByteString"/>s.</returns>


### PR DESCRIPTION
Use the breadth of .NET documentation tags where appropriate. The previous code had markdown in places which will not display correctly in Intellisense.

This also reduces a lot of copy-paste documentation by using `inheritdoc`.

Closes #127