### PR TITLE
fix: remove value response name and list push length

### DIFF
--- a/src/Momento.Sdk/Incubating/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk/Incubating/Internal/ScsDataClient.cs
@@ -447,17 +447,17 @@ internal sealed class ScsDataClient : ScsDataClientBase
         return new CacheListFetchResponse(response);
     }
 
-    public async Task<CacheListRemoveAllResponse> ListRemoveValueAsync(string cacheName, string listName, byte[] value)
+    public async Task<CacheListRemoveValueResponse> ListRemoveValueAsync(string cacheName, string listName, byte[] value)
     {
         return await ListRemoveValueAsync(cacheName, listName, value.ToByteString());
     }
 
-    public async Task<CacheListRemoveAllResponse> ListRemoveValueAsync(string cacheName, string listName, string value)
+    public async Task<CacheListRemoveValueResponse> ListRemoveValueAsync(string cacheName, string listName, string value)
     {
         return await ListRemoveValueAsync(cacheName, listName, value.ToByteString());
     }
 
-    public async Task<CacheListRemoveAllResponse> ListRemoveValueAsync(string cacheName, string listName, ByteString value)
+    public async Task<CacheListRemoveValueResponse> ListRemoveValueAsync(string cacheName, string listName, ByteString value)
     {
         _ListRemoveRequest request = new()
         {
@@ -473,6 +473,6 @@ internal sealed class ScsDataClient : ScsDataClientBase
         {
             throw CacheExceptionMapper.Convert(e);
         }
-        return new CacheListRemoveAllResponse();
+        return new CacheListRemoveValueResponse();
     }
 }

--- a/src/Momento.Sdk/Incubating/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk/Incubating/Internal/ScsDataClient.cs
@@ -335,17 +335,15 @@ internal sealed class ScsDataClient : ScsDataClientBase
 
     public async Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, byte[] value, bool refreshTtl, uint? truncateBackToSize = null, uint? ttlSeconds = null)
     {
-        await SendListPushFrontAsync(cacheName, listName, value.ToByteString(), refreshTtl, truncateBackToSize, ttlSeconds);
-        return new CacheListPushFrontResponse();
+        return await SendListPushFrontAsync(cacheName, listName, value.ToByteString(), refreshTtl, truncateBackToSize, ttlSeconds);
     }
 
     public async Task<CacheListPushFrontResponse> ListPushFrontAsync(string cacheName, string listName, string value, bool refreshTtl, uint? truncateBackToSize = null, uint? ttlSeconds = null)
     {
-        await SendListPushFrontAsync(cacheName, listName, value.ToByteString(), refreshTtl, truncateBackToSize, ttlSeconds);
-        return new CacheListPushFrontResponse();
+        return await SendListPushFrontAsync(cacheName, listName, value.ToByteString(), refreshTtl, truncateBackToSize, ttlSeconds);
     }
 
-    public async Task SendListPushFrontAsync(string cacheName, string listName, ByteString value, bool refreshTtl, uint? truncateBackToSize = null, uint? ttlSeconds = null)
+    public async Task<CacheListPushFrontResponse> SendListPushFrontAsync(string cacheName, string listName, ByteString value, bool refreshTtl, uint? truncateBackToSize = null, uint? ttlSeconds = null)
     {
         _ListPushFrontRequest request = new()
         {
@@ -355,15 +353,17 @@ internal sealed class ScsDataClient : ScsDataClientBase
             RefreshTtl = refreshTtl,
             TtlMilliseconds = TtlSecondsToMilliseconds(ttlSeconds)
         };
+        _ListPushFrontResponse response;
 
         try
         {
-            await this.grpcManager.Client.ListPushFrontAsync(request, MetadataWithCache(cacheName), deadline: CalculateDeadline());
+            response = await this.grpcManager.Client.ListPushFrontAsync(request, MetadataWithCache(cacheName), deadline: CalculateDeadline());
         }
         catch (Exception e)
         {
             throw CacheExceptionMapper.Convert(e);
         }
+        return new CacheListPushFrontResponse(response);
     }
 
     public async Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, byte[] value, bool refreshTtl, uint? truncateFrontToSize = null, uint? ttlSeconds = null)

--- a/src/Momento.Sdk/Incubating/Internal/ScsDataClient.cs
+++ b/src/Momento.Sdk/Incubating/Internal/ScsDataClient.cs
@@ -368,17 +368,15 @@ internal sealed class ScsDataClient : ScsDataClientBase
 
     public async Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, byte[] value, bool refreshTtl, uint? truncateFrontToSize = null, uint? ttlSeconds = null)
     {
-        await SendListPushBackAsync(cacheName, listName, value.ToByteString(), refreshTtl, truncateFrontToSize, ttlSeconds);
-        return new CacheListPushBackResponse();
+        return await SendListPushBackAsync(cacheName, listName, value.ToByteString(), refreshTtl, truncateFrontToSize, ttlSeconds);
     }
 
     public async Task<CacheListPushBackResponse> ListPushBackAsync(string cacheName, string listName, string value, bool refreshTtl, uint? truncateFrontToSize = null, uint? ttlSeconds = null)
     {
-        await SendListPushBackAsync(cacheName, listName, value.ToByteString(), refreshTtl, truncateFrontToSize, ttlSeconds);
-        return new CacheListPushBackResponse();
+        return await SendListPushBackAsync(cacheName, listName, value.ToByteString(), refreshTtl, truncateFrontToSize, ttlSeconds);
     }
 
-    public async Task SendListPushBackAsync(string cacheName, string listName, ByteString value, bool refreshTtl, uint? truncateFrontToSize = null, uint? ttlSeconds = null)
+    public async Task<CacheListPushBackResponse> SendListPushBackAsync(string cacheName, string listName, ByteString value, bool refreshTtl, uint? truncateFrontToSize = null, uint? ttlSeconds = null)
     {
         _ListPushBackRequest request = new()
         {
@@ -388,15 +386,17 @@ internal sealed class ScsDataClient : ScsDataClientBase
             RefreshTtl = refreshTtl,
             TtlMilliseconds = TtlSecondsToMilliseconds(ttlSeconds)
         };
+        _ListPushBackResponse response;
 
         try
         {
-            await this.grpcManager.Client.ListPushBackAsync(request, MetadataWithCache(cacheName), deadline: CalculateDeadline());
+            response = await this.grpcManager.Client.ListPushBackAsync(request, MetadataWithCache(cacheName), deadline: CalculateDeadline());
         }
         catch (Exception e)
         {
             throw CacheExceptionMapper.Convert(e);
         }
+        return new CacheListPushBackResponse(response);
     }
 
     public async Task<CacheListPopFrontResponse> ListPopFrontAsync(string cacheName, string listName)

--- a/src/Momento.Sdk/Incubating/Responses/CacheListPushBackResponse.cs
+++ b/src/Momento.Sdk/Incubating/Responses/CacheListPushBackResponse.cs
@@ -1,5 +1,13 @@
+using Momento.Protos.CacheClient;
+
 namespace Momento.Sdk.Incubating.Responses;
 
 public class CacheListPushBackResponse
 {
+    public int ListLength { get; private set; }
+
+    public CacheListPushBackResponse(_ListPushBackResponse response)
+    {
+        ListLength = checked((int)response.ListLength);
+    }
 }

--- a/src/Momento.Sdk/Incubating/Responses/CacheListPushBackResponse.cs
+++ b/src/Momento.Sdk/Incubating/Responses/CacheListPushBackResponse.cs
@@ -2,8 +2,14 @@ using Momento.Protos.CacheClient;
 
 namespace Momento.Sdk.Incubating.Responses;
 
+/// <summary>
+/// The result of a <c>ListPushBack</c> command
+/// </summary>
 public class CacheListPushBackResponse
 {
+    /// <summary>
+    /// The length of the list post-push (and post-truncate, if that applies)
+    /// </summary>
     public int ListLength { get; private set; }
 
     public CacheListPushBackResponse(_ListPushBackResponse response)

--- a/src/Momento.Sdk/Incubating/Responses/CacheListPushFrontResponse.cs
+++ b/src/Momento.Sdk/Incubating/Responses/CacheListPushFrontResponse.cs
@@ -2,8 +2,14 @@ using Momento.Protos.CacheClient;
 
 namespace Momento.Sdk.Incubating.Responses;
 
+/// <summary>
+/// The result of a <c>ListPushFront</c> command
+/// </summary>
 public class CacheListPushFrontResponse
 {
+    /// <summary>
+    /// The length of the list post-push (and post-truncate, if that applies)
+    /// </summary>
     public int ListLength { get; private set; }
 
     public CacheListPushFrontResponse(_ListPushFrontResponse response)

--- a/src/Momento.Sdk/Incubating/Responses/CacheListPushFrontResponse.cs
+++ b/src/Momento.Sdk/Incubating/Responses/CacheListPushFrontResponse.cs
@@ -1,5 +1,13 @@
+using Momento.Protos.CacheClient;
+
 namespace Momento.Sdk.Incubating.Responses;
 
 public class CacheListPushFrontResponse
 {
+    public int ListLength { get; private set; }
+
+    public CacheListPushFrontResponse(_ListPushFrontResponse response)
+    {
+        ListLength = checked((int)response.ListLength);
+    }
 }

--- a/src/Momento.Sdk/Incubating/Responses/CacheListRemoveValueResponse.cs
+++ b/src/Momento.Sdk/Incubating/Responses/CacheListRemoveValueResponse.cs
@@ -1,5 +1,5 @@
 namespace Momento.Sdk.Incubating.Responses;
 
-public class CacheListRemoveAllResponse
+public class CacheListRemoveValueResponse
 {
 }

--- a/src/Momento.Sdk/Incubating/SimpleCacheClient.cs
+++ b/src/Momento.Sdk/Incubating/SimpleCacheClient.cs
@@ -639,7 +639,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     /// <param name="value">The value to completely remove from the list.</param>
     /// <returns>Task representing the result of the cache operation.</returns>
     /// <exception cref="ArgumentNullException">Any of <paramref name="cacheName"/>, <paramref name="listName"/>, or <paramref name="value"/> is <see langword="null"/>.</exception>
-    public async Task<CacheListRemoveAllResponse> ListRemoveValueAsync(string cacheName, string listName, byte[] value)
+    public async Task<CacheListRemoveValueResponse> ListRemoveValueAsync(string cacheName, string listName, byte[] value)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
         Utils.ArgumentNotNull(listName, nameof(listName));
@@ -649,7 +649,7 @@ public class SimpleCacheClient : ISimpleCacheClient
     }
 
     /// <inheritdoc cref="ListRemoveValueAsync(string, string, byte[])"/>
-    public async Task<CacheListRemoveAllResponse> ListRemoveValueAsync(string cacheName, string listName, string value)
+    public async Task<CacheListRemoveValueResponse> ListRemoveValueAsync(string cacheName, string listName, string value)
     {
         Utils.ArgumentNotNull(cacheName, nameof(cacheName));
         Utils.ArgumentNotNull(listName, nameof(listName));

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
@@ -39,8 +39,8 @@ public class ListTest : TestBase
         var value2 = Utils.NewGuidByteArray();
         pushResponse = await client.ListPushFrontAsync(cacheName, listName, value2, false);
         Assert.Equal(2, pushResponse.ListLength);
-        fetchResponse = await client.ListFetchAsync(cacheName, listName);
 
+        fetchResponse = await client.ListFetchAsync(cacheName, listName);
         list = fetchResponse.ByteArrayList!;
         Assert.Equal(value2, list[0]);
         Assert.Equal(value1, list[1]);
@@ -114,7 +114,6 @@ public class ListTest : TestBase
         Assert.Equal(2, pushResponse.ListLength);
 
         fetchResponse = await client.ListFetchAsync(cacheName, listName);
-
         list = fetchResponse.StringList()!;
         Assert.Equal(value2, list[0]);
         Assert.Equal(value1, list[1]);
@@ -172,7 +171,8 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value1 = Utils.NewGuidByteArray();
 
-        await client.ListPushBackAsync(cacheName, listName, value1, false);
+        var pushResponse = await client.ListPushBackAsync(cacheName, listName, value1, false);
+        Assert.Equal(1, pushResponse.ListLength);
 
         var fetchResponse = await client.ListFetchAsync(cacheName, listName);
         Assert.Equal(CacheGetStatus.HIT, fetchResponse.Status);
@@ -183,9 +183,10 @@ public class ListTest : TestBase
 
         // Test push semantics
         var value2 = Utils.NewGuidByteArray();
-        await client.ListPushBackAsync(cacheName, listName, value2, false);
-        fetchResponse = await client.ListFetchAsync(cacheName, listName);
+        pushResponse = await client.ListPushBackAsync(cacheName, listName, value2, false);
+        Assert.Equal(2, pushResponse.ListLength);
 
+        fetchResponse = await client.ListFetchAsync(cacheName, listName);
         list = fetchResponse.ByteArrayList!;
         Assert.Equal(value1, list[0]);
         Assert.Equal(value2, list[1]);
@@ -307,7 +308,8 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value1 = Utils.NewGuidString();
 
-        await client.ListPushBackAsync(cacheName, listName, value1, false);
+        var pushResponse = await client.ListPushBackAsync(cacheName, listName, value1, false);
+        Assert.Equal(1, pushResponse.ListLength);
 
         var fetchResponse = await client.ListFetchAsync(cacheName, listName);
         Assert.Equal(CacheGetStatus.HIT, fetchResponse.Status);
@@ -318,9 +320,10 @@ public class ListTest : TestBase
 
         // Test push semantics
         var value2 = Utils.NewGuidString();
-        await client.ListPushBackAsync(cacheName, listName, value2, false);
-        fetchResponse = await client.ListFetchAsync(cacheName, listName);
+        pushResponse = await client.ListPushBackAsync(cacheName, listName, value2, false);
+        Assert.Equal(2, pushResponse.ListLength);
 
+        fetchResponse = await client.ListFetchAsync(cacheName, listName);
         list = fetchResponse.StringList()!;
         Assert.Equal(value1, list[0]);
         Assert.Equal(value2, list[1]);

--- a/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
+++ b/tests/Integration/Momento.Sdk.Incubating.Tests/ListTest.cs
@@ -25,7 +25,8 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value1 = Utils.NewGuidByteArray();
 
-        await client.ListPushFrontAsync(cacheName, listName, value1, false);
+        var pushResponse = await client.ListPushFrontAsync(cacheName, listName, value1, false);
+        Assert.Equal(1, pushResponse.ListLength);
 
         var fetchResponse = await client.ListFetchAsync(cacheName, listName);
         Assert.Equal(CacheGetStatus.HIT, fetchResponse.Status);
@@ -36,7 +37,8 @@ public class ListTest : TestBase
 
         // Test push semantics
         var value2 = Utils.NewGuidByteArray();
-        await client.ListPushFrontAsync(cacheName, listName, value2, false);
+        pushResponse = await client.ListPushFrontAsync(cacheName, listName, value2, false);
+        Assert.Equal(2, pushResponse.ListLength);
         fetchResponse = await client.ListFetchAsync(cacheName, listName);
 
         list = fetchResponse.ByteArrayList!;
@@ -96,7 +98,8 @@ public class ListTest : TestBase
         var listName = Utils.NewGuidString();
         var value1 = Utils.NewGuidString();
 
-        await client.ListPushFrontAsync(cacheName, listName, value1, false);
+        var pushResponse = await client.ListPushFrontAsync(cacheName, listName, value1, false);
+        Assert.Equal(1, pushResponse.ListLength);
 
         var fetchResponse = await client.ListFetchAsync(cacheName, listName);
         Assert.Equal(CacheGetStatus.HIT, fetchResponse.Status);
@@ -107,7 +110,9 @@ public class ListTest : TestBase
 
         // Test push semantics
         var value2 = Utils.NewGuidString();
-        await client.ListPushFrontAsync(cacheName, listName, value2, false);
+        pushResponse = await client.ListPushFrontAsync(cacheName, listName, value2, false);
+        Assert.Equal(2, pushResponse.ListLength);
+
         fetchResponse = await client.ListFetchAsync(cacheName, listName);
 
         list = fetchResponse.StringList()!;


### PR DESCRIPTION
This fixes two minor issues:
1. The `ListRemoveValue` response had an out of date name. Changed to `CacheListRemoveValue`
2. Added list length to the response for `ListPushFront` and `ListPushBack` 

Closes #144 