### PR TITLE
feat: release from release branch

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -41,23 +41,3 @@ jobs:
         run: |
           dotnet test tests/Integration/Momento.Sdk.Incubating.Tests
         shell: bash
-
-      - name: Set release
-        id: semrel
-        uses: go-semantic-release/action@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          allow-initial-development-versions: true
-          force-bump-patch-version: true
-
-      - name: Pack and Publish
-        run: |
-          set -x
-          pushd src/Momento.Sdk
-            VERSION="${{ steps.semrel.outputs.version }}"
-            echo "version: ${VERSION}"
-            dotnet build --configuration Release
-            dotnet pack -c Release -p:Version=${VERSION}
-            dotnet nuget push ./bin/Release/Momento.Sdk.${VERSION}.nupkg --source https://api.nuget.org/v3/index.json --api-key=${{secrets.NUGET_API_KEY}}
-          popd
-        shell: bash

--- a/.github/workflows/manual-release.yaml
+++ b/.github/workflows/manual-release.yaml
@@ -1,0 +1,20 @@
+name: Manual Release
+# Triggers a merge from main->release, which will then trigger a release
+# from the release branch.
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  merge-to-release-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Merge main -> release
+        uses: devmasx/merge-branch@master
+        with:
+          type: now
+          from_branch: main
+          target_branch: release
+          github_token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}

--- a/.github/workflows/on-push-to-release-branch.yaml
+++ b/.github/workflows/on-push-to-release-branch.yaml
@@ -1,0 +1,63 @@
+name: On push Main
+
+on:
+  push:
+    branches: [release]
+
+jobs:
+  build_csharp:
+    runs-on: ubuntu-latest
+    env:
+      TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      TEST_CACHE_NAME: client-sdk-csharp
+
+    steps:
+      - name: Get current time
+        uses: gerred/actions/current-time@master
+        id: current-time
+
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "6.0.x"
+
+      - name: Build
+        run: |
+          dotnet build
+        shell: bash
+
+      - name: Unit Test
+        run: |
+          dotnet test tests/Unit/Momento.Sdk.Tests
+        shell: bash
+
+      - name: Integration Test
+        run: |
+          dotnet test tests/Integration/Momento.Sdk.Tests
+        shell: bash
+
+      - name: Incubating Integration Test
+        run: |
+          dotnet test tests/Integration/Momento.Sdk.Incubating.Tests
+        shell: bash
+
+      - name: Set release
+        id: semrel
+        uses: go-semantic-release/action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-initial-development-versions: true
+          force-bump-patch-version: true
+
+      - name: Pack and Publish
+        run: |
+          set -x
+          pushd src/Momento.Sdk
+            VERSION="${{ steps.semrel.outputs.version }}"
+            echo "version: ${VERSION}"
+            dotnet build --configuration Release
+            dotnet pack -c Release -p:Version=${VERSION}
+            dotnet nuget push ./bin/Release/Momento.Sdk.${VERSION}.nupkg --source https://api.nuget.org/v3/index.json --api-key=${{secrets.NUGET_API_KEY}}
+          popd
+        shell: bash


### PR DESCRIPTION
Updates the `cd.yaml` job so that we don't do a release on
every commit.  Introduces a new manual release job that we
can use to decide when to do a release.  Releases will come
from the `release` branch rather than the `main` branch.
