### PR TITLE
feat: implement `ListLength`

### DIFF
--- a/src/Momento.Sdk/Incubating/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk/Incubating/Internal/ScsDataClient.cs
@@ -473,4 +473,23 @@ internal sealed class ScsDataClient : ScsDataClientBase
         }
         return new CacheListRemoveAllResponse();
     }
+
+    public async Task<CacheListLengthResponse> ListLengthAsync(string cacheName, string listName)
+    {
+        _ListLengthRequest request = new()
+        {
+            ListName = listName.ToByteString(),
+        };
+        _ListLengthResponse response;
+
+        try
+        {
+            response = await this.grpcManager.Client.ListLengthAsync(request, MetadataWithCache(cacheName), deadline: CalculateDeadline());
+        }
+        catch (Exception e)
+        {
+            throw CacheExceptionMapper.Convert(e);
+        }
+        return new CacheListLengthResponse(response);
+    }
 }

--- a/src/Momento.Sdk/Incubating/Responses/CacheListLengthResponse.cs
+++ b/src/Momento.Sdk/Incubating/Responses/CacheListLengthResponse.cs
@@ -1,0 +1,16 @@
+using Momento.Protos.CacheClient;
+
+namespace Momento.Sdk.Incubating.Responses;
+
+public class CacheListLengthResponse
+{
+    public int Length { get; private set; } = 0;
+
+    public CacheListLengthResponse(_ListLengthResponse response)
+    {
+        if (response.ListCase == _ListLengthResponse.ListOneofCase.Found)
+        {
+            Length = checked((int)response.Found.Length);
+        }
+    }
+}

--- a/src/Momento.Sdk/Incubating/SimpleCacheClient.cs
+++ b/src/Momento.Sdk/Incubating/SimpleCacheClient.cs
@@ -658,6 +658,23 @@ public class SimpleCacheClient : ISimpleCacheClient
         return await this.dataClient.ListRemoveAllAsync(cacheName, listName, value);
     }
 
+    /// <summary>
+    /// Calculate the length of a list in the cache.
+    ///
+    /// A list that does not exist is interpreted to have length 0.
+    /// </summary>
+    /// <param name="cacheName">Name of the cache to perform the lookup in.</param>
+    /// <param name="listName">The list to calculate length.</param>
+    /// <returns>Task representing the length of the list.</returns>
+    /// <exception cref="ArgumentNullException">Any of <paramref name="cacheName"/> or <paramref name="listName"/> is <see langword="null"/>.</exception>
+    public async Task<CacheListLengthResponse> ListLengthAsync(string cacheName, string listName)
+    {
+        Utils.ArgumentNotNull(cacheName, nameof(cacheName));
+        Utils.ArgumentNotNull(listName, nameof(listName));
+
+        return await this.dataClient.ListLengthAsync(cacheName, listName);
+    }
+
     /// <inheritdoc />
     public void Dispose()
     {

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
@@ -562,4 +562,32 @@ public class ListTest : TestBase
         await client.ListRemoveAllAsync(cacheName, listName, Utils.NewGuidString());
         Assert.Equal(CacheGetStatus.MISS, (await client.ListFetchAsync(cacheName, listName)).Status);
     }
+
+    [Theory]
+    [InlineData(null, "my-list")]
+    [InlineData("cache", null)]
+    public async Task ListLengthAsync_NullChecks_ThrowsException(string cacheName, string listName)
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.ListLengthAsync(cacheName, listName));
+    }
+
+    [Fact]
+    public async Task ListLengthAsync_ListIsMissing_HappyPath()
+    {
+        var lengthResponse = await client.ListLengthAsync(cacheName, Utils.NewGuidString());
+        Assert.Equal(0, lengthResponse.Length);
+    }
+
+    [Fact]
+    public async Task ListLengthAsync_ListIsFound_HappyPath()
+    {
+        var listName = Utils.NewGuidString();
+        foreach (var i in Enumerable.Range(0, 10))
+        {
+            await client.ListPushBackAsync(cacheName, listName, Utils.NewGuidByteArray(), false);
+        }
+
+        var lengthResponse = await client.ListLengthAsync(cacheName, listName);
+        Assert.Equal(10, lengthResponse.Length);
+    }
 }


### PR DESCRIPTION
Implements, tests, and documents `ListLengthAsync`. A list not in the
cache is interpreted to have length 0.

Closes #133