### PR TITLE
chore: rename `ListRemoveAll` to `ListRemoveValue`

### DIFF
--- a/src/Momento.Sdk/Incubating/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk/Incubating/Internal/ScsDataClient.cs
@@ -447,17 +447,17 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheListFetchResponse(response);
     }
 
-    public async Task<CacheListRemoveAllResponse> ListRemoveAllAsync(string cacheName, string listName, byte[] value)
+    public async Task<CacheListRemoveAllResponse> ListRemoveValueAsync(string cacheName, string listName, byte[] value)
     {
-        return await ListRemoveAllAsync(cacheName, listName, value.ToByteString());
+        return await ListRemoveValueAsync(cacheName, listName, value.ToByteString());
     }
 
-    public async Task<CacheListRemoveAllResponse> ListRemoveAllAsync(string cacheName, string listName, string value)
+    public async Task<CacheListRemoveAllResponse> ListRemoveValueAsync(string cacheName, string listName, string value)
     {
-        return await ListRemoveAllAsync(cacheName, listName, value.ToByteString());
+        return await ListRemoveValueAsync(cacheName, listName, value.ToByteString());
     }
 
-    public async Task<CacheListRemoveAllResponse> ListRemoveAllAsync(string cacheName, string listName, ByteString value)
+    public async Task<CacheListRemoveAllResponse> ListRemoveValueAsync(string cacheName, string listName, ByteString value)
     {
         _ListRemoveRequest request = new()
         {

--- a/src/Momento.Sdk/Incubating/SimpleCacheClient.cs
+++ b/src/Momento.Sdk/Incubating/SimpleCacheClient.cs
@@ -639,23 +639,23 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="value">The value to completely remove from the list.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
     /// <exception cref="ArgumentNullException">Any of <paramref name="cacheName"/>, <paramref name="listName"/>, or <paramref name="value"/> is <see langword="null"/>.</exception>
-    public async Task<CacheListRemoveAllResponse> ListRemoveAllAsync(string cacheName, string listName, byte[] value)
+    public async Task<CacheListRemoveAllResponse> ListRemoveValueAsync(string cacheName, string listName, byte[] value)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
         Utils.ArgumentNotNull(listName, nameof(listName));
         Utils.ArgumentNotNull(value, nameof(value));
 
-        return await this.dataClient.ListRemoveAllAsync(cacheName, listName, value);
+        return await this.dataClient.ListRemoveValueAsync(cacheName, listName, value);
     }
 
-    /// <inheritdoc cref="ListRemoveAllAsync(string, string, byte[])"/>
-    public async Task<CacheListRemoveAllResponse> ListRemoveAllAsync(string cacheName, string listName, string value)
+    /// <inheritdoc cref="ListRemoveValueAsync(string, string, byte[])"/>
+    public async Task<CacheListRemoveAllResponse> ListRemoveValueAsync(string cacheName, string listName, string value)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
         Utils.ArgumentNotNull(listName, nameof(listName));
         Utils.ArgumentNotNull(value, nameof(value));
 
-        return await this.dataClient.ListRemoveAllAsync(cacheName, listName, value);
+        return await this.dataClient.ListRemoveValueAsync(cacheName, listName, value);
     }
 
     /// <inheritdoc />

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
@@ -513,13 +513,13 @@ public class ListTest : TestBase
     [InlineData(null, "my-list", new byte[] { 0x00 })]
     [InlineData("cache", null, new byte[] { 0x00 })]
     [InlineData("cache", "my-list", null)]
-    public async Task ListRemoveAllAsync_NullChecksByteArray_ThrowsException(string cacheName, string listName, byte[] value)
+    public async Task ListRemoveValueAsync_NullChecksByteArray_ThrowsException(string cacheName, string listName, byte[] value)
     {
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.ListRemoveAllAsync(cacheName, listName, value));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.ListRemoveValueAsync(cacheName, listName, value));
     }
 
     [Fact]
-    public async Task ListRemoveAllAsync_ValueIsByteArray_HappyPath()
+    public async Task ListRemoveValueAsync_ValueIsByteArray_HappyPath()
     {
         var listName = Utils.NewGuidString();
         var list = new List<byte[]>() { Utils.NewGuidByteArray(), Utils.NewGuidByteArray(), Utils.NewGuidByteArray() };
@@ -535,7 +535,7 @@ public class ListTest : TestBase
         await client.ListPushBackAsync(cacheName, listName, valueOfInterest, false);
 
         // Remove value of interest
-        await client.ListRemoveAllAsync(cacheName, listName, valueOfInterest);
+        await client.ListRemoveValueAsync(cacheName, listName, valueOfInterest);
 
         // Test not there
         var cachedList = (await client.ListFetchAsync(cacheName, listName)).ByteArrayList!;
@@ -543,7 +543,7 @@ public class ListTest : TestBase
     }
 
     [Fact]
-    public async Task ListRemoveAllAsync_ValueIsByteArray_ValueNotPresentNoop()
+    public async Task ListRemoveValueAsync_ValueIsByteArray_ValueNotPresentNoop()
     {
         var listName = Utils.NewGuidString();
         var list = new List<byte[]>() { Utils.NewGuidByteArray(), Utils.NewGuidByteArray(), Utils.NewGuidByteArray() };
@@ -553,18 +553,18 @@ public class ListTest : TestBase
             await client.ListPushBackAsync(cacheName, listName, value, false);
         }
 
-        await client.ListRemoveAllAsync(cacheName, listName, Utils.NewGuidByteArray());
+        await client.ListRemoveValueAsync(cacheName, listName, Utils.NewGuidByteArray());
 
         var cachedList = (await client.ListFetchAsync(cacheName, listName)).ByteArrayList!;
         Assert.True(list.ListEquals(cachedList));
     }
 
     [Fact]
-    public async Task ListRemoveAllAsync_ValueIsByteArray_ListNotThereNoop()
+    public async Task ListRemoveValueAsync_ValueIsByteArray_ListNotThereNoop()
     {
         var listName = Utils.NewGuidString();
         Assert.Equal(CacheGetStatus.MISS, (await client.ListFetchAsync(cacheName, listName)).Status);
-        await client.ListRemoveAllAsync(cacheName, listName, Utils.NewGuidByteArray());
+        await client.ListRemoveValueAsync(cacheName, listName, Utils.NewGuidByteArray());
         Assert.Equal(CacheGetStatus.MISS, (await client.ListFetchAsync(cacheName, listName)).Status);
     }
 
@@ -572,13 +572,13 @@ public class ListTest : TestBase
     [InlineData(null, "my-list", "")]
     [InlineData("cache", null, "")]
     [InlineData("cache", "my-list", null)]
-    public async Task ListRemoveAllAsync_NullChecksString_ThrowsException(string cacheName, string listName, string value)
+    public async Task ListRemoveValueAsync_NullChecksString_ThrowsException(string cacheName, string listName, string value)
     {
-        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.ListRemoveAllAsync(cacheName, listName, value));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await client.ListRemoveValueAsync(cacheName, listName, value));
     }
 
     [Fact]
-    public async Task ListRemoveAllAsync_ValueIsString_HappyPath()
+    public async Task ListRemoveValueAsync_ValueIsString_HappyPath()
     {
         var listName = Utils.NewGuidString();
         var list = new List<string>() { Utils.NewGuidString(), Utils.NewGuidString(), Utils.NewGuidString() };
@@ -594,7 +594,7 @@ public class ListTest : TestBase
         await client.ListPushBackAsync(cacheName, listName, valueOfInterest, false);
 
         // Remove value of interest
-        await client.ListRemoveAllAsync(cacheName, listName, valueOfInterest);
+        await client.ListRemoveValueAsync(cacheName, listName, valueOfInterest);
 
         // Test not there
         var cachedList = (await client.ListFetchAsync(cacheName, listName)).StringList()!;
@@ -602,7 +602,7 @@ public class ListTest : TestBase
     }
 
     [Fact]
-    public async Task ListRemoveAllAsync_ValueIsByteString_ValueNotPresentNoop()
+    public async Task ListRemoveValueAsync_ValueIsByteString_ValueNotPresentNoop()
     {
         var listName = Utils.NewGuidString();
         var list = new List<string>() { Utils.NewGuidString(), Utils.NewGuidString(), Utils.NewGuidString() };
@@ -612,18 +612,18 @@ public class ListTest : TestBase
             await client.ListPushBackAsync(cacheName, listName, value, false);
         }
 
-        await client.ListRemoveAllAsync(cacheName, listName, Utils.NewGuidString());
+        await client.ListRemoveValueAsync(cacheName, listName, Utils.NewGuidString());
 
         var cachedList = (await client.ListFetchAsync(cacheName, listName)).StringList()!;
         Assert.True(list.SequenceEqual(cachedList));
     }
 
     [Fact]
-    public async Task ListRemoveAllAsync_ValueIsString_ListNotThereNoop()
+    public async Task ListRemoveValueAsync_ValueIsString_ListNotThereNoop()
     {
         var listName = Utils.NewGuidString();
         Assert.Equal(CacheGetStatus.MISS, (await client.ListFetchAsync(cacheName, listName)).Status);
-        await client.ListRemoveAllAsync(cacheName, listName, Utils.NewGuidString());
+        await client.ListRemoveValueAsync(cacheName, listName, Utils.NewGuidString());
         Assert.Equal(CacheGetStatus.MISS, (await client.ListFetchAsync(cacheName, listName)).Status);
     }
 }


### PR DESCRIPTION
Renaming for clarity: `ListRemoveValue` removes all instances of `value` from a list.